### PR TITLE
Update runtests.jl so to match instruction

### DIFF
--- a/exercises/practice/phone-number/runtests.jl
+++ b/exercises/practice/phone-number/runtests.jl
@@ -8,9 +8,7 @@ if VERSION < v"1.1"
     @eval isnothing(::Nothing) = true
 end
 
-# Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
-# Returns the cleaned phone number as a digit string if given number is valid,
-# else returns `nothing`.
+# I think this part is redundant since it's not longer a problem (inwalid number test was removerd to match project instructions)
 
 const expected_number = "2234567890"
 const valid_10digit_num = (
@@ -22,22 +20,7 @@ const valid_11digit_num = (
         "12234567890",
         "  1 223 456 7890 ",
         "+1 (223) 456-7890",
-)
-const invalid_num = (
-        "123456789",
-        "1223456789",
-        "22234567890",
-        "321234567890",
-        "223-abc-7890",
-        "223-@:!-7890",
-        "(023) 456-7890",
-        "(123) 456-7890",
-        "(223) 056-7890",
-        "(223) 156-7890",
-        "1 (023) 456-7890",
-        "1 (123) 456-7890",
-        "1 (223) 056-7890",
-        "1 (223) 156-7890",
+
 )
 
 @testset "clean 10-digit number" begin
@@ -52,8 +35,3 @@ end
     end
 end
 
-@testset "detect invalid number" begin
-    @testset "$number" for number in invalid_num
-        @test isnothing(clean(number))
-    end
-end


### PR DESCRIPTION
Hi,
The project description says:

>Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
>
>For example, the inputs
>
>+1 (613)-995-0253
>613-995-0253
>1 613 995 0253
>613.995.0253
>should all produce the output
>6139950253

And that's basically it. There is nothing in the project instruction that would suggest that the challenge include changing if the number is valid
(wrong number of digits, '0' or '1' on index 1 or 4). 

Either test or description should be corrected.