### PR TITLE
Use docstrings instead of type annotations

### DIFF
--- a/exercises/leap/leap.ipynb
+++ b/exercises/leap/leap.ipynb
@@ -15,7 +15,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": ["# submit\n", "\"\"\"\n", "    is_leap_year(year)\n", "\n", "Test if `year` is a leap year in the gregorian calendar.\n", "\n", "\"\"\"\n", "function is_leap_year(year)\n", "\n", "end\n", ""]
+            "source": ["# submit\n", "\"\"\"\n", "    is_leap_year(year)\n", "\n", "Return `true` if `year` is a leap year in the gregorian calendar.\n", "\n", "\"\"\"\n", "function is_leap_year(year)\n", "\n", "end\n", ""]
         },
         {
             "cell_type": "markdown",

--- a/exercises/leap/leap.ipynb
+++ b/exercises/leap/leap.ipynb
@@ -15,7 +15,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": ["# submit\n", "function is_leap_year(year::Int)\n", "\n", "end\n", ""]
+            "source": ["# submit\n", "\"\"\"\n", "    is_leap_year(year)\n", "\n", "Test if `year` is a leap year in the gregorian calendar.\n", "\n", "\"\"\"\n", "function is_leap_year(year)\n", "\n", "end\n", ""]
         },
         {
             "cell_type": "markdown",

--- a/exercises/leap/leap.jl
+++ b/exercises/leap/leap.jl
@@ -1,4 +1,10 @@
-function is_leap_year(year::Int)
+"""
+    is_leap_year(year)
+
+Test if `year` is a leap year in the gregorian calendar.
+
+"""
+function is_leap_year(year)
 
 end
 

--- a/exercises/leap/leap.jl
+++ b/exercises/leap/leap.jl
@@ -1,7 +1,7 @@
 """
     is_leap_year(year)
 
-Test if `year` is a leap year in the gregorian calendar.
+Return `true` if `year` is a leap year in the gregorian calendar.
 
 """
 function is_leap_year(year)

--- a/exercises/nucleotide-count/nucleotide-count.ipynb
+++ b/exercises/nucleotide-count/nucleotide-count.ipynb
@@ -15,7 +15,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": ["# submit\n", "function count_nucleotides(strand::AbstractString)\n", "\n", "end"]
+            "source": ["# submit\n", "\"\"\"\n", "    count_nucleotides(strand)\n", "\n", "The frequency of each nucleotide within `strand` as a dictionary.\n", "\n", "Invalid strands raise a DomainError.\n", "\n", "\"\"\"\n", "function count_nucleotides(strand)\n", "\n", "end"]
         },
         {
             "cell_type": "markdown",

--- a/exercises/nucleotide-count/nucleotide-count.ipynb
+++ b/exercises/nucleotide-count/nucleotide-count.ipynb
@@ -15,7 +15,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": ["# submit\n", "\"\"\"\n", "    count_nucleotides(strand)\n", "\n", "The frequency of each nucleotide within `strand` as a dictionary.\n", "\n", "Invalid strands raise a DomainError.\n", "\n", "\"\"\"\n", "function count_nucleotides(strand)\n", "\n", "end"]
+            "source": ["# submit\n", "\"\"\"\n", "    count_nucleotides(strand)\n", "\n", "The frequency of each nucleotide within `strand` as a dictionary.\n", "\n", "Invalid strands raise a `DomainError`.\n", "\n", "\"\"\"\n", "function count_nucleotides(strand)\n", "\n", "end"]
         },
         {
             "cell_type": "markdown",

--- a/exercises/nucleotide-count/nucleotide-count.jl
+++ b/exercises/nucleotide-count/nucleotide-count.jl
@@ -3,7 +3,7 @@
 
 The frequency of each nucleotide within `strand` as a dictionary.
 
-Invalid strands raise a DomainError.
+Invalid strands raise a `DomainError`.
 
 """
 function count_nucleotides(strand)

--- a/exercises/nucleotide-count/nucleotide-count.jl
+++ b/exercises/nucleotide-count/nucleotide-count.jl
@@ -1,3 +1,11 @@
-function count_nucleotides(strand::AbstractString)
+"""
+    count_nucleotides(strand)
+
+The frequency of each nucleotide within `strand` as a dictionary.
+
+Invalid strands raise a DomainError.
+
+"""
+function count_nucleotides(strand)
 
 end

--- a/exercises/pangram/pangram.ipynb
+++ b/exercises/pangram/pangram.ipynb
@@ -15,7 +15,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": ["# submit\n", "function ispangram(input::AbstractString)\n", "\n", "end\n", ""]
+            "source": ["# submit\n", "\"\"\"\n", "    ispangram(input)\n", "\n", "Return `true` if `input` contains every alphabetic character (case insensitive).\n", "\n", "\"\"\"\n", "function ispangram(input)\n", "\n", "end\n", ""]
         },
         {
             "cell_type": "markdown",

--- a/exercises/pangram/pangram.jl
+++ b/exercises/pangram/pangram.jl
@@ -1,4 +1,10 @@
-function ispangram(input::AbstractString)
+"""
+    ispangram(input)
+
+Return `true` if `input` contains every alphabetic character (case insensitive).
+
+"""
+function ispangram(input)
 
 end
 


### PR DESCRIPTION
Users often overdo it on the type annotations in a way that is
unidiomatic for Julia and contrary to the recommendations of experienced
Julia programmers like Lyndon White and the Julia core team.

To provide some guidance to users, I've added docstrings to all of the
exercise skeletons that I've removed annotations from (the first three
in the track).