### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "76bf4e45-02be-4881-a65f-4863acdff33f",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Julia locally",
+      "blurb": "Learn how to install Julia locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "5eecd035-fe5d-4ada-be7a-1092e5a31d70",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Julia",
+      "blurb": "An overview of how to get started from scratch with Julia"
+    },
+    {
+      "uuid": "8103e3fb-1de0-4630-a59a-ebcc4d2a54b9",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Julia track",
+      "blurb": "Learn how to test your Julia exercises on Exercism"
+    },
+    {
+      "uuid": "5cf21489-763b-4ec9-9609-4aa3ed013565",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Julia resources",
+      "blurb": "A collection of useful resources to help you master Julia"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
