### PR TITLE
Add basic GitHub actions CI for exercise tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,20 @@
+name: Run tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.0.4, 1.1.1, 1.2.0-rc3, 1.3.0-alpha]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - name: "Set up Julia ${{ matrix.julia-version }}"
+        uses: julia-actions/setup-julia@v0.1.0-release
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Test exercises
+        run: julia --color=yes runtests.jl

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1.0.0
       - name: "Set up Julia ${{ matrix.julia-version }}"
-        uses: julia-actions/setup-julia@v0.1.0-release
+        uses: julia-actions/setup-julia@v0.1.0
         with:
           version: ${{ matrix.julia-version }}
       - name: Test exercises


### PR DESCRIPTION
This runs the exercise tests as a GitHub action/workflow. The configlet, notebook checking etc. solely run on Travis for now.