### PR TITLE
Add test for binary-search

### DIFF
--- a/exercises/binary-search/runtests.jl
+++ b/exercises/binary-search/runtests.jl
@@ -45,6 +45,7 @@ end
             @test_skip binarysearch([1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8], 6, by = round) == 4:4
             @test_skip binarysearch([1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8], 1, by = round) == 1:1
             @test_skip binarysearch([1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8], 11, by = round) == 7:7
+            @test_skip binarysearch([1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8], 11, by =  abs2∘round) == 7:7
             @test_skip binarysearch([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634], 144.4, by = round) == 10:10
             @test_skip binarysearch([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 20.6, by = round) == 6:6
         end


### PR DESCRIPTION
The test will fail if `lt(x, key)` is used instead of `lt(x, by(key))`. See the following behavior for the test and why it fails:

```julia
function binarysearch(book::AbstractVector, key; 
                      rev = false, 
                      by = identity, 
                      lt = ifelse(rev, >, <),
                      debug = false, 
                      wrong = false)

    debug && @show book

    isempty(book) && return 1:0
    i = (length(book)+1) ÷ 2

    x, k = by(book[i]), by(key)

    kk = wrong ? key : k

    if x == k
        return i:i
    elseif lt(x, kk)
        debug && println("  ($x $lt $kk), going right at indices ($(i+1):end)")
        i .+ binarysearch(@view(book[i+1:end]), key; rev=rev, by=by, lt=lt, debug=debug)
    else
        debug && println("  !($x $lt $kk), going left at indices 1:$(i-1)")
        binarysearch(@view(book[1:i-1]), key; rev=rev, by=by, lt=lt, debug=debug)
    end
end
```
```
julia> binarysearch([1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8], 11, by =  abs2∘round, debug=true, wrong=true)
book = [1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8]
  !(36.0 < 11), going left at indices 1:3
book = [1.1, 2.9, 4.4]
  (9.0 < 121), going right at indices (3:end)
book = [4.4]
  (16.0 < 121), going right at indices (2:end)
book = Float64[]
4:3

julia> binarysearch([1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8], 11, by =  abs2∘round, debug=true, wrong=false)
book = [1.1, 2.9, 4.4, 5.5, 8.1, 9.0, 10.8]
  (36.0 < 121), going right at indices (5:end)
book = [8.1, 9.0, 10.8]
  (81.0 < 121), going right at indices (3:end)
book = [10.8]
7:7
```