### PR TITLE
phone-number: Update instructions to match tests

### DIFF
--- a/exercises/practice/phone-number/.docs/instructions.md
+++ b/exercises/practice/phone-number/.docs/instructions.md
@@ -26,6 +26,11 @@ should all produce the output
 
 `6139950253`
 
-**Note** Valid output falows the _"NXXNXXXXXX"_ format, where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9. **In other case please return `nothing`**
-
 **Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+When an input is invalid your function must throw an `ArgumentError`.
+Invalid inputs include:
+- `apple`
+- `100`
+- `2 555 555 1234`
+- `100 200 3000`

--- a/exercises/practice/phone-number/.docs/instructions.md
+++ b/exercises/practice/phone-number/.docs/instructions.md
@@ -26,4 +26,6 @@ should all produce the output
 
 `6139950253`
 
+**Note** Valid output falows the _"NXXNXXXXXX"_ format, where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9. **In other case please return `nothing`**
+
 **Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -5,7 +5,8 @@
   ],
   "contributors": [
     "cmcaine",
-    "SaschaMann"
+    "SaschaMann",
+    "Rigante-pl"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/phone-number/.meta/example.jl
+++ b/exercises/practice/phone-number/.meta/example.jl
@@ -11,7 +11,7 @@ function clean(phone_number)
     result = match(r, phone_number)
 
     if result === nothing
-        throw(ArgumentError("\"$phone_number\" is not a valid US phone number."))
+        throw(ArgumentError("\"$phone_number\" is not a valid NANP phone number."))
     else
         return Base.string(result.captures...)
     end

--- a/exercises/practice/phone-number/.meta/example.jl
+++ b/exercises/practice/phone-number/.meta/example.jl
@@ -10,9 +10,9 @@ function clean(phone_number)
 
     result = match(r, phone_number)
 
-    if result != nothing
-        result = Base.string(result.captures...)
+    if result === nothing
+        throw(ArgumentError("\"$phone_number\" is not a valid US phone number."))
+    else
+        return Base.string(result.captures...)
     end
-
-    return result
 end

--- a/exercises/practice/phone-number/runtests.jl
+++ b/exercises/practice/phone-number/runtests.jl
@@ -2,12 +2,6 @@ using Test
 
 include("phone-number.jl")
 
-# Julia 1.0 compat
-if VERSION < v"1.1"
-    @eval isnothing(::Any) = false
-    @eval isnothing(::Nothing) = true
-end
-
 # Tests adapted from `problem-specifications//canonical-data.json` @ v1.2.0
 # Returns the cleaned phone number as a digit string if given number is valid,
 # else returns `nothing`.
@@ -54,6 +48,6 @@ end
 
 @testset "detect invalid number" begin
     @testset "$number" for number in invalid_num
-        @test isnothing(clean(number))
+        @test_throws ArgumentError clean(number)
     end
 end


### PR DESCRIPTION
The instruction don't contain information about the conditions that "_detect an invalid number_" test is testing. Either this should be included, or the test should be removed (pr #373).
Note: Those first pull request ever... I have no idea what I'm doing. Please assume good will, if I'm doing it wrong.