### PR TITLE
difference-of-squares: Test that result is Integer (fixes #138)

### DIFF
--- a/exercises/difference-of-squares/runtests.jl
+++ b/exercises/difference-of-squares/runtests.jl
@@ -3,20 +3,20 @@ using Test
 include("difference-of-squares.jl")
 
 @testset "Square the sum of the numbers up to the given number" begin
-    @test square_of_sum(5) == 225
-    @test square_of_sum(10) == 3025
-    @test square_of_sum(100) == 25502500
+    @test square_of_sum(5)::Integer == 225
+    @test square_of_sum(10)::Integer == 3025
+    @test square_of_sum(100)::Integer == 25502500
 end
 
 @testset "Sum the squares of the numbers up to the given number" begin
-    @test sum_of_squares(5) == 55
-    @test sum_of_squares(10) == 385
-    @test sum_of_squares(100) == 338350
+    @test sum_of_squares(5)::Integer == 55
+    @test sum_of_squares(10)::Integer == 385
+    @test sum_of_squares(100)::Integer == 338350
 end
 
 @testset "Subtract sum of squares from square of sums" begin
-    @test difference(0) == 0
-    @test difference(5) == 170
-    @test difference(10) == 2640
-    @test difference(100) == 25164150
+    @test difference(0)::Integer == 0
+    @test difference(5)::Integer == 170
+    @test difference(10)::Integer == 2640
+    @test difference(100)::Integer == 25164150
 end


### PR DESCRIPTION
This ensures that a solution using Gauss's formula uses `÷` and not `/`.