### PR TITLE
Fail if  there are 26 letters case sensitive

### DIFF
--- a/exercises/pangram/runtests.jl
+++ b/exercises/pangram/runtests.jl
@@ -38,3 +38,10 @@ end
     @test !ispangram("the quick brown fox jumped over the lazy FOX")
 end
 
+@testset "a-m and A-M are 26 different letters but not a pangram" begin
+    @test !ispangram("abcdefghijklm ABCDEFGHIJKLM")
+end
+
+@testset "pangram with more than 26 letters (if case sensitive)" begin
+    @test ispangram("the 1 quick brown fox jumps Over the 2 lazy dogs")
+end


### PR DESCRIPTION
I received one solution where it was only checked whether there are exactly 26 letters (case sensitive)
This would result in that `a...m A...M` is a pangram for example.
Also fails if there are more than 26 letters when counting i.e o and O as two different ones.