### PR TITLE
Upgrade exercises to work in v0.7/v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: julia
 
 os:
+  - osx
   - linux
 
 julia:
+  - 0.7
+  - 1.0
   - nightly
-  - 0.6
 
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia v0.7-alpha
+julia v1.0

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -11,5 +11,10 @@
 {{ . }}
 {{ end }}
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,7 +1,7 @@
 To install Julia on your system follow the instructions on the [Julia Language Downloads page](http://julialang.org/downloads/).
 
-[JuliaPro](http://juliacomputing.com/products/juliapro.html) includes the latest stable version of Julia, the Juno IDE, a debugger, a Jupyter notebook environment and many of the most popular Julia packages. It is a convenient way to install everything you will need to get started.
+[JuliaPro](http://juliacomputing.com/products/juliapro.html) includes the latest stable version of Julia, the Juno IDE, a debugger, a Jupyter notebook environment and many of the most popular Julia packages. It is a convenient way to install everything you will need to get started. Please note that JuliaPro may contain outdated versions of packages or the language itself as it focuses on providing a stable installation.
 
-For a local installation, it is recommended to use [Juno](http://junolab.org/). It's an IDE based on Atom and offers a powerful text editor as well as additional features for developing in Julia. Just follow the instructions on their website.
+For a local installation, there are multiple IDEs/editor plugins available. The most popular ones are [Juno](http://junolab.org/) and the [VS Code extension](https://github.com/JuliaEditorSupport/julia-vscode). Just follow the instructions on their websites.
 
-A simple way to get started with Julia without the need of a local installation is [JuliaBox](http://junolab.org/), which is an online IDE based on Jupyter notebooks. You just access it from your browser, login and you can start solving exercises.
+A simple way to get started with Julia without the need of a local installation is [JuliaBox](https://juliabox.com/), which is an online IDE based on Jupyter notebooks. You just access it from your browser, login and you can start solving exercises.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -10,5 +10,10 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/runtests.jl
+++ b/exercises/anagram/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("anagram.jl")
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -32,5 +32,10 @@ things based on word boundaries.
 Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/example.jl
+++ b/exercises/atbash-cipher/example.jl
@@ -1,4 +1,4 @@
-cipher(input::AbstractString) = map(x->isalpha(x)?Char(219-Int(x)):x, lowercase(filter(isalnum, input)))
-encode(input::AbstractString) = join(matchall(r"(.{1,5})", cipher(input)), ' ')
+cipher(input::AbstractString) = map(x->isletter(x) ? Char(219-Int(x)) : x, lowercase(filter(c -> isletter(c) || isnumeric(c), input)))
+encode(input::AbstractString) = join(collect((m.match for m = eachmatch(r"(.{1,5})", cipher(input)))), ' ')
 decode(input::AbstractString) = cipher(input)
 

--- a/exercises/atbash-cipher/runtests.jl
+++ b/exercises/atbash-cipher/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("atbash-cipher.jl")
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -19,5 +19,10 @@ Bob's conversational partner is a purist when it comes to written communication 
 Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/example.jl
+++ b/exercises/bob/example.jl
@@ -18,12 +18,12 @@ issilence(stimulus::AbstractString) = isempty(stimulus)
 isquestion(stimulus::AbstractString) = endswith(stimulus, '?')
 
 function isshouting(stimulus::AbstractString)
-    all(isupper, stimulus) && return true
-    !any(isalpha, stimulus) && return false
+    all(isuppercase, stimulus) && return true
+    !any(isletter, stimulus) && return false
 
     for c in stimulus
         # ignore all non-letter chars
-        if isalpha(c) && !isupper(c)
+        if isletter(c) && !isuppercase(c)
             return false
         end
     end

--- a/exercises/bob/runtests.jl
+++ b/exercises/bob/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("bob.jl")
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -30,5 +30,10 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/example.jl
+++ b/exercises/collatz-conjecture/example.jl
@@ -1,5 +1,5 @@
 function collatz(n::Integer)
-    n <= 0 && throw(DomainError())
+    n <= 0 && throw(DomainError("n must be strictly positive"))
     iseven(n) ? div(n, 2) : 3n + 1
 end
 

--- a/exercises/collatz-conjecture/runtests.jl
+++ b/exercises/collatz-conjecture/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("collatz-conjecture.jl")
 

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -45,5 +45,10 @@ Implement `jm` analogous to `im` so that `1 + 1jm == ComplexNumber(1, 1)`.
 Wikipedia [https://en.wikipedia.org/wiki/Complex_number](https://en.wikipedia.org/wiki/Complex_number)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/complex-numbers/runtests.jl
+++ b/exercises/complex-numbers/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("complex-numbers.jl")
 
@@ -62,7 +62,7 @@ end
 @testset "Complex exponential" begin
     @test_skip exp(ComplexNumber(0, π)) ≈ ComplexNumber(-1, 0)
     @test_skip exp(ComplexNumber(0, 0)) == ComplexNumber(1, 0)
-    @test_skip exp(ComplexNumber(1, 0)) ≈ ComplexNumber(e, 0)
+    @test_skip exp(ComplexNumber(1, 0)) ≈ ComplexNumber(ℯ, 0)
 end
 
 # Bonus B

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -13,5 +13,10 @@ Certain methods have a unicode operator equivalent. E.g. `intersect(CustomSet([1
 
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/example.jl
+++ b/exercises/custom-set/example.jl
@@ -1,4 +1,4 @@
-import Base: AbstractSet, isempty, length, in, issubset, start, next, done,
+import Base: AbstractSet, isempty, length, in, issubset, iterate,
              push!, ==, copy, intersect!, intersect, union!, union
 
 struct CustomSet{T} <: AbstractSet{T}
@@ -13,9 +13,13 @@ copy(s::CustomSet) = CustomSet(copy(s.elements))
 push!(s::CustomSet, element) = push!(s.elements, element)
 
 # Iterator protocol
-start(::CustomSet) = 1
-next(s::CustomSet, state) = s.elements[state], state + 1
-done(s::CustomSet, state) = state > length(s)
+function iterate(s::CustomSet, state=1)
+    if state > length(s)
+        return nothing
+    end
+
+    s.elements[state], state + 1
+end
 
 function disjoint(s1::CustomSet, s2::CustomSet)
     for element in s1

--- a/exercises/custom-set/runtests.jl
+++ b/exercises/custom-set/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("custom-set.jl")
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -16,5 +16,10 @@ natural numbers is 3025 - 385 = 2640.
 Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/difference-of-squares/example.jl
+++ b/exercises/difference-of-squares/example.jl
@@ -1,7 +1,7 @@
 # This uses reduce instead of sum because sum can't handle empty collections properly.
 # There is no universal zero-element, so it has to be specified manually and cannot
 # be determined automatically. Otherwise, n=0 will cause an error.
-sum_of_squares(n::Int) = reduce(+, 0, i^2 for i in 1:n)
+sum_of_squares(n::Int) = reduce(+, i^2 for i in 1:n; init=0)
 
 # However, sum{T<:Real}(r::Range{T}) can handle "empty" ranges.
 square_of_sum(n::Int) = sum(1:n)^2

--- a/exercises/difference-of-squares/runtests.jl
+++ b/exercises/difference-of-squares/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("difference-of-squares.jl")
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -50,5 +50,10 @@ game while being scored at 4 in the Hawaiian-language version.
 The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/runtests.jl
+++ b/exercises/etl/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("etl.jl")
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -8,5 +8,10 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/example.jl
+++ b/exercises/gigasecond/example.jl
@@ -1,1 +1,3 @@
+using Dates
+
 add_gigasecond(date::DateTime) = date + Dates.Second(10^9)

--- a/exercises/gigasecond/runtests.jl
+++ b/exercises/gigasecond/runtests.jl
@@ -1,4 +1,5 @@
-using Base.Test
+using Test
+using Dates
 
 include("gigasecond.jl")
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -30,5 +30,10 @@ experiment make the code better? Worse? Did you learn anything from it?
 JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/example.jl
+++ b/exercises/grains/example.jl
@@ -16,8 +16,3 @@ function check_square_input(square)
     square <  0 && throw(DomainError(square, "Negative square input is invalid."))
     square > 64 && throw(DomainError(square, "Square input greater than 64 is invalid."))
 end
-
-if VERSION < v"0.7-"  # backwards compatibility
-    Base.DomainError(val) = DomainError()
-    Base.DomainError(val, msg) = DomainError()
-end

--- a/exercises/grains/example.jl
+++ b/exercises/grains/example.jl
@@ -17,7 +17,7 @@ function check_square_input(square)
     square > 64 && throw(DomainError(square, "Square input greater than 64 is invalid."))
 end
 
-if VERSION < v"0.7"  # backwards compatibility
+if VERSION < v"0.7-"  # backwards compatibility
     Base.DomainError(val) = DomainError()
     Base.DomainError(val, msg) = DomainError()
 end

--- a/exercises/grains/runtests.jl
+++ b/exercises/grains/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("grains.jl")
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -40,5 +40,10 @@ exception vs returning a special value) may differ between languages.
 The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/example.jl
+++ b/exercises/hamming/example.jl
@@ -1,4 +1,4 @@
 function distance(s1::AbstractString, s2::AbstractString)
     length(s1) != length(s2) && throw(ArgumentError("Sequences must have the same length"))
-    reduce(+, 0, a != b for (a, b) in zip(s1, s2))
+    reduce(+, a != b for (a, b) in zip(s1, s2); init=0)
 end

--- a/exercises/hamming/runtests.jl
+++ b/exercises/hamming/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("hamming.jl")
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -18,5 +18,10 @@ If everything goes well, you will be ready to fetch your first real exercise.
 This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/runtests.jl
+++ b/exercises/hello-world/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("hello-world.jl")
 

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -47,5 +47,10 @@ Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (represen
 Converting a string into a number and some basic processing utilizing a relatable real world example. [https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation](https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isbn-verifier/example.jl
+++ b/exercises/isbn-verifier/example.jl
@@ -5,13 +5,13 @@ end
 struct ISBN <: AbstractString
     s::AbstractString
 
-    ISBN(s) = verify(s) ? new(replace(s, "-", "")) : throw(ArgumentError("invalid ISBN string: $s"))
+    ISBN(s) = verify(s) ? new(replace(s, "-" => "")) : throw(ArgumentError("invalid ISBN string: $s"))
 end
 
 string(s::ISBN) = s.s
 
 function verify(s::AbstractString)
-    s = replace(s, "-", "")
+    s = replace(s, "-" => "")
     chars = split(s, "")
 
     length(chars) == 10 || return false

--- a/exercises/isbn-verifier/runtests.jl
+++ b/exercises/isbn-verifier/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("isbn-verifier.jl")
 

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -17,5 +17,10 @@ The word *isograms*, however, is not an isogram, because the s repeats.
 Wikipedia [https://en.wikipedia.org/wiki/Isogram](https://en.wikipedia.org/wiki/Isogram)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isogram/example.jl
+++ b/exercises/isogram/example.jl
@@ -3,7 +3,7 @@ function isisogram(s::AbstractString)
     chars = Char[]
 
     for c in s
-        isalpha(c) || continue
+        isletter(c) || continue
         c ∉ chars ? push!(chars, c) : return false
     end
 

--- a/exercises/isogram/runtests.jl
+++ b/exercises/isogram/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("isogram.jl")
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -30,5 +30,10 @@ phenomenon, go watch [this youtube video][video].
 JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/runtests.jl
+++ b/exercises/leap/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("leap.jl")
 

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -68,5 +68,10 @@ Sum the digits
 The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/example.jl
+++ b/exercises/luhn/example.jl
@@ -1,5 +1,5 @@
 function luhn(id::AbstractString)
-    id = split(replace(id, ' ', ""), "")
+    id = split(replace(id, ' ' => ""), "")
     length(id) < 2 && return false
     all(all(isdigit, s) for s in id) || return false
 

--- a/exercises/luhn/runtests.jl
+++ b/exercises/luhn/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("luhn.jl")
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -16,5 +16,10 @@ Here is an analogy:
 The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/example.jl
+++ b/exercises/nucleotide-count/example.jl
@@ -1,7 +1,7 @@
 function count_nucleotides(strand::AbstractString)
     counter = Dict('A' => 0, 'C' => 0, 'G' => 0, 'T' => 0)
     for sym in strand
-        sym in keys(counter) || throw(DomainError())
+        sym in keys(counter) || throw(DomainError(sym, "only A, C, G and T are valid nucleotides"))
         counter[sym] += 1
     end
     return counter

--- a/exercises/nucleotide-count/runtests.jl
+++ b/exercises/nucleotide-count/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("nucleotide-count.jl")
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -12,5 +12,10 @@ insensitive. Input will not contain non-ASCII symbols.
 Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/example.jl
+++ b/exercises/pangram/example.jl
@@ -1,2 +1,1 @@
-ispangram(input::AbstractString) = length(Set(matchall(r"[a-z]", lowercase(input)))) == 26
-
+ispangram(input::AbstractString) = length(Set(collect((m.match for m = eachmatch(r"[a-z]", lowercase(input)))))) == 26

--- a/exercises/pangram/runtests.jl
+++ b/exercises/pangram/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("pangram.jl")
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -18,5 +18,10 @@ the right and left of the current position in the previous row.
 Pascal's Triangle at Wolfram Math World [http://mathworld.wolfram.com/PascalsTriangle.html](http://mathworld.wolfram.com/PascalsTriangle.html)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/example.jl
+++ b/exercises/pascals-triangle/example.jl
@@ -1,1 +1,1 @@
-triangle(n::Int) = n >= 0 ? [[binomial(i, j) for j in 0:i] for i in 0:n-1] : throw(DomainError())
+triangle(n::Int) = n >= 0 ? [[binomial(i, j) for j in 0:i] for i in 0:n-1] : throw(DomainError(n, "n must be strictly positive"))

--- a/exercises/pascals-triangle/runtests.jl
+++ b/exercises/pascals-triangle/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("pascals-triangle.jl")
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -32,5 +32,10 @@ should all produce the output
 Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/example.jl
+++ b/exercises/phone-number/example.jl
@@ -11,7 +11,7 @@ function clean(phone_number)
     result = match(r, phone_number)
 
     if result != nothing
-        result = string(result.captures...)
+        result = Base.string(result.captures...)
     end
 
     return result

--- a/exercises/phone-number/runtests.jl
+++ b/exercises/phone-number/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("phone-number.jl")
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -21,5 +21,10 @@ Convert a number to a string, the contents of which depend on the number's facto
 A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/runtests.jl
+++ b/exercises/raindrops/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("raindrops.jl")
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -22,5 +22,10 @@ each nucleotide with its complement:
 Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/example.jl
+++ b/exercises/rna-transcription/example.jl
@@ -1,7 +1,7 @@
 # Given a DNA strand, its transcribed RNA strand is formed by replacing each nucleotide with its complement:
 # G -> C, C -> G, T -> A, A -> U
 function to_rna(dna::AbstractString)
-    typeof(match(r"^[GCTA]+$", dna)) == Void && error("Invalid RNA strand")
+    typeof(match(r"^[GCTA]+$", dna)) == Nothing && error("Invalid RNA strand")
     # Define character associations
     a_nucleotides = Dict('G'=>'C', 'C'=>'G', 'T'=>'A', 'A'=>'U')
     # Replace characters using dictionary

--- a/exercises/rna-transcription/runtests.jl
+++ b/exercises/rna-transcription/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("rna-transcription.jl")
 

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -38,5 +38,10 @@ there are lots of collisions (like when you generate name one thousand times).
 A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/example.jl
+++ b/exercises/robot-name/example.jl
@@ -1,6 +1,16 @@
 # http://docs.julialang.org/en/stable/stdlib/numbers/#random-numbers
 
-new_name() = join(map(x->Char(x), rand(65:90, 2))) * repr(rand(100:999))
+name_history = String[]
+
+function new_name()
+    generate_name() = join(map(x->Char(x), rand(65:90, 2))) * repr(rand(100:999))
+    name = generate_name()
+    while name in name_history
+        name = generate_name()
+    end
+    push!(name_history, name)
+    name
+end
 
 mutable struct Robot
     name::AbstractString

--- a/exercises/robot-name/robot-name.jl
+++ b/exercises/robot-name/robot-name.jl
@@ -1,4 +1,4 @@
-type Robot
+mutable struct Robot
 
 end
 

--- a/exercises/robot-name/runtests.jl
+++ b/exercises/robot-name/runtests.jl
@@ -1,14 +1,14 @@
-using Base.Test
+using Test
 
 include("robot-name.jl")
 
 # Random names means a risk of collisions.
-history = []
+history = String[]
 
-isname(x) = ismatch(r"^[A-Z]{2}[0-9]{3}$", x)
+isname(x) = occursin(r"^[A-Z]{2}[0-9]{3}$", x)
 
 @testset "one robot" begin
-    r1 = Robot()
+    global r1 = Robot()
     push!(history, r1.name)
 
     @testset "name of robot is valid" begin
@@ -24,8 +24,8 @@ isname(x) = ismatch(r"^[A-Z]{2}[0-9]{3}$", x)
 end
 
 @testset "two robots" begin
-    r2 = Robot()
-    r3 = Robot()
+    global r2 = Robot()
+    global r3 = Robot()
 
     @testset "names of robots are valid" begin
         @test isname(r2.name)
@@ -46,7 +46,7 @@ end
 end
 
 @testset "many robots" begin
-    robots = []
+    global robots = Robot[]
 
     for i=1:10
         push!(robots, Robot())
@@ -66,4 +66,3 @@ end
         push!(history, r.name)
     end
 end
-

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -31,5 +31,10 @@ direction it is pointing.
 Inspired by an interview question at a famous company.
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-simulator/runtests.jl
+++ b/exercises/robot-simulator/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("robot-simulator.jl")
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -46,5 +46,10 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/runtests.jl
+++ b/exercises/roman-numerals/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("roman-numerals.jl")
 

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -57,5 +57,10 @@ R13"abcdefghijklmnopqrstuvwxyz" == "nopqrstuvwxyzabcdefghijklm"
 Wikipedia [https://en.wikipedia.org/wiki/Caesar_cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rotational-cipher/example.jl
+++ b/exercises/rotational-cipher/example.jl
@@ -12,7 +12,7 @@ rotate(n::Int, s::String) = join(rotate(n, c) for c in s)
 for n in 0:26
     # current_module() is necessary due to constraints of runtests.jl
     # This is not required for the user solving the exercise
-    eval(current_module(), :(macro $(Symbol(:R, n, :_str))(s::String)
+    Core.eval(@__MODULE__, :(macro $(Symbol(:R, n, :_str))(s::String)
         :(rotate($$n, $s))
     end))
 end

--- a/exercises/rotational-cipher/runtests.jl
+++ b/exercises/rotational-cipher/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("rotational-cipher.jl")
 

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -27,5 +27,10 @@ be decoded always represent the count for the following character.
 Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/example.jl
+++ b/exercises/run-length-encoding/example.jl
@@ -5,7 +5,7 @@ function encode(s)
     for char in s
         (char == s[1]) ? (count += 1) : break
     end
-    count_str = (count == 1) ? "" : dec(count)
+    count_str = (count == 1) ? "" : string(count)
     return string(count_str, s[1], encode(s[count + 1 : end]))
 end
 

--- a/exercises/run-length-encoding/runtests.jl
+++ b/exercises/run-length-encoding/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("run-length-encoding.jl")
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -43,5 +43,10 @@ And to total:
 Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scrabble-score/runtests.jl
+++ b/exercises/scrabble-score/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("scrabble-score.jl")
 

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -32,5 +32,10 @@ has caused the array to be reversed.
 Bert, in Mary Poppins [http://www.imdb.com/title/tt0058331/quotes/qt0437047](http://www.imdb.com/title/tt0058331/quotes/qt0437047)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/secret-handshake/runtests.jl
+++ b/exercises/secret-handshake/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("secret-handshake.jl")
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -33,5 +33,10 @@ language).
 Sieve of Eratosthenes at Wikipedia [http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/example.jl
+++ b/exercises/sieve/example.jl
@@ -1,11 +1,11 @@
 function sieve(limit::Integer)
-    limit <= 0 && error("Invalid limit")
+    limit <= 0 && throw(DomainError(limit, "limit must be strictly positive"))
     nums = fill(true, limit)
     nums[1] = false
-    primes = []
-    while (i = findfirst(nums)) > 0
+    primes = Int[]
+    while (i = findfirst(nums)) != nothing
         push!(primes, i)
-        for j = find(nums)
+        for j = findall(nums)
             if j % i == 0
                 nums[j] = false
             end

--- a/exercises/sieve/runtests.jl
+++ b/exercises/sieve/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("sieve.jl")
 

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -27,5 +27,10 @@ like these examples:
 Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension. [https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/](https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/spiral-matrix/example.jl
+++ b/exercises/spiral-matrix/example.jl
@@ -1,9 +1,10 @@
+using LinearAlgebra
 #Credit to u/SingularInfinity on Redit: https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/djb8po0
 
 function spiral_matrix(n::Int)
-    n < 0 && throw(DomainError("n should be positive"))
-    n == 0 && return Matrix{Int}(0,0)
+    n < 0 && throw(DomainError(n, "n should be positive"))
+    n == 0 && return Matrix{Int}(undef,0,0)
     n == 1 && return reshape(Int[1], 1, 1)
     m = (2n - 1) .+ spiral_matrix(n-1)
-    return [ RowVector(1:n); rot180(m) n+1:2n-1 ]
+    return [ Transpose(1:n); rot180(m) n+1:2n-1 ]
 end

--- a/exercises/spiral-matrix/runtests.jl
+++ b/exercises/spiral-matrix/runtests.jl
@@ -1,11 +1,11 @@
-using Base.Test
+using Test
 
 include("spiral-matrix.jl")
 
 
 @testset "Different valid values" begin
     @testset "Empty spiral" begin
-        @test spiral_matrix(0) == Matrix{Int}(0,0)
+        @test spiral_matrix(0) == Matrix{Int}(undef,0,0)
     end
     @testset "Trivial spiral" begin
         @test spiral_matrix(1) == reshape([1],(1,1))

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -62,5 +62,10 @@ the corresponding output row should contain the spaces in its right-most column(
 Reddit r/dailyprogrammer challenge #270 [Easy]. [https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text](https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/runtests.jl
+++ b/exercises/transpose/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("transpose.jl")
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -26,5 +26,10 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/runtests.jl
+++ b/exercises/triangle/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("triangle.jl")
 

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -25,5 +25,10 @@ conversion, pretend it doesn't exist and implement it yourself.
 All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/example.jl
+++ b/exercises/trinary/example.jl
@@ -1,4 +1,4 @@
 function trinary_to_decimal(str::AbstractString)
-    typeof(match(r"^[0-2]+$", str)) == Void && return 0
+    typeof(match(r"^[0-2]+$", str)) == Nothing && return 0
     mapreduce(i->(i[2]-'0')*3^i[1], +, zip(0:length(str), reverse(str)))
 end

--- a/exercises/trinary/runtests.jl
+++ b/exercises/trinary/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("trinary.jl")
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -15,5 +15,10 @@ free: 1
 This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
 
 
+## Version compatibility
+Julia 1.0 and 0.7 are the only supported Julia versions on Exercism.
+For the most part, the test suites and solutions should be compatible to 0.6, but you will have to change `using Test` back to `using Base.Test` in the `runtests.jl` file.
+Note that 0.7 and 1.0 are almost identical, except for deprecation warnings, which have all been removed in 1.0.
+
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/runtests.jl
+++ b/exercises/word-count/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 include("word-count.jl")
 

--- a/runtests.jl
+++ b/runtests.jl
@@ -1,6 +1,6 @@
-using Base.Test
+using Test
 
-import Base.Test.@test_skip, Base.Test.@test_broken
+import Test.@test_skip, Test.@test_broken
 
 # When testing the example solution, all tests must pass, even ones marked as skipped or broken.
 # The track user will not be affected by this.
@@ -13,6 +13,9 @@ macro test_broken(ex)
     @test eval(current_module(), ex)
 end
 
+# Store base path to cd back to it later
+const path = pwd()
+
 for exercise in readdir("exercises")
     # Allow only testing specified execises
     if !isempty(ARGS) && !(exercise in ARGS)
@@ -23,19 +26,20 @@ for exercise in readdir("exercises")
     isdir(exercise_path) || continue
 
     # Create temporary directory
-    temp_path = mktempdir(".")
+    temp_path = mktempdir()
 
     # Copy tests & example to the temporary directory
     cp(joinpath(exercise_path, "example.jl"), joinpath(temp_path, "$exercise.jl"))
     cp(joinpath(exercise_path, "runtests.jl"), joinpath(temp_path, "runtests.jl"))
 
     try
-        # Run the tests
-        @testset "$exercise example" begin
-            # Run the tests within an anonymous module to prevent definitions from
-            # one exercise leaking into another.
-            eval(Module(), :(include(joinpath($temp_path, "runtests.jl"))))
-        end
+        @info "Testing $exercise"
+        # Run the tests within their own Julia process to prevent definitions from
+        # one exercise leaking into another.
+        cd(temp_path)
+        run(`julia runtests.jl`)
+        cd(path)
+        println()
     finally
         # Delete the temporary directory
         rm(temp_path, recursive=true)


### PR DESCRIPTION
This should make all exercises and examples work on v0.7.

However, I'm having issues porting `runtests.jl` that I need help with. The previous way of running all exercise tests in a separate module doesn't work but I can't find enough information about the changes to `include` that prevent the old way from working.

The problematic [line](https://github.com/exercism/julia/blob/master/runtests.jl#L37):
`eval(Module(), :(include(joinpath($temp_path, "runtests.jl"))))`

This throws the error 
```julia
anagram example: Error During Test at /home/travis/build/exercism/julia/runtests.jl:34
  Got exception UndefVarError(:include) outside of a @test
  UndefVarError: include not defined
  Stacktrace:
   [1] top-level scope at none:0
   [2] eval at ./boot.jl:319 [inlined]
   [3] eval(::Module, ::Expr) at ./deprecated.jl:55
   [4] macro expansion at /home/travis/build/exercism/julia/runtests.jl:37 [inlined]
   [5] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1079 [inlined]
   [6] top-level scope at /home/travis/build/exercism/julia/runtests.jl:37 [inlined]
   [7] top-level scope at ./none:0
   [8] include at ./boot.jl:317 [inlined]
   [9] include_relative(::Module, ::String) at ./loading.jl:1040
   [10] include(::Module, ::String) at ./sysimg.jl:29
   [11] exec_options(::Base.JLOptions) at ./client.jl:235
   [12] _start() at ./client.jl:428
```

The dep warning says the following: ``Warning: `eval(m, x)` is deprecated, use `Core.eval(m, x)` instead.`` but changing that doesn't change the error above.

This could be fixed by running them in a separate Julia process, but that's not really a nice solution. I'm at a loss here on how to fix this.