### PR TITLE
Add exercise: isbn-verifier

### DIFF
--- a/config.json
+++ b/config.json
@@ -404,6 +404,19 @@
       "topics": [
         "exceptions"
       ]
+    },
+    {
+      "uuid": "22b64a2b-7f08-444d-be6e-8b42e5c9207c",
+      "slug": "isbn-verifier",
+      "core": false,
+      "unlocked_by": "luhn",
+      "difficulty": 2,
+      "topics": [
+        "strings",
+        "arithmetics",
+        "control-flow (conditionals)",
+        "metaprogramming"
+      ]
     }
   ],
   "foregone": [

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -1,0 +1,51 @@
+# ISBN Verifier
+
+The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
+numbers. These normally contain dashes and look like: `3-598-21508-8`
+
+## ISBN
+
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+
+```
+(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
+```
+
+If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+
+## Example
+
+Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+```
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+```
+
+Since the result is 0, this proves that our ISBN is valid.
+
+## Task
+
+The program should construct a string of type `ISBN <: AbstractString`.
+Given a string the program should check if the provided string is a valid ISBN-10. If the string is invalid, the constructor should throw an appropriate error.
+Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+
+The program should be able to verify ISBN-10 both with and without separating dashes.
+
+
+## Caveats
+
+Converting from strings to numbers can be tricky in certain languages.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+
+## Bonus tasks
+
+* Implement `show(io::IO, isbn::ISBN)` to print the ISBN in the standard format with dashes.
+
+* Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
+
+* Generate valid ISBN, maybe even from a given starting ISBN.## Source
+
+Converting a string into a number and some basic processing utilizing a relatable real world example. [https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation](https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation)
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isbn-verifier/example.jl
+++ b/exercises/isbn-verifier/example.jl
@@ -1,0 +1,26 @@
+macro isbn_str(s)
+    ISBN(s)
+end
+
+struct ISBN <: AbstractString
+    s::AbstractString
+
+    ISBN(s) = verify(s) ? new(replace(s, "-", "")) : throw(ArgumentError("invalid ISBN string: $s"))
+end
+
+function verify(s::AbstractString)
+    s = replace(s, "-", "")
+    chars = split(s, "")
+
+    length(chars) == 10 || return false
+
+    if last(chars) == "X"
+        chars[end] = "10"
+    end
+
+    all(c -> all(isdigit, c), chars) || return false
+
+    sum(parse(Int, c) * i for (c, i) in zip(chars, 10:-1:1)) % 11 == 0
+end
+
+Base.isvalid(::Type{ISBN}, s::AbstractString) = verify(s)

--- a/exercises/isbn-verifier/runtests.jl
+++ b/exercises/isbn-verifier/runtests.jl
@@ -1,0 +1,73 @@
+using Base.Test
+
+include("isbn-verifier.jl")
+
+@test ISBN <: AbstractString
+
+@testset "valid ISBN numbers" begin
+    # ISBN number
+    @test isvalid(ISBN, "3-598-21508-8")
+    # ISBN number with a check digit of 10
+    @test isvalid(ISBN, "3-598-21507-X")
+    # ISBN without separating dashes
+    @test isvalid(ISBN, "3598215088")
+    # ISBN without separating dashes and X as check digit
+    @test isvalid(ISBN, "359821507X")
+end
+
+@testset "invalid ISBN numbers" begin
+    # invalid ISBN check digit
+    @test !isvalid(ISBN, "3-598-21508-9")
+    # check digit is a character other than X
+    @test !isvalid(ISBN, "3-598-21507-A")
+    # invalid character in ISBN
+    @test !isvalid(ISBN, "3-598-2K507-0")
+    # X is only valid as a check isdigit
+    @test !isvalid(ISBN, "3-598-2X507-9")
+    # ISBN without check digit and dashes
+    @test !isvalid(ISBN, "359821507")
+    # too long ISBN and no dashes
+    @test !isvalid(ISBN, "3598215078X")
+    # ISBN without check digit
+    @test !isvalid(ISBN, "3-598-21507")
+    # too long ISBN
+    @test !isvalid(ISBN, "3-598-21507-XX")
+    # check digit of X should not be used for 0
+    @test !isvalid(ISBN, "3-598-21515-X")
+    # empty ISBN
+    @test !isvalid(ISBN, "")
+end
+
+@testset "constructing valid ISBN numbers" begin
+    # ISBN number
+    @test isbn"3-598-21508-8".s == "3598215088"
+    # ISBN number with a check digit of 10
+    @test isbn"3-598-21507-X".s == "359821507X"
+    # ISBN without separating dashes
+    @test isbn"3598215088".s == "3598215088"
+    # ISBN without separating dashes and X as check digit
+    @test isbn"359821507X".s == "359821507X"
+end
+
+@testset "constructing invalid ISBN numbers" begin
+    # invalid ISBN check digit
+    @test_throws ArgumentError ISBN("3-598-21508-9")
+    # check digit is a character other than X
+    @test_throws ArgumentError ISBN("3-598-21507-A")
+    # invalid character in ISBN
+    @test_throws ArgumentError ISBN("3-598-2K507-0")
+    # X is only valid as a check isdigit
+    @test_throws ArgumentError ISBN("3-598-2X507-9")
+    # ISBN without check digit and dashes
+    @test_throws ArgumentError ISBN("359821507")
+    # too long ISBN and no dashes
+    @test_throws ArgumentError ISBN("3598215078X")
+    # ISBN without check digit
+    @test_throws ArgumentError ISBN("3-598-21507")
+    # too long ISBN
+    @test_throws ArgumentError ISBN("3-598-21507-XX")
+    # check digit of X should not be used for 0
+    @test_throws ArgumentError ISBN("3-598-21515-X")
+    # empty ISBN
+    @test_throws ArgumentError ISBN("")
+end


### PR DESCRIPTION
I have extended the common problem specification to work with a custom string type and literal. This introduces new concepts and it behaves similar to version strings or LaTeXStrings.