### PR TITLE
Remove type annotations from hamming

### DIFF
--- a/exercises/hamming/example.jl
+++ b/exercises/hamming/example.jl
@@ -1,4 +1,4 @@
-function distance(s1::AbstractString, s2::AbstractString)
+function distance(s1, s2)
     length(s1) != length(s2) && throw(ArgumentError("Sequences must have the same length"))
-    reduce(+, a != b for (a, b) in zip(s1, s2); init=0)
+    count(a != b for (a, b) in zip(s1, s2))
 end

--- a/exercises/hamming/hamming.ipynb
+++ b/exercises/hamming/hamming.ipynb
@@ -15,7 +15,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": ["# submit\n", "function distance(s1::AbstractString, s2::AbstractString)\n", "\n", "end"]
+            "source": ["# submit\n", "\"Your optional docstring here\"\n", "function distance(a, b)\n", "\n", "end"]
         },
         {
             "cell_type": "markdown",

--- a/exercises/hamming/hamming.jl
+++ b/exercises/hamming/hamming.jl
@@ -1,3 +1,4 @@
-function distance(s1::AbstractString, s2::AbstractString)
+"Your optional docstring here"
+function distance(a, b)
 
 end


### PR DESCRIPTION
Type annotations are baaad.

In this case, for common solutions, the code will work for any iterable,
but with type annotations it will be artificially restricted to strings.
That's not clever.

Updated example.jl slightly while I was here, because `count` is a bit
nicer than mapreduce.