### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -13,16 +13,10 @@
     ]
   },
   "contributors": [
-    {
-      "github_username": "cmcaine",
-      "exercism_username": "cmcaine"
-    }
+    "cmcaine"
   ],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": "javascript/boolean"
 }

--- a/exercises/concept/annalyns-infiltration2/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration2/.meta/config.json
@@ -13,16 +13,10 @@
     ]
   },
   "contributors": [
-    {
-      "github_username": "cmcaine",
-      "exercism_username": "cmcaine"
-    }
+    "cmcaine"
   ],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": "javascript/boolean"
 }

--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": "javascript/enchantments"
 }

--- a/exercises/concept/emoji-times/.meta/config.json
+++ b/exercises/concept/emoji-times/.meta/config.json
@@ -14,14 +14,8 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "cmcaine",
-      "exercism_username": "cmcaine"
-    },
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "cmcaine",
+    "SaschaMann"
   ],
   "forked_from": null
 }

--- a/exercises/concept/encounters/.meta/config.json
+++ b/exercises/concept/encounters/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": null
 }

--- a/exercises/concept/exercism-matrix/.meta/config.json
+++ b/exercises/concept/exercism-matrix/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": null
 }

--- a/exercises/concept/fibonacci-iterator/.meta/config.json
+++ b/exercises/concept/fibonacci-iterator/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": null
 }

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": "fsharp/basics"
 }

--- a/exercises/concept/leap/.meta/config.json
+++ b/exercises/concept/leap/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": "v2/leap"
 }

--- a/exercises/concept/stage-heralding/.meta/config.json
+++ b/exercises/concept/stage-heralding/.meta/config.json
@@ -14,14 +14,8 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    },
-    {
-      "github_username": "cmcaine",
-      "exercism_username": "cmcaine"
-    }
+    "SaschaMann",
+    "cmcaine"
   ],
   "forked_from": null
 }

--- a/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/exercises/concept/vehicle-purchase/.meta/config.json
@@ -14,10 +14,7 @@
   },
   "contributors": [],
   "authors": [
-    {
-      "github_username": "SaschaMann",
-      "exercism_username": "SaschaMann"
-    }
+    "SaschaMann"
   ],
   "forked_from": "swift/vehicle-purchase"
 }


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
