### PR TITLE
 Change exercise topics to be more similar to shared TOPICS.txt 

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,8 +21,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "arithmetics",
-        "control_flow_conditionals",
+        "math",
+        "conditionals",
         "integers"
       ]
     },
@@ -34,7 +34,7 @@
       "difficulty": 1,
       "topics": [
         "chars",
-        "control_flow_loops",
+        "loops",
         "strings"
       ]
     },
@@ -45,7 +45,7 @@
       "unlocked_by": "nucleotide-count",
       "difficulty": 1,
       "topics": [
-        "exceptions",
+        "exception_handling",
         "generators",
         "strings"
       ]
@@ -70,7 +70,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "control_flow_if_else_statements",
+        "conditionals",
         "strings",
         "unicode"
       ]
@@ -107,7 +107,7 @@
       "difficulty": 2,
       "topics": [
         "arrays",
-        "control_flow_loops",
+        "loops",
         "filtering",
         "sorting",
         "strings"
@@ -143,8 +143,8 @@
       "unlocked_by": "rotational-cipher",
       "difficulty": 1,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "strings"
       ]
     },
@@ -166,8 +166,8 @@
       "unlocked_by": "difference-of-squares",
       "difficulty": 1,
       "topics": [
-        "control_flow_conditionals",
-        "exceptions",
+        "conditionals",
+        "exception_handling",
         "integers",
         "math"
       ]
@@ -180,7 +180,7 @@
       "difficulty": 1,
       "topics": [
         "arrays",
-        "control_flow_loops",
+        "loops",
         "strings"
       ]
     },
@@ -192,8 +192,8 @@
       "difficulty": 1,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "strings"
       ]
     },
@@ -205,7 +205,7 @@
       "difficulty": 1,
       "topics": [
         "arrays",
-        "control_flow_loops",
+        "loops",
         "strings"
       ]
     },
@@ -216,8 +216,8 @@
       "unlocked_by": "raindrops",
       "difficulty": 1,
       "topics": [
-        "arithmetics",
-        "control_flow_conditionals",
+        "math",
+        "conditionals",
         "strings"
       ]
     },
@@ -228,7 +228,7 @@
       "unlocked_by": "raindrops",
       "difficulty": 1,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "strings"
       ]
     },
@@ -240,8 +240,8 @@
       "difficulty": 1,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "strings"
       ]
     },
@@ -264,8 +264,8 @@
       "unlocked_by": "difference-of-squares",
       "difficulty": 2,
       "topics": [
-        "control_flow_exceptions",
-        "control_flow_if_else_statements",
+        "exception_handling",
+        "conditionals",
         "math"
       ]
     },
@@ -277,8 +277,8 @@
       "difficulty": 2,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "filtering",
         "math"
       ]
@@ -327,8 +327,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "conditionals",
-        "functional_abstraction"
+        "conditionals"
       ]
     },
     {
@@ -339,8 +338,8 @@
       "difficulty": 2,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "strings"
       ]
     },
@@ -351,9 +350,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-        "function_extension",
         "time",
-        "methods",
         "multiple_dispatch",
         "structs"
       ]
@@ -365,9 +362,7 @@
       "unlocked_by": "clock",
       "difficulty": 10,
       "topics": [
-        "function_extension",
         "math",
-        "methods",
         "multiple_dispatch",
         "structs"
       ]
@@ -379,9 +374,7 @@
       "unlocked_by": "clock",
       "difficulty": 8,
       "topics": [
-        "function_extension",
         "math",
-        "methods",
         "multiple_dispatch",
         "structs"
       ]
