### PR TITLE
Add check for denominator not being 0 in testsets

### DIFF
--- a/exercises/rational-numbers/runtests.jl
+++ b/exercises/rational-numbers/runtests.jl
@@ -103,7 +103,7 @@ end
 @testset "Ordering" begin
     for a in -5:5, b in -5:5, c in -5:5
         a == b == 0 && continue
-        
+        b == 0 && continue
         r = RationalNumber(a, b)
 
         @test (r == c) == (a / b == c)
@@ -115,7 +115,7 @@ end
 
         for d in -5:5
             c == d == 0 && continue
-
+            d == 0 && continue
             s = RationalNumber(c, d)
 
             @test (r == s) == (a / b == c / d)


### PR DESCRIPTION
This blew up in my face.
Here's the fix. 🦾