### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Exercism Julia Track
 
-[![Join the chat at https://gitter.im/exercism/xjulia](https://badges.gitter.im/exercism/xjulia.svg)](https://gitter.im/exercism/xjulia?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/exercism/xjulia.svg?branch=master)](https://travis-ci.org/exercism/xjulia)
+[![Join the chat at https://gitter.im/exercism/julia](https://badges.gitter.im/exercism/julia.svg)](https://gitter.im/exercism/julia?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/exercism/julia.svg?branch=master)](https://travis-ci.org/exercism/julia)
 
 Exercism exercises in Julia.
 
@@ -29,7 +29,7 @@ Exercises for the Julia track go in the `exercises` directory and should follow 
 
 Replace `<slug>` with the exercise slug of the exercise you're working on.
 
-See [Issue #2](https://github.com/exercism/xjulia/issues/2) for discussion on the structure and style guidelines.
+See [Issue #2](https://github.com/exercism/julia/issues/2) for discussion on the structure and style guidelines.
 
 ### Adding it to config
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "julia",
   "language": "Julia",
-  "repository": "https://github.com/exercism/xjulia",
+  "repository": "https://github.com/exercism/julia",
   "active": false,
   "exercises": [
     {


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1