### PR TITLE
Add missing contributors and authors to concept exercises

### DIFF
--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -12,7 +12,9 @@
       "enchantments.jl"
     ]
   },
-  "contributors": [],
+  "contributors": [
+    "cmcaine"
+  ],
   "authors": [
     "SaschaMann"
   ],

--- a/exercises/concept/fibonacci-iterator/.meta/config.json
+++ b/exercises/concept/fibonacci-iterator/.meta/config.json
@@ -12,7 +12,11 @@
       "fibonacci.jl"
     ]
   },
-  "contributors": [],
+  "contributors": [
+    "cmcaine",
+    "miguelraz",
+    "iHiD"
+  ],
   "authors": [
     "SaschaMann"
   ],

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -12,7 +12,9 @@
       "lasagna.jl"
     ]
   },
-  "contributors": [],
+  "contributors": [
+    "ErikSchierboom"
+  ],
   "authors": [
     "SaschaMann"
   ],

--- a/exercises/concept/leap/.meta/config.json
+++ b/exercises/concept/leap/.meta/config.json
@@ -14,7 +14,8 @@
   },
   "contributors": [],
   "authors": [
-    "SaschaMann"
+    "SaschaMann",
+    "cmcaine"
   ],
   "forked_from": ["v2/leap"]
 }

--- a/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/exercises/concept/vehicle-purchase/.meta/config.json
@@ -12,7 +12,9 @@
       "vehicle-purchase.jl"
     ]
   },
-  "contributors": [],
+  "contributors": [
+    "cmcaine"
+  ],
   "authors": [
     "SaschaMann"
   ],


### PR DESCRIPTION
I've tried to apply the same policy as in #354 where all reviews count as contribution or more.