### PR TITLE
Nucleotide Count: expect DomainError instead of ErrorException

### DIFF
--- a/exercises/nucleotide-count/example.jl
+++ b/exercises/nucleotide-count/example.jl
@@ -1,7 +1,7 @@
 function count_nucleotides(strand::AbstractString)
     counter = Dict('A' => 0, 'C' => 0, 'G' => 0, 'T' => 0)
     for sym in strand
-        sym in keys(counter) || error("Invalid nucleotide in strand")
+        sym in keys(counter) || throw(DomainError())
         counter[sym] += 1
     end
     return counter

--- a/exercises/nucleotide-count/runtests.jl
+++ b/exercises/nucleotide-count/runtests.jl
@@ -15,5 +15,5 @@ end
 end
 
 @testset "strand with invalid nucleotides" begin
-    @test_throws ErrorException count_nucleotides("AGXXACT")
+    @test_throws DomainError count_nucleotides("AGXXACT")
 end


### PR DESCRIPTION
In [my first cut of a solution](http://exercism.io/submissions/8ee2cc5ec49a464ba3d553c5a46a78ff) to this problem, I complained in a comment about the fact that the tests expect specifically an ErrorException, when a more specific error (KeyError) would be thrown otherwise.

Then @SaschaMann offered that maybe a DomainError is more appropriate, if we have to specify the type of the exception being thrown. I like that idea, so here is a PR that makes the change. I'm open to further discussion if anyone has thoughts on this.