### PR TITLE
config.json: Update exercise ordering

### DIFF
--- a/config.json
+++ b/config.json
@@ -236,7 +236,7 @@
       "uuid": "bccc00fa-811c-4bf9-8e55-07a0d0affb08",
       "slug": "etl",
       "core": false,
-      "unlocked_by": "scrabble-score",
+      "unlocked_by": "nucleotide-count",
       "difficulty": 2,
       "topics": [
         "arrays",
@@ -409,7 +409,7 @@
       "uuid": "22b64a2b-7f08-444d-be6e-8b42e5c9207c",
       "slug": "isbn-verifier",
       "core": false,
-      "unlocked_by": "luhn",
+      "unlocked_by": "raindrops",
       "difficulty": 2,
       "topics": [
         "strings",


### PR DESCRIPTION
## Problem
While linting with the next release of [Configlet](https://github.com/exercism/configlet/releases/tag/v3.8.0) a number of exercises were still found to contain invalid unlocked_by configurations.

## What's changed
The master config file was updated following manner:

1. The exercise 'etl' is now unlocked_by the core exercise 'nucleotide-count', which is the core exercise that unlocks 'scrabble-score'.
1. The exercise 'isbn-verifier' is now unlocked_by the core exercise 'raindrops', which is the core exercise that unlocks 'luhn'.

## Testing Steps
1. Download the pre-release of Configlet [here](https://github.com/exercism/configlet/releases/tag/v3.8.0)
1. Run `configlet lint <path-to-fsharp-track>`
1. Validate that there are no lint errors.

closes #107