### PR TITLE
Update nucleotide-count.jl comment

### DIFF
--- a/exercises/practice/nucleotide-count/nucleotide-count.jl
+++ b/exercises/practice/nucleotide-count/nucleotide-count.jl
@@ -1,7 +1,7 @@
 """
     count_nucleotides(strand)
 
-The frequency of each nucleotide within `strand` as a dictionary.
+The count of each nucleotide within `strand` as a dictionary.
 
 Invalid strands raise a `DomainError`.
 


### PR DESCRIPTION
I got tricked by my own excitement beginning the julia track.
I started solving the Nucleotide Count exercise without a complete reading of its introduction;
the comment at the beginning seemed just enough:

> count_nucleotides(strand)
> The frequency of each nucleotide within `strand` as a dictionary.
> Invalid strands raise a `DomainError`.

So I read **frequency** and I think: count(nt) / length(strand) 

It was fun solving that.. Untill the tests revealed  my mistake:
we are asked to return the count of each nucleotide: not their frequencies.

To avoid the confusion -for future students- I'd propose to replace "frequency" with "count" in the comment of the exercise's .jl file.