### PR TITLE
Link to new contributing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Document how to contribute to the Julia track._
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md).
+Please see the [contributing guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
 ## Working on the Exercises
 


### PR DESCRIPTION
We moved the contributing documentation out of the problem specifications repository.