### PR TITLE
Prepare exercises for v0.6

### DIFF
--- a/exercises/custom-set/example.jl
+++ b/exercises/custom-set/example.jl
@@ -1,7 +1,7 @@
 import Base: AbstractSet, isempty, length, in, issubset, start, next, done,
              push!, ==, copy, intersect!, intersect, union!, union
 
-type CustomSet{T} <: AbstractSet
+struct CustomSet{T} <: AbstractSet{T}
     elements::Array{T, 1}
 end
 

--- a/exercises/luhn/example.jl
+++ b/exercises/luhn/example.jl
@@ -1,7 +1,7 @@
 function luhn(id::AbstractString)
     id = split(replace(id, ' ', ""), "")
     length(id) < 2 && return false
-    all(isdigit, id) || return false
+    all(all(isdigit, s) for s in id) || return false
 
     numbers = Int[]
     for val in id


### PR DESCRIPTION
Do not merge before v0.6 is released!
---
This updates `custom-set` and `luhn` to v0.6. Currently all other exercises work just fine; the testsuites did not require updating.

---
This fixes #37.