### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,14 +5,20 @@
   "active": false,
   "exercises": [
     {
+      "uuid": "a668410d-41aa-4710-a68f-54521da6486d",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "878e9897-c4b6-40ff-9034-8f2aedf07a91",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "generators",
@@ -21,21 +27,30 @@
       ]
     },
     {
+      "uuid": "c64e03cc-1952-4b2d-9a53-25c43187a4e6",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "dates"
       ]
     },
     {
+      "uuid": "16550822-4751-4bb3-9e15-80361006e2d6",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "generators"
       ]
     },
     {
+      "uuid": "bf709fe6-d269-467a-a3da-5bbdaf674f91",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (conditionals)",
@@ -45,7 +60,10 @@
       ]
     },
     {
+      "uuid": "54c24809-c6e7-419b-8ec3-6d8d128ca546",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "chars",
@@ -54,7 +72,10 @@
       ]
     },
     {
+      "uuid": "07875495-146f-44a3-b13a-e8e74a37b87d",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (loops)",
@@ -63,7 +84,10 @@
       ]
     },
     {
+      "uuid": "0d5f865c-b704-445c-ac31-df34168f54aa",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "exception handling",
@@ -73,7 +97,10 @@
       ]
     },
     {
+      "uuid": "8740c914-f008-4b6b-8e7d-7470e78e6a8e",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (conditionals)",
@@ -82,7 +109,10 @@
       ]
     },
     {
+      "uuid": "7a083573-2c68-47cc-8bc8-c0e483cf0e50",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (loops)",
@@ -91,7 +121,10 @@
       ]
     },
     {
+      "uuid": "5feec698-0bf8-4308-9f72-2cecaab5e75e",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (loops)",
@@ -101,7 +134,10 @@
       ]
     },
     {
+      "uuid": "cc08d672-9c58-4e7a-bfb7-344cbad811f7",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -110,7 +146,10 @@
       ]
     },
     {
+      "uuid": "a4638670-941d-4213-8407-d9ebba70bd42",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -119,7 +158,10 @@
       ]
     },
     {
+      "uuid": "58c41643-971c-4199-a10f-7dc21093e5e3",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (loops)",
@@ -128,7 +170,10 @@
       ]
     },
     {
+      "uuid": "19f9e7c4-f2a5-4636-b7b2-4e0a15977e01",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (loops)",
@@ -138,7 +183,10 @@
       ]
     },
     {
+      "uuid": "d2cb1621-2a2e-4791-a6b6-fdbca74a5583",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "control-flow (loops)",
@@ -149,7 +197,10 @@
       ]
     },
     {
+      "uuid": "4bc9a4f8-fc4d-4e6b-a93c-07069bbc5bc9",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "arrays",
@@ -158,7 +209,10 @@
       ]
     },
     {
+      "uuid": "bccc00fa-811c-4bf9-8e55-07a0d0affb08",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "arrays",
@@ -167,7 +221,10 @@
       ]
     },
     {
+      "uuid": "9474a13b-09c1-4e4d-90e3-1a14fde5eb62",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "strings",
@@ -176,7 +233,10 @@
       ]
     },
     {
+      "uuid": "5e3b376a-06ab-442f-8d18-710db7778db6",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "control-flow (loops)",
@@ -187,7 +247,10 @@
       ]
     },
     {
+      "uuid": "c09ed7ec-fa7c-4f6a-994f-3d3eb7f22df4",
       "slug": "trinary",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "arrays",
@@ -197,7 +260,10 @@
       ]
     },
     {
+      "uuid": "e5a6d640-cd76-4453-8247-fd34ffed4fe5",
       "slug": "transpose",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "control-flow (loops)",
@@ -207,7 +273,10 @@
       ]
     },
     {
+      "uuid": "d2c85375-c0e7-4e04-88f1-08736e5afa04",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "arrays",
@@ -216,7 +285,10 @@
       ]
     },
     {
+      "uuid": "7cb2d96a-4707-4cec-9ead-313fcb5fbb94",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "structs",
@@ -225,7 +297,10 @@
       ]
     },
     {
+      "uuid": "eca7e62c-7bbf-436c-8011-2920cb2ab1c1",
       "slug": "complex-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "structs",
@@ -236,7 +311,10 @@
       ]
     },
     {
+      "uuid": "79ea05f1-3f27-4b92-bc47-0cebcd8d5a6f",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "string literals",
@@ -245,7 +323,10 @@
       ]
     },
     {
+      "uuid": "b47377f7-84af-4a10-83ef-c2444a4f8940",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "types",
@@ -257,9 +338,6 @@
         "iterators"
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16