@@ -393,12 +386,9 @@
       "unlocked_by": "clock",
       "difficulty": 8,
       "topics": [
-        "function_extension",
         "iterators",
-        "methods",
         "multiple_dispatch",
-        "parametric_types",
-        "types"
+        "structs"
       ]
     },
     {
@@ -440,7 +430,7 @@
       "unlocked_by": "difference-of-squares",
       "difficulty": 1,
       "topics": [
-        "exceptions"
+        "exception_handling"
       ]
     },
     {
@@ -461,8 +451,8 @@
       "unlocked_by": "raindrops",
       "difficulty": 5,
       "topics": [
-        "arithmetics",
-        "control_flow_conditionals",
+        "math",
+        "conditionals",
         "metaprogramming",
         "strings",
         "structs"
@@ -475,7 +465,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "arithmetics",
+        "math",
         "integers",
         "math"
       ]

--- a/config.json
+++ b/config.json
@@ -1,474 +1,474 @@
 {
-  "language": "Julia",
-  "active": true,
-  "blurb": "Julia is an open-source high-level, dynamic programming language whose sweet spot is technical and scientific computing. It is convenient for day-to-day work and fast enough for high performance computing.",
-  "exercises": [
-    {
-      "slug": "hello-world",
-      "uuid": "a668410d-41aa-4710-a68f-54521da6486d",
-      "core": true,
-      "auto_approve": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "strings"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "8740c914-f008-4b6b-8e7d-7470e78e6a8e",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "math",
-        "conditionals",
-        "integers"
-      ]
-    },
-    {
-      "slug": "nucleotide-count",
-      "uuid": "54c24809-c6e7-419b-8ec3-6d8d128ca546",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "chars",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "hamming",
-      "uuid": "878e9897-c4b6-40ff-9034-8f2aedf07a91",
-      "core": false,
-      "unlocked_by": "nucleotide-count",
-      "difficulty": 1,
-      "topics": [
-        "exception_handling",
-        "generators",
-        "strings"
-      ]
-    },
-    {
-      "slug": "rna-transcription",
-      "uuid": "0d5f865c-b704-445c-ac31-df34168f54aa",
-      "core": false,
-      "unlocked_by": "nucleotide-count",
-      "difficulty": 1,
-      "topics": [
-        "exception_handling",
-        "filtering",
-        "pattern_matching",
-        "strings"
-      ]
-    },
-    {
-      "slug": "bob",
-      "uuid": "9474a13b-09c1-4e4d-90e3-1a14fde5eb62",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "conditionals",
-        "strings",
-        "unicode"
-      ]
-    },
-    {
-      "slug": "run-length-encoding",
-      "uuid": "9814f832-8bd1-4a2b-9a1e-fc0e3e8541b5",
-      "core": false,
-      "unlocked_by": "nucleotide-count",
-      "difficulty": 1,
-      "topics": [
-        "algorithms",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "pangram",
-      "uuid": "4bc9a4f8-fc4d-4e6b-a93c-07069bbc5bc9",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "arrays",
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "anagram",
-      "uuid": "d2cb1621-2a2e-4791-a6b6-fdbca74a5583",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "loops",
-        "filtering",
-        "sorting",
-        "strings"
-      ]
-    },
-    {
-      "slug": "binary-search",
-      "uuid": "325385bb-2a70-4c7a-8b4e-e6297fc69872",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "arrays",
-        "searching"
-      ]
-    },
-    {
-      "slug": "rotational-cipher",
-      "uuid": "79ea05f1-3f27-4b92-bc47-0cebcd8d5a6f",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "metaprogramming",
-        "string_literals",
-        "strings"
-      ]
-    },
-    {
-      "slug": "atbash-cipher",
-      "uuid": "a4638670-941d-4213-8407-d9ebba70bd42",
-      "core": false,
-      "unlocked_by": "rotational-cipher",
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "difference-of-squares",
-      "uuid": "16550822-4751-4bb3-9e15-80361006e2d6",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "generators",
-        "math"
-      ]
-    },
-    {
-      "slug": "pascals-triangle",
-      "uuid": "bf709fe6-d269-467a-a3da-5bbdaf674f91",
-      "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
-        "exception_handling",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "raindrops",
-      "uuid": "7a083573-2c68-47cc-8bc8-c0e483cf0e50",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "arrays",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "scrabble-score",
-      "uuid": "5feec698-0bf8-4308-9f72-2cecaab5e75e",
-      "core": false,
-      "unlocked_by": "nucleotide-count",
-      "difficulty": 1,
-      "topics": [
-        "arrays",
-        "conditionals",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "07875495-146f-44a3-b13a-e8e74a37b87d",
-      "core": false,
-      "unlocked_by": "nucleotide-count",
-      "difficulty": 1,
-      "topics": [
-        "arrays",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "luhn",
-      "uuid": "cc08d672-9c58-4e7a-bfb7-344cbad811f7",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 1,
-      "topics": [
-        "math",
-        "conditionals",
-        "strings"
-      ]
-    },
-    {
-      "slug": "roman-numerals",
-      "uuid": "58c41643-971c-4199-a10f-7dc21093e5e3",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 1,
-      "topics": [
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "isogram",
-      "uuid": "19f9e7c4-f2a5-4636-b7b2-4e0a15977e01",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 1,
-      "topics": [
-        "arrays",
-        "conditionals",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "etl",
-      "uuid": "bccc00fa-811c-4bf9-8e55-07a0d0affb08",
-      "core": false,
-      "unlocked_by": "nucleotide-count",
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "sorting",
-        "strings"
-      ]
-    },
-    {
-      "slug": "collatz-conjecture",
-      "uuid": "d1d5a74a-d488-4e2e-bd63-b74730057c98",
-      "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 2,
-      "topics": [
-        "exception_handling",
-        "conditionals",
-        "math"
-      ]
-    },
-    {
-      "slug": "sieve",
-      "uuid": "5e3b376a-06ab-442f-8d18-710db7778db6",
-      "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "conditionals",
-        "loops",
-        "filtering",
-        "math"
-      ]
-    },
-    {
-      "slug": "trinary",
-      "uuid": "c09ed7ec-fa7c-4f6a-994f-3d3eb7f22df4",
-      "core": false,
-      "unlocked_by": "secret-handshake",
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "integers",
-        "math",
-        "strings"
-      ]
-    },
-    {
-      "slug": "secret-handshake",
-      "uuid": "d2c85375-c0e7-4e04-88f1-08736e5afa04",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "filtering"
-      ]
-    },
-    {
-      "slug": "phone-number",
-      "uuid": "f7a3f344-a9fa-4a36-ac44-12bc8673899e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
-        "pattern_matching",
-        "regular_expressions",
-        "strings"
-      ]
-    },
-    {
-      "slug": "triangle",
-      "uuid": "f5be4623-2a9a-4bf5-bb32-dd81eddf0683",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "conditionals"
-      ]
-    },
-    {
-      "slug": "transpose",
-      "uuid": "e5a6d640-cd76-4453-8247-fd34ffed4fe5",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "arrays",
-        "conditionals",
-        "loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "clock",
-      "uuid": "39bc1f1e-68e3-4d35-880b-d6b6fa174605",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "time",
-        "multiple_dispatch",
-        "structs"
-      ]
-    },
-    {
-      "slug": "complex-numbers",
-      "uuid": "eca7e62c-7bbf-436c-8011-2920cb2ab1c1",
-      "core": false,
-      "unlocked_by": "clock",
-      "difficulty": 10,
-      "topics": [
-        "math",
-        "multiple_dispatch",
-        "structs"
-      ]
-    },
-    {
-      "slug": "rational-numbers",
-      "uuid": "0caf0209-be6e-4585-a90b-e41c94c5fa40",
-      "core": false,
-      "unlocked_by": "clock",
-      "difficulty": 8,
-      "topics": [
-        "math",
-        "multiple_dispatch",
-        "structs"
-      ]
-    },
-    {
-      "slug": "custom-set",
-      "uuid": "b47377f7-84af-4a10-83ef-c2444a4f8940",
-      "core": false,
-      "unlocked_by": "clock",
-      "difficulty": 8,
-      "topics": [
-        "iterators",
-        "multiple_dispatch",
-        "structs"
-      ]
-    },
-    {
-      "slug": "robot-name",
-      "uuid": "7cb2d96a-4707-4cec-9ead-313fcb5fbb94",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "randomness",
-        "strings",
-        "structs"
-      ]
-    },
-    {
-      "slug": "gigasecond",
-      "uuid": "c64e03cc-1952-4b2d-9a53-25c43187a4e6",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "dates"
-      ]
-    },
-    {
-      "slug": "robot-simulator",
-      "uuid": "e4b19962-ebc1-4f12-9ac8-45f17faeaa55",
-      "core": false,
-      "unlocked_by": "robot-name",
-      "difficulty": 6,
-      "topics": [
-        "structs"
-      ]
-    },
-    {
-      "slug": "grains",
-      "uuid": "4cc2a5d6-e662-4d99-81d4-05d6bcd500f4",
-      "core": false,
-      "unlocked_by": "difference-of-squares",
-      "difficulty": 1,
-      "topics": [
-        "exception_handling"
-      ]
-    },
-    {
-      "slug": "spiral-matrix",
-      "uuid": "3a2facfd-5ec8-49a0-a5aa-2229f07da896",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "iterators",
-        "matrix"
-      ]
-    },
-    {
-      "slug": "isbn-verifier",
-      "uuid": "22b64a2b-7f08-444d-be6e-8b42e5c9207c",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 5,
-      "topics": [
-        "math",
-        "conditionals",
-        "metaprogramming",
-        "strings",
-        "structs"
-      ]
-    },
-    {
-      "slug": "armstrong-numbers",
-      "uuid": "af4ae5d7-8d9d-4d21-b5d3-62f4fd8b4719",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "math",
-        "integers",
-        "math"
-      ]
-    }
-  ]
+    "language": "Julia",
+    "active": true,
+    "blurb": "Julia is an open-source high-level, dynamic programming language whose sweet spot is technical and scientific computing. It is convenient for day-to-day work and fast enough for high performance computing.",
+    "exercises": [
+        {
+            "slug": "hello-world",
+            "uuid": "a668410d-41aa-4710-a68f-54521da6486d",
+            "core": true,
+            "auto_approve": true,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "strings"
+            ]
+        },
+        {
+            "slug": "leap",
+            "uuid": "8740c914-f008-4b6b-8e7d-7470e78e6a8e",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "math",
+                "conditionals",
+                "integers"
+            ]
+        },
+        {
+            "slug": "nucleotide-count",
+            "uuid": "54c24809-c6e7-419b-8ec3-6d8d128ca546",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "chars",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "hamming",
+            "uuid": "878e9897-c4b6-40ff-9034-8f2aedf07a91",
+            "core": false,
+            "unlocked_by": "nucleotide-count",
+            "difficulty": 1,
+            "topics": [
+                "exception_handling",
+                "generators",
+                "strings"
+            ]
+        },
+        {
+            "slug": "rna-transcription",
+            "uuid": "0d5f865c-b704-445c-ac31-df34168f54aa",
+            "core": false,
+            "unlocked_by": "nucleotide-count",
+            "difficulty": 1,
+            "topics": [
+                "exception_handling",
+                "filtering",
+                "pattern_matching",
+                "strings"
+            ]
+        },
+        {
+            "slug": "bob",
+            "uuid": "9474a13b-09c1-4e4d-90e3-1a14fde5eb62",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 2,
+            "topics": [
+                "conditionals",
+                "strings",
+                "unicode"
+            ]
+        },
+        {
+            "slug": "run-length-encoding",
+            "uuid": "9814f832-8bd1-4a2b-9a1e-fc0e3e8541b5",
+            "core": false,
+            "unlocked_by": "nucleotide-count",
+            "difficulty": 1,
+            "topics": [
+                "algorithms",
+                "strings",
+                "text_formatting"
+            ]
+        },
+        {
+            "slug": "pangram",
+            "uuid": "4bc9a4f8-fc4d-4e6b-a93c-07069bbc5bc9",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "arrays",
+                "filtering",
+                "strings"
+            ]
+        },
+        {
+            "slug": "anagram",
+            "uuid": "d2cb1621-2a2e-4791-a6b6-fdbca74a5583",
+            "core": false,
+            "unlocked_by": "pangram",
+            "difficulty": 2,
+            "topics": [
+                "arrays",
+                "loops",
+                "filtering",
+                "sorting",
+                "strings"
+            ]
+        },
+        {
+            "slug": "binary-search",
+            "uuid": "325385bb-2a70-4c7a-8b4e-e6297fc69872",
+            "core": false,
+            "unlocked_by": "pangram",
+            "difficulty": 3,
+            "topics": [
+                "arrays",
+                "searching"
+            ]
+        },
+        {
+            "slug": "rotational-cipher",
+            "uuid": "79ea05f1-3f27-4b92-bc47-0cebcd8d5a6f",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 2,
+            "topics": [
+                "metaprogramming",
+                "string_literals",
+                "strings"
+            ]
+        },
+        {
+            "slug": "atbash-cipher",
+            "uuid": "a4638670-941d-4213-8407-d9ebba70bd42",
+            "core": false,
+            "unlocked_by": "rotational-cipher",
+            "difficulty": 1,
+            "topics": [
+                "conditionals",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "difference-of-squares",
+            "uuid": "16550822-4751-4bb3-9e15-80361006e2d6",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "generators",
+                "math"
+            ]
+        },
+        {
+            "slug": "pascals-triangle",
+            "uuid": "bf709fe6-d269-467a-a3da-5bbdaf674f91",
+            "core": false,
+            "unlocked_by": "difference-of-squares",
+            "difficulty": 1,
+            "topics": [
+                "conditionals",
+                "exception_handling",
+                "integers",
+                "math"
+            ]
+        },
+        {
+            "slug": "raindrops",
+            "uuid": "7a083573-2c68-47cc-8bc8-c0e483cf0e50",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "arrays",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "scrabble-score",
+            "uuid": "5feec698-0bf8-4308-9f72-2cecaab5e75e",
+            "core": false,
+            "unlocked_by": "nucleotide-count",
+            "difficulty": 1,
+            "topics": [
+                "arrays",
+                "conditionals",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "word-count",
+            "uuid": "07875495-146f-44a3-b13a-e8e74a37b87d",
+            "core": false,
+            "unlocked_by": "nucleotide-count",
+            "difficulty": 1,
+            "topics": [
+                "arrays",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "luhn",
+            "uuid": "cc08d672-9c58-4e7a-bfb7-344cbad811f7",
+            "core": false,
+            "unlocked_by": "raindrops",
+            "difficulty": 1,
+            "topics": [
+                "math",
+                "conditionals",
+                "strings"
+            ]
+        },
+        {
+            "slug": "roman-numerals",
+            "uuid": "58c41643-971c-4199-a10f-7dc21093e5e3",
+            "core": false,
+            "unlocked_by": "raindrops",
+            "difficulty": 1,
+            "topics": [
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "isogram",
+            "uuid": "19f9e7c4-f2a5-4636-b7b2-4e0a15977e01",
+            "core": false,
+            "unlocked_by": "pangram",
+            "difficulty": 1,
+            "topics": [
+                "arrays",
+                "conditionals",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "etl",
+            "uuid": "bccc00fa-811c-4bf9-8e55-07a0d0affb08",
+            "core": false,
+            "unlocked_by": "nucleotide-count",
+            "difficulty": 2,
+            "topics": [
+                "arrays",
+                "sorting",
+                "strings"
+            ]
+        },
+        {
+            "slug": "collatz-conjecture",
+            "uuid": "d1d5a74a-d488-4e2e-bd63-b74730057c98",
+            "core": false,
+            "unlocked_by": "difference-of-squares",
+            "difficulty": 2,
+            "topics": [
+                "exception_handling",
+                "conditionals",
+                "math"
+            ]
+        },
+        {
+            "slug": "sieve",
+            "uuid": "5e3b376a-06ab-442f-8d18-710db7778db6",
+            "core": false,
+            "unlocked_by": "difference-of-squares",
+            "difficulty": 2,
+            "topics": [
+                "arrays",
+                "conditionals",
+                "loops",
+                "filtering",
+                "math"
+            ]
+        },
+        {
+            "slug": "trinary",
+            "uuid": "c09ed7ec-fa7c-4f6a-994f-3d3eb7f22df4",
+            "core": false,
+            "unlocked_by": "secret-handshake",
+            "difficulty": 2,
+            "topics": [
+                "arrays",
+                "integers",
+                "math",
+                "strings"
+            ]
+        },
+        {
+            "slug": "secret-handshake",
+            "uuid": "d2c85375-c0e7-4e04-88f1-08736e5afa04",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 2,
+            "topics": [
+                "arrays",
+                "filtering"
+            ]
+        },
+        {
+            "slug": "phone-number",
+            "uuid": "f7a3f344-a9fa-4a36-ac44-12bc8673899e",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "conditionals",
+                "pattern_matching",
+                "regular_expressions",
+                "strings"
+            ]
+        },
+        {
+            "slug": "triangle",
+            "uuid": "f5be4623-2a9a-4bf5-bb32-dd81eddf0683",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "conditionals"
+            ]
+        },
+        {
+            "slug": "transpose",
+            "uuid": "e5a6d640-cd76-4453-8247-fd34ffed4fe5",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 2,
+            "topics": [
+                "arrays",
+                "conditionals",
+                "loops",
+                "strings"
+            ]
+        },
+        {
+            "slug": "clock",
+            "uuid": "39bc1f1e-68e3-4d35-880b-d6b6fa174605",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 5,
+            "topics": [
+                "time",
+                "multiple_dispatch",
+                "structs"
+            ]
+        },
+        {
+            "slug": "complex-numbers",
+            "uuid": "eca7e62c-7bbf-436c-8011-2920cb2ab1c1",
+            "core": false,
+            "unlocked_by": "clock",
+            "difficulty": 10,
+            "topics": [
+                "math",
+                "multiple_dispatch",
+                "structs"
+            ]
+        },
+        {
+            "slug": "rational-numbers",
+            "uuid": "0caf0209-be6e-4585-a90b-e41c94c5fa40",
+            "core": false,
+            "unlocked_by": "clock",
+            "difficulty": 8,
+            "topics": [
+                "math",
+                "multiple_dispatch",
+                "structs"
+            ]
+        },
+        {
+            "slug": "custom-set",
+            "uuid": "b47377f7-84af-4a10-83ef-c2444a4f8940",
+            "core": false,
+            "unlocked_by": "clock",
+            "difficulty": 8,
+            "topics": [
+                "iterators",
+                "multiple_dispatch",
+                "structs"
+            ]
+        },
+        {
+            "slug": "robot-name",
+            "uuid": "7cb2d96a-4707-4cec-9ead-313fcb5fbb94",
+            "core": true,
+            "unlocked_by": null,
+            "difficulty": 5,
+            "topics": [
+                "randomness",
+                "strings",
+                "structs"
+            ]
+        },
+        {
+            "slug": "gigasecond",
+            "uuid": "c64e03cc-1952-4b2d-9a53-25c43187a4e6",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "dates"
+            ]
+        },
+        {
+            "slug": "robot-simulator",
+            "uuid": "e4b19962-ebc1-4f12-9ac8-45f17faeaa55",
+            "core": false,
+            "unlocked_by": "robot-name",
+            "difficulty": 6,
+            "topics": [
+                "structs"
+            ]
+        },
+        {
+            "slug": "grains",
+            "uuid": "4cc2a5d6-e662-4d99-81d4-05d6bcd500f4",
+            "core": false,
+            "unlocked_by": "difference-of-squares",
+            "difficulty": 1,
+            "topics": [
+                "exception_handling"
+            ]
+        },
+        {
+            "slug": "spiral-matrix",
+            "uuid": "3a2facfd-5ec8-49a0-a5aa-2229f07da896",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 3,
+            "topics": [
+                "iterators",
+                "matrix"
+            ]
+        },
+        {
+            "slug": "isbn-verifier",
+            "uuid": "22b64a2b-7f08-444d-be6e-8b42e5c9207c",
+            "core": false,
+            "unlocked_by": "raindrops",
+            "difficulty": 5,
+            "topics": [
+                "math",
+                "conditionals",
+                "metaprogramming",
+                "strings",
+                "structs"
+            ]
+        },
+        {
+            "slug": "armstrong-numbers",
+            "uuid": "af4ae5d7-8d9d-4d21-b5d3-62f4fd8b4719",
+            "core": false,
+            "unlocked_by": null,
+            "difficulty": 1,
+            "topics": [
+                "math",
+                "integers",
+                "math"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Some of the topics used in `config.json` had the same meaning as topics in `problem-specification/TOPICS.txt` but had slightly different names. This PR updates them to follow the conventional names wherever possible.