### PR TITLE
Slightly improve phrasing of key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1055,7 +1055,7 @@
   "key_features": [
     {
       "title": "Fast",
-      "content": "Julia is designed for high performance. Julia compiles efficient native code for multiple platforms",
+      "content": "Julia is designed for high performance and compiles efficient native code for multiple platforms",
       "icon": ""
     },
     {
@@ -1070,7 +1070,7 @@
     },
     {
       "title": "Composable",
-      "content": "Julia uses multiple dispatch as a paradigm, making it unreasonably effective for composing programs!",
+      "content": "Julia uses multiple dispatch as a paradigm, making it unreasonably effective for composing programs",
       "icon": ""
     },
     {
@@ -1080,7 +1080,7 @@
     },
     {
       "title": "Natural Syntax",
-      "content": "Unicode operators & identifiers, plus operator overloading, allows elegant code that looks like math",
+      "content": "Unicode operators and identifiers, and operator overloading allow elegant code that looks like math",
       "icon": ""
     }
   ],

--- a/config.json
+++ b/config.json
@@ -1080,7 +1080,7 @@
     },
     {
       "title": "Natural Syntax",
-      "content": "Unicode operators and identifiers, and operator overloading allow elegant code that looks like math",
+      "content": "Use operator overloading plus unicode operators and identifiers to write code that looks like math",
       "icon": ""
     }
   ],


### PR DESCRIPTION
While I liked making them all exactly 100 chars long, I find it painful to look at some of the phrases and inconsistencies on the website.

The oxford comma is sometimes omitted due to the 100 char requirement.

---

You can see what it currently looks like on https://exercism.lol/tracks/julia (in incognito or logged out)