### PR TITLE
Add Julia maintainers as default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Default fallback
+*                       @exercism/julia
+
 # Maintainers 
 config/maintainers.json @exercism/maintainers-admin
 


### PR DESCRIPTION
This will automatically request a review from Julia maintainers.

Later rules in the CODEOWNERS file take precedence, so the maintainers.json and CODEOWNERS rules are unaffected: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file