### PR TITLE
🤖 Simplify tests.toml files

### DIFF
--- a/exercises/concept/dnd-char/.meta/tests.toml
+++ b/exercises/concept/dnd-char/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [1e9ae1dc-35bd-43ba-aa08-e4b94c20fa37]
 description = "ability modifier for score 3 is -4"
-include = true
 
 [cc9bb24e-56b8-4e9e-989d-a0d1a29ebb9c]
 description = "ability modifier for score 4 is -3"
-include = true
 
 [5b519fcd-6946-41ee-91fe-34b4f9808326]
 description = "ability modifier for score 5 is -3"
-include = true
 
 [dc2913bd-6d7a-402e-b1e2-6d568b1cbe21]
 description = "ability modifier for score 6 is -2"
-include = true
 
 [099440f5-0d66-4b1a-8a10-8f3a03cc499f]
 description = "ability modifier for score 7 is -2"
-include = true
 
 [cfda6e5c-3489-42f0-b22b-4acb47084df0]
 description = "ability modifier for score 8 is -1"
-include = true
 
 [c70f0507-fa7e-4228-8463-858bfbba1754]
 description = "ability modifier for score 9 is -1"
-include = true
 
 [6f4e6c88-1cd9-46a0-92b8-db4a99b372f7]
 description = "ability modifier for score 10 is 0"
-include = true
 
 [e00d9e5c-63c8-413f-879d-cd9be9697097]
 description = "ability modifier for score 11 is 0"
-include = true
 
 [eea06f3c-8de0-45e7-9d9d-b8cab4179715]
 description = "ability modifier for score 12 is +1"
-include = true
 
 [9c51f6be-db72-4af7-92ac-b293a02c0dcd]
 description = "ability modifier for score 13 is +1"
-include = true
 
 [94053a5d-53b6-4efc-b669-a8b5098f7762]
 description = "ability modifier for score 14 is +2"
-include = true
 
 [8c33e7ca-3f9f-4820-8ab3-65f2c9e2f0e2]
 description = "ability modifier for score 15 is +2"
-include = true
 
 [c3ec871e-1791-44d0-b3cc-77e5fb4cd33d]
 description = "ability modifier for score 16 is +3"
-include = true
 
 [3d053cee-2888-4616-b9fd-602a3b1efff4]
 description = "ability modifier for score 17 is +3"
-include = true
 
 [bafd997a-e852-4e56-9f65-14b60261faee]
 description = "ability modifier for score 18 is +4"
-include = true
 
 [4f28f19c-2e47-4453-a46a-c0d365259c14]
 description = "random ability is within range"
-include = true
 
 [385d7e72-864f-4e88-8279-81a7d75b04ad]
 description = "random character is valid"
-include = true
 
 [2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe]
 description = "each ability is only calculated once"
-include = true

--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
 description = "basic"
-include = true
 
 [79ae3889-a5c0-4b01-baf0-232d31180c08]
 description = "lowercase words"
-include = true
 
 [ec7000a7-3931-4a17-890e-33ca2073a548]
 description = "punctuation"
-include = true
 
 [32dd261c-0c92-469a-9c5c-b192e94a63b0]
 description = "all caps word"
-include = true
 
 [ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
 description = "punctuation without whitespace"
-include = true
 
 [0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
 description = "very long abbreviation"
-include = true
 
 [6a078f49-c68d-4b7b-89af-33a1a98c28cc]
 description = "consecutive delimiters"
-include = true
 
 [5118b4b1-4572-434c-8d57-5b762e57973e]
 description = "apostrophes"
-include = true
 
 [adc12eab-ec2d-414f-b48c-66a4fc06cdef]
 description = "underscore emphasis"
-include = true

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -4,196 +4,147 @@
 
 [17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
 description = "not allergic to anything"
-include = true
 
 [07ced27b-1da5-4c2e-8ae2-cb2791437546]
 description = "allergic only to eggs"
-include = true
 
 [5035b954-b6fa-4b9b-a487-dae69d8c5f96]
 description = "allergic to eggs and something else"
-include = true
 
 [64a6a83a-5723-4b5b-a896-663307403310]
 description = "allergic to something, but not eggs"
-include = true
 
 [90c8f484-456b-41c4-82ba-2d08d93231c6]
 description = "allergic to everything"
-include = true
 
 [d266a59a-fccc-413b-ac53-d57cb1f0db9d]
 description = "not allergic to anything"
-include = true
 
 [ea210a98-860d-46b2-a5bf-50d8995b3f2a]
 description = "allergic only to peanuts"
-include = true
 
 [eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
 description = "allergic to peanuts and something else"
-include = true
 
 [9152058c-ce39-4b16-9b1d-283ec6d25085]
 description = "allergic to something, but not peanuts"
-include = true
 
 [d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
 description = "allergic to everything"
-include = true
 
 [b948b0a1-cbf7-4b28-a244-73ff56687c80]
 description = "not allergic to anything"
-include = true
 
 [9ce9a6f3-53e9-4923-85e0-73019047c567]
 description = "allergic only to shellfish"
-include = true
 
 [b272fca5-57ba-4b00-bd0c-43a737ab2131]
 description = "allergic to shellfish and something else"
-include = true
 
 [21ef8e17-c227-494e-8e78-470a1c59c3d8]
 description = "allergic to something, but not shellfish"
-include = true
 
 [cc789c19-2b5e-4c67-b146-625dc8cfa34e]
 description = "allergic to everything"
-include = true
 
 [651bde0a-2a74-46c4-ab55-02a0906ca2f5]
 description = "not allergic to anything"
-include = true
 
 [b649a750-9703-4f5f-b7f7-91da2c160ece]
 description = "allergic only to strawberries"
-include = true
 
 [50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
 description = "allergic to strawberries and something else"
-include = true
 
 [23dd6952-88c9-48d7-a7d5-5d0343deb18d]
 description = "allergic to something, but not strawberries"
-include = true
 
 [74afaae2-13b6-43a2-837a-286cd42e7d7e]
 description = "allergic to everything"
-include = true
 
 [c49a91ef-6252-415e-907e-a9d26ef61723]
 description = "not allergic to anything"
-include = true
 
 [b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
 description = "allergic only to tomatoes"
-include = true
 
 [1ca50eb1-f042-4ccf-9050-341521b929ec]
 description = "allergic to tomatoes and something else"
-include = true
 
 [e9846baa-456b-4eff-8025-034b9f77bd8e]
 description = "allergic to something, but not tomatoes"
-include = true
 
 [b2414f01-f3ad-4965-8391-e65f54dad35f]
 description = "allergic to everything"
-include = true
 
 [978467ab-bda4-49f7-b004-1d011ead947c]
 description = "not allergic to anything"
-include = true
 
 [59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
 description = "allergic only to chocolate"
-include = true
 
 [b0a7c07b-2db7-4f73-a180-565e07040ef1]
 description = "allergic to chocolate and something else"
-include = true
 
 [f5506893-f1ae-482a-b516-7532ba5ca9d2]
 description = "allergic to something, but not chocolate"
-include = true
 
 [02debb3d-d7e2-4376-a26b-3c974b6595c6]
 description = "allergic to everything"
-include = true
 
 [17f4a42b-c91e-41b8-8a76-4797886c2d96]
 description = "not allergic to anything"
-include = true
 
 [7696eba7-1837-4488-882a-14b7b4e3e399]
 description = "allergic only to pollen"
-include = true
 
 [9a49aec5-fa1f-405d-889e-4dfc420db2b6]
 description = "allergic to pollen and something else"
-include = true
 
 [3cb8e79f-d108-4712-b620-aa146b1954a9]
 description = "allergic to something, but not pollen"
-include = true
 
 [1dc3fe57-7c68-4043-9d51-5457128744b2]
 description = "allergic to everything"
-include = true
 
 [d3f523d6-3d50-419b-a222-d4dfd62ce314]
 description = "not allergic to anything"
-include = true
 
 [eba541c3-c886-42d3-baef-c048cb7fcd8f]
 description = "allergic only to cats"
-include = true
 
 [ba718376-26e0-40b7-bbbe-060287637ea5]
 description = "allergic to cats and something else"
-include = true
 
 [3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
 description = "allergic to something, but not cats"
-include = true
 
 [1faabb05-2b98-4995-9046-d83e4a48a7c1]
 description = "allergic to everything"
-include = true
 
 [f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
 description = "no allergies"
-include = true
 
 [9e1a4364-09a6-4d94-990f-541a94a4c1e8]
 description = "just eggs"
-include = true
 
 [8851c973-805e-4283-9e01-d0c0da0e4695]
 description = "just peanuts"
-include = true
 
 [2c8943cb-005e-435f-ae11-3e8fb558ea98]
 description = "just strawberries"
-include = true
 
 [6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
 description = "eggs and peanuts"
-include = true
 
 [19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
 description = "more than eggs but not peanuts"
-include = true
 
 [4b68f470-067c-44e4-889f-c9fe28917d2f]
 description = "lots of stuff"
-include = true
 
 [0881b7c5-9efa-4530-91bd-68370d054bc7]
 description = "everything"
-include = true
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
 description = "no allergen score parts"
-include = true

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"
-include = true
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
-include = true
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"
-include = true
 
 [64cd4584-fc15-4781-b633-3d814c4941a4]
 description = "detects anagram"
-include = true
 
 [99c91beb-838f-4ccd-b123-935139917283]
 description = "detects three anagrams"
-include = true
 
 [78487770-e258-4e1f-a646-8ece10950d90]
 description = "detects multiple anagrams with different case"
-include = true
 
 [1d0ab8aa-362f-49b7-9902-3d0c668d557b]
 description = "does not detect non-anagrams with identical checksum"
-include = true
 
 [9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
 description = "detects anagrams case-insensitively"
-include = true
 
 [b248e49f-0905-48d2-9c8d-bd02d8c3e392]
 description = "detects anagrams using case-insensitive subject"
-include = true
 
 [f367325c-78ec-411c-be76-e79047f4bd54]
 description = "detects anagrams using case-insensitive possible matches"
-include = true
 
 [7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
 description = "does not detect an anagram if the original word is repeated"
-include = true
 
 [9878a1c9-d6ea-4235-ae51-3ea2befd6842]
 description = "anagrams must use all letters exactly once"
-include = true
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
-include = true
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
-include = true

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
-include = true
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
 description = "Single digit numbers are Armstrong numbers"
-include = true
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
 description = "There are no 2 digit Armstrong numbers"
-include = true
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
 description = "Three digit number that is an Armstrong number"
-include = true
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
 description = "Three digit number that is not an Armstrong number"
-include = true
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
 description = "Four digit number that is an Armstrong number"
-include = true
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
 description = "Four digit number that is not an Armstrong number"
-include = true
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
 description = "Seven digit number that is an Armstrong number"
-include = true
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
 description = "Seven digit number that is not an Armstrong number"
-include = true

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
 description = "encode yes"
-include = true
 
 [b4ffe781-ea81-4b74-b268-cc58ba21c739]
 description = "encode no"
-include = true
 
 [10e48927-24ab-4c4d-9d3f-3067724ace00]
 description = "encode OMG"
-include = true
 
 [d59b8bc3-509a-4a9a-834c-6f501b98750b]
 description = "encode spaces"
-include = true
 
 [31d44b11-81b7-4a94-8b43-4af6a2449429]
 description = "encode mindblowingly"
-include = true
 
 [d503361a-1433-48c0-aae0-d41b5baa33ff]
 description = "encode numbers"
-include = true
 
 [79c8a2d5-0772-42d4-b41b-531d0b5da926]
 description = "encode deep thought"
-include = true
 
 [9ca13d23-d32a-4967-a1fd-6100b8742bab]
 description = "encode all the letters"
-include = true
 
 [bb50e087-7fdf-48e7-9223-284fe7e69851]
 description = "decode exercism"
-include = true
 
 [ac021097-cd5d-4717-8907-b0814b9e292c]
 description = "decode a sentence"
-include = true
 
 [18729de3-de74-49b8-b68c-025eaf77f851]
 description = "decode numbers"
-include = true
 
 [0f30325f-f53b-415d-ad3e-a7a4f63de034]
 description = "decode all the letters"
-include = true
 
 [39640287-30c6-4c8c-9bac-9d613d1a5674]
 description = "decode with too many spaces"
-include = true
 
 [b34edf13-34c0-49b5-aa21-0768928000d5]
 description = "decode with no spaces"
-include = true

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
 description = "finds a value in an array with one element"
-include = true
 
 [73469346-b0a0-4011-89bf-989e443d503d]
 description = "finds a value in the middle of an array"
-include = true
 
 [327bc482-ab85-424e-a724-fb4658e66ddb]
 description = "finds a value at the beginning of an array"
-include = true
 
 [f9f94b16-fe5e-472c-85ea-c513804c7d59]
 description = "finds a value at the end of an array"
-include = true
 
 [f0068905-26e3-4342-856d-ad153cadb338]
 description = "finds a value in an array of odd length"
-include = true
 
 [fc316b12-c8b3-4f5e-9e89-532b3389de8c]
 description = "finds a value in an array of even length"
-include = true
 
 [da7db20a-354f-49f7-a6a1-650a54998aa6]
 description = "identifies that a value is not included in the array"
-include = true
 
 [95d869ff-3daf-4c79-b622-6e805c675f97]
 description = "a value smaller than the array's smallest value is not found"
-include = true
 
 [8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
 description = "a value larger than the array's largest value is not found"
-include = true
 
 [f439a0fa-cf42-4262-8ad1-64bf41ce566a]
 description = "nothing is found in an empty array"
-include = true
 
 [2c353967-b56d-40b8-acff-ce43115eed64]
 description = "nothing is found when the left and right bounds cross"
-include = true

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -4,27 +4,21 @@
 
 [e162fead-606f-437a-a166-d051915cea8e]
 description = "stating something"
-include = true
 
 [73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
 description = "shouting"
-include = true
 
 [d6c98afd-df35-4806-b55e-2c457c3ab748]
 description = "shouting gibberish"
-include = true
 
 [8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
 description = "asking a question"
-include = true
 
 [81080c62-4e4d-4066-b30a-48d8d76920d9]
 description = "asking a numeric question"
-include = true
 
 [2a02716d-685b-4e2e-a804-2adaf281c01e]
 description = "asking gibberish"
-include = true
 
 [c02f9179-ab16-4aa7-a8dc-940145c385f7]
 description = "talking forcefully"
@@ -40,64 +34,48 @@ include = false
 
 [a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
 description = "shouting numbers"
-include = true
 
 [f7bc4b92-bdff-421e-a238-ae97f230ccac]
 description = "no letters"
-include = true
 
 [bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
 description = "question with no letters"
-include = true
 
 [496143c8-1c31-4c01-8a08-88427af85c66]
 description = "shouting with special characters"
-include = true
 
 [e6793c1c-43bd-4b8d-bc11-499aea73925f]
 description = "shouting with no exclamation mark"
-include = true
 
 [aa8097cc-c548-4951-8856-14a404dd236a]
 description = "statement containing question mark"
-include = true
 
 [9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
 description = "non-letters with question"
-include = true
 
 [8608c508-f7de-4b17-985b-811878b3cf45]
 description = "prattling on"
-include = true
 
 [bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
 description = "silence"
-include = true
 
 [d6c47565-372b-4b09-b1dd-c40552b8378b]
 description = "prolonged silence"
-include = true
 
 [4428f28d-4100-4d85-a902-e5a78cb0ecd3]
 description = "alternate silence"
-include = true
 
 [66953780-165b-4e7e-8ce3-4bcb80b6385a]
 description = "multiple line question"
-include = true
 
 [5371ef75-d9ea-4103-bcfa-2da973ddec1b]
 description = "starting with whitespace"
-include = true
 
 [05b304d6-f83b-46e7-81e0-4cd3ca647900]
 description = "ending with whitespace"
-include = true
 
 [72bd5ad3-9b2f-4931-a988-dce1f5771de2]
 description = "other whitespace"
-include = true
 
 [12983553-8601-46a8-92fa-fcaa3bc4a2a0]
 description = "non-question ending with whitespace"
-include = true

--- a/exercises/practice/circular-buffer/.meta/tests.toml
+++ b/exercises/practice/circular-buffer/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [28268ed4-4ff3-45f3-820e-895b44d53dfa]
 description = "reading empty buffer should fail"
-include = true
 
 [2e6db04a-58a1-425d-ade8-ac30b5f318f3]
 description = "can read an item just written"
-include = true
 
 [90741fe8-a448-45ce-be2b-de009a24c144]
 description = "each item may only be read once"
-include = true
 
 [be0e62d5-da9c-47a8-b037-5db21827baa7]
 description = "items are read in the order they are written"
-include = true
 
 [2af22046-3e44-4235-bfe6-05ba60439d38]
 description = "full buffer can't be written to"
-include = true
 
 [547d192c-bbf0-4369-b8fa-fc37e71f2393]
 description = "a read frees up capacity for another write"
-include = true
 
 [04a56659-3a81-4113-816b-6ecb659b4471]
 description = "read position is maintained even across multiple writes"
-include = true
 
 [60c3a19a-81a7-43d7-bb0a-f07242b1111f]
 description = "items cleared out of buffer can't be read"
-include = true
 
 [45f3ae89-3470-49f3-b50e-362e4b330a59]
 description = "clear frees up capacity for another write"
-include = true
 
 [e1ac5170-a026-4725-bfbe-0cf332eddecd]
 description = "clear does nothing on empty buffer"
-include = true
 
 [9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b]
 description = "overwrite acts like write on non-full buffer"
-include = true
 
 [880f916b-5039-475c-bd5c-83463c36a147]
 description = "overwrite replaces the oldest item on full buffer"
-include = true
 
 [bfecab5b-aca1-4fab-a2b0-cd4af2b053c3]
 description = "overwrite replaces the oldest item remaining in buffer following a read"
-include = true
 
 [9cebe63a-c405-437b-8b62-e3fdc1ecec5a]
 description = "initial clear does not affect wrapping around"
-include = true

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -4,208 +4,156 @@
 
 [a577bacc-106b-496e-9792-b3083ea8705e]
 description = "on the hour"
-include = true
 
 [b5d0c360-3b88-489b-8e84-68a1c7a4fa23]
 description = "past the hour"
-include = true
 
 [473223f4-65f3-46ff-a9f7-7663c7e59440]
 description = "midnight is zero hours"
-include = true
 
 [ca95d24a-5924-447d-9a96-b91c8334725c]
 description = "hour rolls over"
-include = true
 
 [f3826de0-0925-4d69-8ac8-89aea7e52b78]
 description = "hour rolls over continuously"
-include = true
 
 [a02f7edf-dfd4-4b11-b21a-86de3cc6a95c]
 description = "sixty minutes is next hour"
-include = true
 
 [8f520df6-b816-444d-b90f-8a477789beb5]
 description = "minutes roll over"
-include = true
 
 [c75c091b-47ac-4655-8d40-643767fc4eed]
 description = "minutes roll over continuously"
-include = true
 
 [06343ecb-cf39-419d-a3f5-dcbae0cc4c57]
 description = "hour and minutes roll over"
-include = true
 
 [be60810e-f5d9-4b58-9351-a9d1e90e660c]
 description = "hour and minutes roll over continuously"
-include = true
 
 [1689107b-0b5c-4bea-aad3-65ec9859368a]
 description = "hour and minutes roll over to exactly midnight"
-include = true
 
 [d3088ee8-91b7-4446-9e9d-5e2ad6219d91]
 description = "negative hour"
-include = true
 
 [77ef6921-f120-4d29-bade-80d54aa43b54]
 description = "negative hour rolls over"
-include = true
 
 [359294b5-972f-4546-bb9a-a85559065234]
 description = "negative hour rolls over continuously"
-include = true
 
 [509db8b7-ac19-47cc-bd3a-a9d2f30b03c0]
 description = "negative minutes"
-include = true
 
 [5d6bb225-130f-4084-84fd-9e0df8996f2a]
 description = "negative minutes roll over"
-include = true
 
 [d483ceef-b520-4f0c-b94a-8d2d58cf0484]
 description = "negative minutes roll over continuously"
-include = true
 
 [1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
 description = "negative sixty minutes is previous hour"
-include = true
 
 [9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
 description = "negative hour and minutes both roll over"
-include = true
 
 [51d41fcf-491e-4ca0-9cae-2aa4f0163ad4]
 description = "negative hour and minutes both roll over continuously"
-include = true
 
 [d098e723-ad29-4ef9-997a-2693c4c9d89a]
 description = "add minutes"
-include = true
 
 [b6ec8f38-e53e-4b22-92a7-60dab1f485f4]
 description = "add no minutes"
-include = true
 
 [efd349dd-0785-453e-9ff8-d7452a8e7269]
 description = "add to next hour"
-include = true
 
 [749890f7-aba9-4702-acce-87becf4ef9fe]
 description = "add more than one hour"
-include = true
 
 [da63e4c1-1584-46e3-8d18-c9dc802c1713]
 description = "add more than two hours with carry"
-include = true
 
 [be167a32-3d33-4cec-a8bc-accd47ddbb71]
 description = "add across midnight"
-include = true
 
 [6672541e-cdae-46e4-8be7-a820cc3be2a8]
 description = "add more than one day (1500 min = 25 hrs)"
-include = true
 
 [1918050d-c79b-4cb7-b707-b607e2745c7e]
 description = "add more than two days"
-include = true
 
 [37336cac-5ede-43a5-9026-d426cbe40354]
 description = "subtract minutes"
-include = true
 
 [0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b]
 description = "subtract to previous hour"
-include = true
 
 [9b4e809c-612f-4b15-aae0-1df0acb801b9]
 description = "subtract more than an hour"
-include = true
 
 [8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
 description = "subtract across midnight"
-include = true
 
 [07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
 description = "subtract more than two hours"
-include = true
 
 [90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
 description = "subtract more than two hours with borrow"
-include = true
 
 [2149f985-7136-44ad-9b29-ec023a97a2b7]
 description = "subtract more than one day (1500 min = 25 hrs)"
-include = true
 
 [ba11dbf0-ac27-4acb-ada9-3b853ec08c97]
 description = "subtract more than two days"
-include = true
 
 [f2fdad51-499f-4c9b-a791-b28c9282e311]
 description = "clocks with same time"
-include = true
 
 [5d409d4b-f862-4960-901e-ec430160b768]
 description = "clocks a minute apart"
-include = true
 
 [a6045fcf-2b52-4a47-8bb2-ef10a064cba5]
 description = "clocks an hour apart"
-include = true
 
 [66b12758-0be5-448b-a13c-6a44bce83527]
 description = "clocks with hour overflow"
-include = true
 
 [2b19960c-212e-4a71-9aac-c581592f8111]
 description = "clocks with hour overflow by several days"
-include = true
 
 [6f8c6541-afac-4a92-b0c2-b10d4e50269f]
 description = "clocks with negative hour"
-include = true
 
 [bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d]
 description = "clocks with negative hour that wraps"
-include = true
 
 [56c0326d-565b-4d19-a26f-63b3205778b7]
 description = "clocks with negative hour that wraps multiple times"
-include = true
 
 [c90b9de8-ddff-4ffe-9858-da44a40fdbc2]
 description = "clocks with minute overflow"
-include = true
 
 [533a3dc5-59a7-491b-b728-a7a34fe325de]
 description = "clocks with minute overflow by several days"
-include = true
 
 [fff49e15-f7b7-4692-a204-0f6052d62636]
 description = "clocks with negative minute"
-include = true
 
 [605c65bb-21bd-43eb-8f04-878edf508366]
 description = "clocks with negative minute that wraps"
-include = true
 
 [b87e64ed-212a-4335-91fd-56da8421d077]
 description = "clocks with negative minute that wraps multiple times"
-include = true
 
 [822fbf26-1f3b-4b13-b9bf-c914816b53dd]
 description = "clocks with negative hours and minutes"
-include = true
 
 [e787bccd-cf58-4a1d-841c-ff80eaaccfaa]
 description = "clocks with negative hours and minutes that wrap"
-include = true
 
 [96969ca8-875a-48a1-86ae-257a528c44f5]
 description = "full clock and zeroed clock"
-include = true

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
 description = "zero steps for one"
-include = true
 
 [3d76a0a6-ea84-444a-821a-f7857c2c1859]
 description = "divide if even"
-include = true
 
 [754dea81-123c-429e-b8bc-db20b05a87b9]
 description = "even and odd steps"
-include = true
 
 [ecfd0210-6f85-44f6-8280-f65534892ff6]
 description = "large number of even and odd steps"
-include = true
 
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
-include = true
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
-include = true

--- a/exercises/practice/complex-numbers/.meta/tests.toml
+++ b/exercises/practice/complex-numbers/.meta/tests.toml
@@ -4,124 +4,93 @@
 
 [9f98e133-eb7f-45b0-9676-cce001cd6f7a]
 description = "Real part of a purely real number"
-include = true
 
 [07988e20-f287-4bb7-90cf-b32c4bffe0f3]
 description = "Real part of a purely imaginary number"
-include = true
 
 [4a370e86-939e-43de-a895-a00ca32da60a]
 description = "Real part of a number with real and imaginary part"
-include = true
 
 [9b3fddef-4c12-4a99-b8f8-e3a42c7ccef6]
 description = "Imaginary part of a purely real number"
-include = true
 
 [a8dafedd-535a-4ed3-8a39-fda103a2b01e]
 description = "Imaginary part of a purely imaginary number"
-include = true
 
 [0f998f19-69ee-4c64-80ef-01b086feab80]
 description = "Imaginary part of a number with real and imaginary part"
-include = true
 
 [a39b7fd6-6527-492f-8c34-609d2c913879]
 description = "Imaginary unit"
-include = true
 
 [9a2c8de9-f068-4f6f-b41c-82232cc6c33e]
 description = "Add purely real numbers"
-include = true
 
 [657c55e1-b14b-4ba7-bd5c-19db22b7d659]
 description = "Add purely imaginary numbers"
-include = true
 
 [4e1395f5-572b-4ce8-bfa9-9a63056888da]
 description = "Add numbers with real and imaginary part"
-include = true
 
 [1155dc45-e4f7-44b8-af34-a91aa431475d]
 description = "Subtract purely real numbers"
-include = true
 
 [f95e9da8-acd5-4da4-ac7c-c861b02f774b]
 description = "Subtract purely imaginary numbers"
-include = true
 
 [f876feb1-f9d1-4d34-b067-b599a8746400]
 description = "Subtract numbers with real and imaginary part"
-include = true
 
 [8a0366c0-9e16-431f-9fd7-40ac46ff4ec4]
 description = "Multiply purely real numbers"
-include = true
 
 [e560ed2b-0b80-4b4f-90f2-63cefc911aaf]
 description = "Multiply purely imaginary numbers"
-include = true
 
 [4d1d10f0-f8d4-48a0-b1d0-f284ada567e6]
 description = "Multiply numbers with real and imaginary part"
-include = true
 
 [b0571ddb-9045-412b-9c15-cd1d816d36c1]
 description = "Divide purely real numbers"
-include = true
 
 [5bb4c7e4-9934-4237-93cc-5780764fdbdd]
 description = "Divide purely imaginary numbers"
-include = true
 
 [c4e7fef5-64ac-4537-91c2-c6529707701f]
 description = "Divide numbers with real and imaginary part"
-include = true
 
 [c56a7332-aad2-4437-83a0-b3580ecee843]
 description = "Absolute value of a positive purely real number"
-include = true
 
 [cf88d7d3-ee74-4f4e-8a88-a1b0090ecb0c]
 description = "Absolute value of a negative purely real number"
-include = true
 
 [bbe26568-86c1-4bb4-ba7a-da5697e2b994]
 description = "Absolute value of a purely imaginary number with positive imaginary part"
-include = true
 
 [3b48233d-468e-4276-9f59-70f4ca1f26f3]
 description = "Absolute value of a purely imaginary number with negative imaginary part"
-include = true
 
 [fe400a9f-aa22-4b49-af92-51e0f5a2a6d3]
 description = "Absolute value of a number with real and imaginary part"
-include = true
 
 [fb2d0792-e55a-4484-9443-df1eddfc84a2]
 description = "Conjugate a purely real number"
-include = true
 
 [e37fe7ac-a968-4694-a460-66cb605f8691]
 description = "Conjugate a purely imaginary number"
-include = true
 
 [f7704498-d0be-4192-aaf5-a1f3a7f43e68]
 description = "Conjugate a number with real and imaginary part"
-include = true
 
 [6d96d4c6-2edb-445b-94a2-7de6d4caaf60]
 description = "Euler's identity/formula"
-include = true
 
 [2d2c05a0-4038-4427-a24d-72f6624aa45f]
 description = "Exponential of 0"
-include = true
 
 [ed87f1bd-b187-45d6-8ece-7e331232c809]
 description = "Exponential of a purely real number"
-include = true
 
 [08eedacc-5a95-44fc-8789-1547b27a8702]
 description = "Exponential of a number with real and imaginary part"
-include = true

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -4,152 +4,114 @@
 
 [20c5f855-f83a-44a7-abdd-fe75c6cf022b]
 description = "sets with no elements are empty"
-include = true
 
 [d506485d-5706-40db-b7d8-5ceb5acf88d2]
 description = "sets with elements are not empty"
-include = true
 
 [759b9740-3417-44c3-8ca3-262b3c281043]
 description = "nothing is contained in an empty set"
-include = true
 
 [f83cd2d1-2a85-41bc-b6be-80adbff4be49]
 description = "when the element is in the set"
-include = true
 
 [93423fc0-44d0-4bc0-a2ac-376de8d7af34]
 description = "when the element is not in the set"
-include = true
 
 [c392923a-637b-4495-b28e-34742cd6157a]
 description = "empty set is a subset of another empty set"
-include = true
 
 [5635b113-be8c-4c6f-b9a9-23c485193917]
 description = "empty set is a subset of non-empty set"
-include = true
 
 [832eda58-6d6e-44e2-92c2-be8cf0173cee]
 description = "non-empty set is not a subset of empty set"
-include = true
 
 [c830c578-8f97-4036-b082-89feda876131]
 description = "set is a subset of set with exact same elements"
-include = true
 
 [476a4a1c-0fd1-430f-aa65-5b70cbc810c5]
 description = "set is a subset of larger set with same elements"
-include = true
 
 [d2498999-3e46-48e4-9660-1e20c3329d3d]
 description = "set is not a subset of set that does not contain its elements"
-include = true
 
 [7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc]
 description = "the empty set is disjoint with itself"
-include = true
 
 [7a2b3938-64b6-4b32-901a-fe16891998a6]
 description = "empty set is disjoint with non-empty set"
-include = true
 
 [589574a0-8b48-48ea-88b0-b652c5fe476f]
 description = "non-empty set is disjoint with empty set"
-include = true
 
 [febeaf4f-f180-4499-91fa-59165955a523]
 description = "sets are not disjoint if they share an element"
-include = true
 
 [0de20d2f-c952-468a-88c8-5e056740f020]
 description = "sets are disjoint if they share no elements"
-include = true
 
 [4bd24adb-45da-4320-9ff6-38c044e9dff8]
 description = "empty sets are equal"
-include = true
 
 [f65c0a0e-6632-4b2d-b82c-b7c6da2ec224]
 description = "empty set is not equal to non-empty set"
-include = true
 
 [81e53307-7683-4b1e-a30c-7e49155fe3ca]
 description = "non-empty set is not equal to empty set"
-include = true
 
 [d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0]
 description = "sets with the same elements are equal"
-include = true
 
 [dd61bafc-6653-42cc-961a-ab071ee0ee85]
 description = "sets with different elements are not equal"
-include = true
 
 [06059caf-9bf4-425e-aaff-88966cb3ea14]
 description = "set is not equal to larger set with same elements"
-include = true
 
 [8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
 description = "add to empty set"
-include = true
 
 [0903dd45-904d-4cf2-bddd-0905e1a8d125]
 description = "add to non-empty set"
-include = true
 
 [b0eb7bb7-5e5d-4733-b582-af771476cb99]
 description = "adding an existing element does not change the set"
-include = true
 
 [893d5333-33b8-4151-a3d4-8f273358208a]
 description = "intersection of two empty sets is an empty set"
-include = true
 
 [d739940e-def2-41ab-a7bb-aaf60f7d782c]
 description = "intersection of an empty set and non-empty set is an empty set"
-include = true
 
 [3607d9d8-c895-4d6f-ac16-a14956e0a4b7]
 description = "intersection of a non-empty set and an empty set is an empty set"
-include = true
 
 [b5120abf-5b5e-41ab-aede-4de2ad85c34e]
 description = "intersection of two sets with no shared elements is an empty set"
-include = true
 
 [af21ca1b-fac9-499c-81c0-92a591653d49]
 description = "intersection of two sets with shared elements is a set of the shared elements"
-include = true
 
 [c5e6e2e4-50e9-4bc2-b89f-c518f015b57e]
 description = "difference of two empty sets is an empty set"
-include = true
 
 [2024cc92-5c26-44ed-aafd-e6ca27d6fcd2]
 description = "difference of empty set and non-empty set is an empty set"
-include = true
 
 [e79edee7-08aa-4c19-9382-f6820974b43e]
 description = "difference of a non-empty set and an empty set is the non-empty set"
-include = true
 
 [c5ac673e-d707-4db5-8d69-7082c3a5437e]
 description = "difference of two non-empty sets is a set of elements that are only in the first set"
-include = true
 
 [c45aed16-5494-455a-9033-5d4c93589dc6]
 description = "union of empty sets is an empty set"
-include = true
 
 [9d258545-33c2-4fcb-a340-9f8aa69e7a41]
 description = "union of an empty set and non-empty set is the non-empty set"
-include = true
 
 [3aade50c-80c7-4db8-853d-75bac5818b83]
 description = "union of a non-empty set and empty set is the non-empty set"
-include = true
 
 [a00bb91f-c4b4-4844-8f77-c73e2e9df77c]
 description = "union of non-empty sets contains all unique elements"
-include = true

--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
 description = "Missed target"
-include = true
 
 [4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
 description = "On the outer circle"
-include = true
 
 [14378687-ee58-4c9b-a323-b089d5274be8]
 description = "On the middle circle"
-include = true
 
 [849e2e63-85bd-4fed-bc3b-781ae962e2c9]
 description = "On the inner circle"
-include = true
 
 [1c5ffd9f-ea66-462f-9f06-a1303de5a226]
 description = "Exactly on centre"
-include = true
 
 [b65abce3-a679-4550-8115-4b74bda06088]
 description = "Near the centre"
-include = true
 
 [66c29c1d-44f5-40cf-9927-e09a1305b399]
 description = "Just within the inner circle"
-include = true
 
 [d1012f63-c97c-4394-b944-7beb3d0b141a]
 description = "Just outside the inner circle"
-include = true
 
 [ab2b5666-b0b4-49c3-9b27-205e790ed945]
 description = "Just within the middle circle"
-include = true
 
 [70f1424e-d690-4860-8caf-9740a52c0161]
 description = "Just outside the middle circle"
-include = true
 
 [a7dbf8db-419c-4712-8a7f-67602b69b293]
 description = "Just within the outer circle"
-include = true
 
 [e0f39315-9f9a-4546-96e4-a9475b885aa7]
 description = "Just outside the outer circle"
-include = true
 
 [045d7d18-d863-4229-818e-b50828c75d19]
 description = "Asymmetric position between the inner and middle circles"
-include = true

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [e46c542b-31fc-4506-bcae-6b62b3268537]
 description = "square of sum 1"
-include = true
 
 [9b3f96cb-638d-41ee-99b7-b4f9c0622948]
 description = "square of sum 5"
-include = true
 
 [54ba043f-3c35-4d43-86ff-3a41625d5e86]
 description = "square of sum 100"
-include = true
 
 [01d84507-b03e-4238-9395-dd61d03074b5]
 description = "sum of squares 1"
-include = true
 
 [c93900cd-8cc2-4ca4-917b-dd3027023499]
 description = "sum of squares 5"
-include = true
 
 [94807386-73e4-4d9e-8dec-69eb135b19e4]
 description = "sum of squares 100"
-include = true
 
 [44f72ae6-31a7-437f-858d-2c0837adabb6]
 description = "difference of squares 1"
-include = true
 
 [005cb2bf-a0c8-46f3-ae25-924029f8b00b]
 description = "difference of squares 5"
-include = true
 
 [b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
 description = "difference of squares 100"
-include = true

--- a/exercises/practice/dnd-character/.meta/tests.toml
+++ b/exercises/practice/dnd-character/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [1e9ae1dc-35bd-43ba-aa08-e4b94c20fa37]
 description = "ability modifier for score 3 is -4"
-include = true
 
 [cc9bb24e-56b8-4e9e-989d-a0d1a29ebb9c]
 description = "ability modifier for score 4 is -3"
-include = true
 
 [5b519fcd-6946-41ee-91fe-34b4f9808326]
 description = "ability modifier for score 5 is -3"
-include = true
 
 [dc2913bd-6d7a-402e-b1e2-6d568b1cbe21]
 description = "ability modifier for score 6 is -2"
-include = true
 
 [099440f5-0d66-4b1a-8a10-8f3a03cc499f]
 description = "ability modifier for score 7 is -2"
-include = true
 
 [cfda6e5c-3489-42f0-b22b-4acb47084df0]
 description = "ability modifier for score 8 is -1"
-include = true
 
 [c70f0507-fa7e-4228-8463-858bfbba1754]
 description = "ability modifier for score 9 is -1"
-include = true
 
 [6f4e6c88-1cd9-46a0-92b8-db4a99b372f7]
 description = "ability modifier for score 10 is 0"
-include = true
 
 [e00d9e5c-63c8-413f-879d-cd9be9697097]
 description = "ability modifier for score 11 is 0"
-include = true
 
 [eea06f3c-8de0-45e7-9d9d-b8cab4179715]
 description = "ability modifier for score 12 is +1"
-include = true
 
 [9c51f6be-db72-4af7-92ac-b293a02c0dcd]
 description = "ability modifier for score 13 is +1"
-include = true
 
 [94053a5d-53b6-4efc-b669-a8b5098f7762]
 description = "ability modifier for score 14 is +2"
-include = true
 
 [8c33e7ca-3f9f-4820-8ab3-65f2c9e2f0e2]
 description = "ability modifier for score 15 is +2"
-include = true
 
 [c3ec871e-1791-44d0-b3cc-77e5fb4cd33d]
 description = "ability modifier for score 16 is +3"
-include = true
 
 [3d053cee-2888-4616-b9fd-602a3b1efff4]
 description = "ability modifier for score 17 is +3"
-include = true
 
 [bafd997a-e852-4e56-9f65-14b60261faee]
 description = "ability modifier for score 18 is +4"
-include = true
 
 [4f28f19c-2e47-4453-a46a-c0d365259c14]
 description = "random ability is within range"
-include = true
 
 [385d7e72-864f-4e88-8279-81a7d75b04ad]
 description = "random character is valid"
-include = true
 
 [2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe]
 description = "each ability is only calculated once"
-include = true

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -4,16 +4,12 @@
 
 [78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
 description = "single letter"
-include = true
 
 [60dbd000-451d-44c7-bdbb-97c73ac1f497]
 description = "single score with multiple letters"
-include = true
 
 [f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
 description = "multiple scores with multiple letters"
-include = true
 
 [5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
 description = "multiple scores with differing numbers of letters"
-include = true

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
-include = true
 
 [6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
 description = "second test for date only specification of time"
-include = true
 
 [77eb8502-2bca-4d92-89d9-7b39ace28dd5]
 description = "third test for date only specification of time"
-include = true
 
 [c9d89a7d-06f8-4e28-a305-64f1b2abc693]
 description = "full time specified"
-include = true
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
-include = true

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [9fbde8de-36b2-49de-baf2-cd42d6f28405]
 description = "1"
-include = true
 
 [ee1f30c2-01d8-4298-b25d-c677331b5e6d]
 description = "2"
-include = true
 
 [10f45584-2fc3-4875-8ec6-666065d1163b]
 description = "3"
-include = true
 
 [a7cbe01b-36f4-4601-b053-c5f6ae055170]
 description = "4"
-include = true
 
 [c50acc89-8535-44e4-918f-b848ad2817d4]
 description = "16"
-include = true
 
 [acd81b46-c2ad-4951-b848-80d15ed5a04f]
 description = "32"
-include = true
 
 [c73b470a-5efb-4d53-9ac6-c5f6487f227b]
 description = "64"
-include = true
 
 [1d47d832-3e85-4974-9466-5bd35af484e3]
 description = "square 0 raises an exception"
-include = true
 
 [61974483-eeb2-465e-be54-ca5dde366453]
 description = "negative square raises an exception"
-include = true
 
 [a95e4374-f32c-45a7-a10d-ffec475c012f]
 description = "square greater than 64 raises an exception"
-include = true
 
 [6eb07385-3659-4b45-a6be-9dc474222750]
 description = "returns the total number of grains on the board"
-include = true

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
-include = true
 
 [54681314-eee2-439a-9db0-b0636c656156]
 description = "single letter identical strands"
-include = true
 
 [294479a3-a4c8-478f-8d63-6209815a827b]
 description = "single letter different strands"
-include = true
 
 [9aed5f34-5693-4344-9b31-40c692fb5592]
 description = "long identical strands"
-include = true
 
 [cd2273a5-c576-46c8-a52b-dee251c3e6e5]
 description = "long different strands"
-include = true
 
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
-include = true
 
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
-include = true
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
-include = true
 
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
-include = true

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -4,4 +4,3 @@
 
 [af9ffe10-dc13-42d8-a742-e7bdafac449d]
 description = "Say Hi!"
-include = true

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
 description = "valid isbn number"
-include = true
 
 [19f76b53-7c24-45f8-87b8-4604d0ccd248]
 description = "invalid isbn check digit"
-include = true
 
 [4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
 description = "valid isbn number with a check digit of 10"
-include = true
 
 [3ed50db1-8982-4423-a993-93174a20825c]
 description = "check digit is a character other than X"
-include = true
 
 [c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
 description = "invalid character in isbn"
-include = true
 
 [28025280-2c39-4092-9719-f3234b89c627]
 description = "X is only valid as a check digit"
-include = true
 
 [f6294e61-7e79-46b3-977b-f48789a4945b]
 description = "valid isbn without separating dashes"
-include = true
 
 [185ab99b-3a1b-45f3-aeec-b80d80b07f0b]
 description = "isbn without separating dashes and X as check digit"
-include = true
 
 [7725a837-ec8e-4528-a92a-d981dd8cf3e2]
 description = "isbn without check digit and dashes"
-include = true
 
 [47e4dfba-9c20-46ed-9958-4d3190630bdf]
 description = "too long isbn and no dashes"
-include = true
 
 [737f4e91-cbba-4175-95bf-ae630b41fb60]
 description = "too short isbn"
-include = true
 
 [5458a128-a9b6-4ff8-8afb-674e74567cef]
 description = "isbn without check digit"
-include = true
 
 [70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7]
 description = "check digit of X should not be used for 0"
-include = true
 
 [94610459-55ab-4c35-9b93-ff6ea1a8e562]
 description = "empty isbn"
-include = true
 
 [7bff28d4-d770-48cc-80d6-b20b3a0fb46c]
 description = "input is 9 characters"
-include = true
 
 [ed6e8d1b-382c-4081-8326-8b772c581fec]
 description = "invalid characters are not ignored"
-include = true
 
 [fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
 description = "input is too long but contains a valid isbn"
-include = true

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [a0e97d2d-669e-47c7-8134-518a1e2c4555]
 description = "empty string"
-include = true
 
 [9a001b50-f194-4143-bc29-2af5ec1ef652]
 description = "isogram with only lower case characters"
-include = true
 
 [8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
 description = "word with one duplicated character"
-include = true
 
 [6450b333-cbc2-4b24-a723-0b459b34fe18]
 description = "word with one duplicated character from the end of the alphabet"
-include = true
 
 [a15ff557-dd04-4764-99e7-02cc1a385863]
 description = "longest reported english isogram"
-include = true
 
 [f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
 description = "word with duplicated character in mixed case"
-include = true
 
 [14a4f3c1-3b47-4695-b645-53d328298942]
 description = "word with duplicated character in mixed case, lowercase first"
-include = true
 
 [423b850c-7090-4a8a-b057-97f1cadd7c42]
 description = "hypothetical isogrammic word with hyphen"
-include = true
 
 [93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
 description = "hypothetical word with duplicated character following hyphen"
-include = true
 
 [36b30e5c-173f-49c6-a515-93a3e825553f]
 description = "isogram with duplicated hyphen"
-include = true
 
 [cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
 description = "made-up name that is an isogram"
-include = true
 
 [5fc61048-d74e-48fd-bc34-abfc21552d4d]
 description = "duplicated character in the middle"
-include = true
 
 [310ac53d-8932-47bc-bbb4-b2b94f25a83e]
 description = "same first and last characters"
-include = true

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [6466b30d-519c-438e-935d-388224ab5223]
 description = "year not divisible by 4 in common year"
-include = true
 
 [ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
 description = "year divisible by 2, not divisible by 4 in common year"
-include = true
 
 [4fe9b84c-8e65-489e-970b-856d60b8b78e]
 description = "year divisible by 4, not divisible by 100 in leap year"
-include = true
 
 [7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
 description = "year divisible by 4 and 5 is still a leap year"
-include = true
 
 [78a7848f-9667-4192-ae53-87b30c9a02dd]
 description = "year divisible by 100, not divisible by 400 in common year"
-include = true
 
 [9d70f938-537c-40a6-ba19-f50739ce8bac]
 description = "year divisible by 100 but not by 3 is still not a leap year"
-include = true
 
 [42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
 description = "year divisible by 400 in leap year"
-include = true
 
 [57902c77-6fe9-40de-8302-587b5c27121e]
 description = "year divisible by 400 but not by 125 is still a leap year"
-include = true
 
 [c30331f6-f9f6-4881-ad38-8ca8c12520c1]
 description = "year divisible by 200, not divisible by 400 in common year"
-include = true

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [792a7082-feb7-48c7-b88b-bbfec160865e]
 description = "single digit strings can not be valid"
-include = true
 
 [698a7924-64d4-4d89-8daa-32e1aadc271e]
 description = "a single zero is invalid"
-include = true
 
 [73c2f62b-9b10-4c9f-9a04-83cee7367965]
 description = "a simple valid SIN that remains valid if reversed"
-include = true
 
 [9369092e-b095-439f-948d-498bd076be11]
 description = "a simple valid SIN that becomes invalid if reversed"
-include = true
 
 [8f9f2350-1faf-4008-ba84-85cbb93ffeca]
 description = "a valid Canadian SIN"
-include = true
 
 [1cdcf269-6560-44fc-91f6-5819a7548737]
 description = "invalid Canadian SIN"
-include = true
 
 [656c48c1-34e8-4e60-9a5a-aad8a367810a]
 description = "invalid credit card"
-include = true
 
 [20e67fad-2121-43ed-99a8-14b5b856adb9]
 description = "invalid long number with an even remainder"
-include = true
 
 [ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
 description = "valid number with an even number of digits"
-include = true
 
 [ef081c06-a41f-4761-8492-385e13c8202d]
 description = "valid number with an odd number of spaces"
-include = true
 
 [bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
 description = "valid strings with a non-digit added at the end become invalid"
-include = true
 
 [2177e225-9ce7-40f6-b55d-fa420e62938e]
 description = "valid strings with punctuation included become invalid"
-include = true
 
 [ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
 description = "valid strings with symbols included become invalid"
-include = true
 
 [08195c5e-ce7f-422c-a5eb-3e45fece68ba]
 description = "single zero with space is invalid"
-include = true
 
 [12e63a3c-f866-4a79-8c14-b359fc386091]
 description = "more than a single zero is valid"
-include = true
 
 [ab56fa80-5de8-4735-8a4a-14dae588663e]
 description = "input digit 9 is correctly converted to output digit 9"
-include = true
 
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"
-include = true
 
 [f94cf191-a62f-4868-bc72-7253114aa157]
 description = "using ascii value for doubled non-digit isn't allowed"
-include = true

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [81ec11da-38dd-442a-bcf9-3de7754609a5]
 description = "paired square brackets"
-include = true
 
 [287f0167-ac60-4b64-8452-a0aa8f4e5238]
 description = "empty string"
-include = true
 
 [6c3615a3-df01-4130-a731-8ef5f5d78dac]
 description = "unpaired brackets"
-include = true
 
 [9d414171-9b98-4cac-a4e5-941039a97a77]
 description = "wrong ordered brackets"
-include = true
 
 [f0f97c94-a149-4736-bc61-f2c5148ffb85]
 description = "wrong closing bracket"
-include = true
 
 [754468e0-4696-4582-a30e-534d47d69756]
 description = "paired with whitespace"
-include = true
 
 [ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
 description = "partially paired brackets"
-include = true
 
 [3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
 description = "simple nested brackets"
-include = true
 
 [2d137f2c-a19e-4993-9830-83967a2d4726]
 description = "several paired brackets"
-include = true
 
 [2e1f7b56-c137-4c92-9781-958638885a44]
 description = "paired and nested brackets"
-include = true
 
 [84f6233b-e0f7-4077-8966-8085d295c19b]
 description = "unopened closing brackets"
-include = true
 
 [9b18c67d-7595-4982-b2c5-4cb949745d49]
 description = "unpaired and nested brackets"
-include = true
 
 [a0205e34-c2ac-49e6-a88a-899508d7d68e]
 description = "paired and wrong nested brackets"
-include = true
 
 [ef47c21b-bcfd-4998-844c-7ad5daad90a8]
 description = "paired and incomplete brackets"
-include = true
 
 [a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
 description = "too many closing brackets"
-include = true
 
 [99255f93-261b-4435-a352-02bdecc9bdf2]
 description = "math expression"
-include = true
 
 [8e357d79-f302-469a-8515-2561877256a1]
 description = "complex latex expression"
-include = true

--- a/exercises/practice/minesweeper/.meta/tests.toml
+++ b/exercises/practice/minesweeper/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [0c5ec4bd-dea7-4138-8651-1203e1cb9f44]
 description = "no rows"
-include = true
 
 [650ac4c0-ad6b-4b41-acde-e4ea5852c3b8]
 description = "no columns"
-include = true
 
 [6fbf8f6d-a03b-42c9-9a58-b489e9235478]
 description = "no mines"
-include = true
 
 [61aff1c4-fb31-4078-acad-cd5f1e635655]
 description = "minefield with only mines"
-include = true
 
 [84167147-c504-4896-85d7-246b01dea7c5]
 description = "mine surrounded by spaces"
-include = true
 
 [cb878f35-43e3-4c9d-93d9-139012cccc4a]
 description = "space surrounded by mines"
-include = true
 
 [7037f483-ddb4-4b35-b005-0d0f4ef4606f]
 description = "horizontal line"
-include = true
 
 [e359820f-bb8b-4eda-8762-47b64dba30a6]
 description = "horizontal line, mines at edges"
-include = true
 
 [c5198b50-804f-47e9-ae02-c3b42f7ce3ab]
 description = "vertical line"
-include = true
 
 [0c79a64d-703d-4660-9e90-5adfa5408939]
 description = "vertical line, mines at edges"
-include = true
 
 [4b098563-b7f3-401c-97c6-79dd1b708f34]
 description = "cross"
-include = true
 
 [04a260f1-b40a-4e89-839e-8dd8525abe0e]
 description = "large minefield"
-include = true

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [3e5c30a8-87e2-4845-a815-a49671ade970]
 description = "empty strand"
-include = true
 
 [a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
 description = "can count one nucleotide in single-character input"
-include = true
 
 [eca0d565-ed8c-43e7-9033-6cefbf5115b5]
 description = "strand with repeated nucleotide"
-include = true
 
 [40a45eac-c83f-4740-901a-20b22d15a39f]
 description = "strand with multiple nucleotides"
-include = true
 
 [b4c47851-ee9e-4b0a-be70-a86e343bd851]
 description = "strand with invalid nucleotides"
-include = true

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
-include = true
 
 [74858f80-4a4d-478b-8a5e-c6477e4e4e84]
 description = "perfect lower case"
-include = true
 
 [61288860-35ca-4abe-ba08-f5df76ecbdcd]
 description = "only lower case"
-include = true
 
 [6564267d-8ac5-4d29-baf2-e7d2e304a743]
 description = "missing the letter 'x'"
-include = true
 
 [c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
 description = "missing the letter 'h'"
-include = true
 
 [d835ec38-bc8f-48e4-9e36-eb232427b1df]
 description = "with underscores"
-include = true
 
 [8cc1e080-a178-4494-b4b3-06982c9be2a8]
 description = "with numbers"
-include = true
 
 [bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
 description = "missing letters replaced by numbers"
-include = true
 
 [938bd5d8-ade5-40e2-a2d9-55a338a01030]
 description = "mixed case and punctuation"
-include = true
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
-include = true

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [9920ce55-9629-46d5-85d6-4201f4a4234d]
 description = "zero rows"
-include = true
 
 [70d643ce-a46d-4e93-af58-12d88dd01f21]
 description = "single row"
-include = true
 
 [a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
 description = "two rows"
-include = true
 
 [97206a99-79ba-4b04-b1c5-3c0fa1e16925]
 description = "three rows"
-include = true
 
 [565a0431-c797-417c-a2c8-2935e01ce306]
 description = "four rows"
-include = true
 
 [06f9ea50-9f51-4eb2-b9a9-c00975686c27]
 description = "five rows"
-include = true
 
 [c3912965-ddb4-46a9-848e-3363e6b00b13]
 description = "six rows"
-include = true
 
 [6cb26c66-7b57-4161-962c-81ec8c99f16b]
 description = "ten rows"
-include = true

--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [163e8e86-7bfd-4ee2-bd68-d083dc3381a3]
 description = "Smallest perfect number is classified correctly"
-include = true
 
 [169a7854-0431-4ae0-9815-c3b6d967436d]
 description = "Medium perfect number is classified correctly"
-include = true
 
 [ee3627c4-7b36-4245-ba7c-8727d585f402]
 description = "Large perfect number is classified correctly"
-include = true
 
 [80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
 description = "Smallest abundant number is classified correctly"
-include = true
 
 [3e300e0d-1a12-4f11-8c48-d1027165ab60]
 description = "Medium abundant number is classified correctly"
-include = true
 
 [ec7792e6-8786-449c-b005-ce6dd89a772b]
 description = "Large abundant number is classified correctly"
-include = true
 
 [e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
 description = "Smallest prime deficient number is classified correctly"
-include = true
 
 [0beb7f66-753a-443f-8075-ad7fbd9018f3]
 description = "Smallest non-prime deficient number is classified correctly"
-include = true
 
 [1c802e45-b4c6-4962-93d7-1cad245821ef]
 description = "Medium deficient number is classified correctly"
-include = true
 
 [47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
 description = "Large deficient number is classified correctly"
-include = true
 
 [a696dec8-6147-4d68-afad-d38de5476a56]
 description = "Edge case (no factors other than itself) is classified correctly"
-include = true
 
 [72445cee-660c-4d75-8506-6c40089dc302]
 description = "Zero is rejected (not a natural number)"
-include = true
 
 [2d72ce2c-6802-49ac-8ece-c790ba3dae13]
 description = "Negative integer is rejected (not a natural number)"
-include = true

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [79666dce-e0f1-46de-95a1-563802913c35]
 description = "cleans the number"
-include = true
 
 [c360451f-549f-43e4-8aba-fdf6cb0bf83f]
 description = "cleans numbers with dots"
-include = true
 
 [08f94c34-9a37-46a2-a123-2a8e9727395d]
 description = "cleans numbers with multiple spaces"
-include = true
 
 [598d8432-0659-4019-a78b-1c6a73691d21]
 description = "invalid when 9 digits"
-include = true
 
 [57061c72-07b5-431f-9766-d97da7c4399d]
 description = "invalid when 11 digits does not start with a 1"
-include = true
 
 [9962cbf3-97bb-4118-ba9b-38ff49c64430]
 description = "valid when 11 digits and starting with 1"
-include = true
 
 [fa724fbf-054c-4d91-95da-f65ab5b6dbca]
 description = "valid when 11 digits and starting with 1 even with punctuation"
-include = true
 
 [c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
 description = "invalid when more than 11 digits"
-include = true
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
-include = true
 
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
-include = true
 
 [d77d07f8-873c-4b17-8978-5f66139bf7d7]
 description = "invalid if area code starts with 0"
-include = true
 
 [c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
 description = "invalid if area code starts with 1"
-include = true
 
 [4d622293-6976-413d-b8bf-dd8a94d4e2ac]
 description = "invalid if exchange code starts with 0"
-include = true
 
 [4cef57b4-7d8e-43aa-8328-1e1b89001262]
 description = "invalid if exchange code starts with 1"
-include = true
 
 [9925b09c-1a0d-4960-a197-5d163cbe308c]
 description = "invalid if area code starts with 0 on valid 11-digit number"
-include = true
 
 [3f809d37-40f3-44b5-ad90-535838b1a816]
 description = "invalid if area code starts with 1 on valid 11-digit number"
-include = true
 
 [e08e5532-d621-40d4-b0cc-96c159276b65]
 description = "invalid if exchange code starts with 0 on valid 11-digit number"
-include = true
 
 [57b32f3d-696a-455c-8bf1-137b6d171cdf]
 description = "invalid if exchange code starts with 1 on valid 11-digit number"
-include = true

--- a/exercises/practice/prime-factors/.meta/tests.toml
+++ b/exercises/practice/prime-factors/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [924fc966-a8f5-4288-82f2-6b9224819ccd]
 description = "no factors"
-include = true
 
 [17e30670-b105-4305-af53-ddde182cb6ad]
 description = "prime number"
-include = true
 
 [f59b8350-a180-495a-8fb1-1712fbee1158]
 description = "square of a prime"
-include = true
 
 [bc8c113f-9580-4516-8669-c5fc29512ceb]
 description = "cube of a prime"
-include = true
 
 [00485cd3-a3fe-4fbe-a64a-a4308fc1f870]
 description = "product of primes and non-primes"
-include = true
 
 [02251d54-3ca1-4a9b-85e1-b38f4b0ccb91]
 description = "product of primes"
-include = true
 
 [070cf8dc-e202-4285-aa37-8d775c9cd473]
 description = "factors include a large prime"
-include = true

--- a/exercises/practice/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/practice/pythagorean-triplet/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [a19de65d-35b8-4480-b1af-371d9541e706]
 description = "triplets whose sum is 12"
-include = true
 
 [48b21332-0a3d-43b2-9a52-90b2a6e5c9f5]
 description = "triplets whose sum is 108"
-include = true
 
 [dffc1266-418e-4daa-81af-54c3e95c3bb5]
 description = "triplets whose sum is 1000"
-include = true
 
 [5f86a2d4-6383-4cce-93a5-e4489e79b186]
 description = "no matching triplets for 1001"
-include = true
 
 [bf17ba80-1596-409a-bb13-343bdb3b2904]
 description = "returns all matching triplets"
-include = true
 
 [9d8fb5d5-6c6f-42df-9f95-d3165963ac57]
 description = "several matching triplets"
-include = true
 
 [f5be5734-8aa0-4bd1-99a2-02adcc4402b4]
 description = "triplets for large number"
-include = true

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [1575d549-e502-46d4-a8e1-6b7bec6123d8]
 description = "the sound for 1 is 1"
-include = true
 
 [1f51a9f9-4895-4539-b182-d7b0a5ab2913]
 description = "the sound for 3 is Pling"
-include = true
 
 [2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
 description = "the sound for 5 is Plang"
-include = true
 
 [d7e60daa-32ef-4c23-b688-2abff46c4806]
 description = "the sound for 7 is Plong"
-include = true
 
 [6bb4947b-a724-430c-923f-f0dc3d62e56a]
 description = "the sound for 6 is Pling as it has a factor 3"
-include = true
 
 [ce51e0e8-d9d4-446d-9949-96eac4458c2d]
 description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
-include = true
 
 [0dd66175-e3e2-47fc-8750-d01739856671]
 description = "the sound for 9 is Pling as it has a factor 3"
-include = true
 
 [022c44d3-2182-4471-95d7-c575af225c96]
 description = "the sound for 10 is Plang as it has a factor 5"
-include = true
 
 [37ab74db-fed3-40ff-b7b9-04acdfea8edf]
 description = "the sound for 14 is Plong as it has a factor of 7"
-include = true
 
 [31f92999-6afb-40ee-9aa4-6d15e3334d0f]
 description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
-include = true
 
 [ff9bb95d-6361-4602-be2c-653fe5239b54]
 description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
-include = true
 
 [d2e75317-b72e-40ab-8a64-6734a21dece1]
 description = "the sound for 25 is Plang as it has a factor 5"
-include = true
 
 [a09c4c58-c662-4e32-97fe-f1501ef7125c]
 description = "the sound for 27 is Pling as it has a factor 3"
-include = true
 
 [bdf061de-8564-4899-a843-14b48b722789]
 description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
-include = true
 
 [c4680bee-69ba-439d-99b5-70c5fd1a7a83]
 description = "the sound for 49 is Plong as it has a factor 7"
-include = true
 
 [17f2bc9a-b65a-4d23-8ccd-266e8c271444]
 description = "the sound for 52 is 52"
-include = true
 
 [e46677ed-ff1a-419f-a740-5c713d2830e4]
 description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
-include = true
 
 [13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
 description = "the sound for 3125 is Plang as it has a factor 5"
-include = true

--- a/exercises/practice/rational-numbers/.meta/tests.toml
+++ b/exercises/practice/rational-numbers/.meta/tests.toml
@@ -4,152 +4,114 @@
 
 [0ba4d988-044c-4ed5-9215-4d0bb8d0ae9f]
 description = "Add two positive rational numbers"
-include = true
 
 [88ebc342-a2ac-4812-a656-7b664f718b6a]
 description = "Add a positive rational number and a negative rational number"
-include = true
 
 [92ed09c2-991e-4082-a602-13557080205c]
 description = "Add two negative rational numbers"
-include = true
 
 [6e58999e-3350-45fb-a104-aac7f4a9dd11]
 description = "Add a rational number to its additive inverse"
-include = true
 
 [47bba350-9db1-4ab9-b412-4a7e1f72a66e]
 description = "Subtract two positive rational numbers"
-include = true
 
 [93926e2a-3e82-4aee-98a7-fc33fb328e87]
 description = "Subtract a positive rational number and a negative rational number"
-include = true
 
 [a965ba45-9b26-442b-bdc7-7728e4b8d4cc]
 description = "Subtract two negative rational numbers"
-include = true
 
 [0df0e003-f68e-4209-8c6e-6a4e76af5058]
 description = "Subtract a rational number from itself"
-include = true
 
 [34fde77a-75f4-4204-8050-8d3a937958d3]
 description = "Multiply two positive rational numbers"
-include = true
 
 [6d015cf0-0ea3-41f1-93de-0b8e38e88bae]
 description = "Multiply a negative rational number by a positive rational number"
-include = true
 
 [d1bf1b55-954e-41b1-8c92-9fc6beeb76fa]
 description = "Multiply two negative rational numbers"
-include = true
 
 [a9b8f529-9ec7-4c79-a517-19365d779040]
 description = "Multiply a rational number by its reciprocal"
-include = true
 
 [d89d6429-22fa-4368-ab04-9e01a44d3b48]
 description = "Multiply a rational number by 1"
-include = true
 
 [0d95c8b9-1482-4ed7-bac9-b8694fa90145]
 description = "Multiply a rational number by 0"
-include = true
 
 [1de088f4-64be-4e6e-93fd-5997ae7c9798]
 description = "Divide two positive rational numbers"
-include = true
 
 [7d7983db-652a-4e66-981a-e921fb38d9a9]
 description = "Divide a positive rational number by a negative rational number"
-include = true
 
 [1b434d1b-5b38-4cee-aaf5-b9495c399e34]
 description = "Divide two negative rational numbers"
-include = true
 
 [d81c2ebf-3612-45a6-b4e0-f0d47812bd59]
 description = "Divide a rational number by 1"
-include = true
 
 [5fee0d8e-5955-4324-acbe-54cdca94ddaa]
 description = "Absolute value of a positive rational number"
-include = true
 
 [3cb570b6-c36a-4963-a380-c0834321bcaa]
 description = "Absolute value of a positive rational number with negative numerator and denominator"
-include = true
 
 [6a05f9a0-1f6b-470b-8ff7-41af81773f25]
 description = "Absolute value of a negative rational number"
-include = true
 
 [5d0f2336-3694-464f-8df9-f5852fda99dd]
 description = "Absolute value of a negative rational number with negative denominator"
-include = true
 
 [f8e1ed4b-9dca-47fb-a01e-5311457b3118]
 description = "Absolute value of zero"
-include = true
 
 [ea2ad2af-3dab-41e7-bb9f-bd6819668a84]
 description = "Raise a positive rational number to a positive integer power"
-include = true
 
 [8168edd2-0af3-45b1-b03f-72c01332e10a]
 description = "Raise a negative rational number to a positive integer power"
-include = true
 
 [e2f25b1d-e4de-4102-abc3-c2bb7c4591e4]
 description = "Raise zero to an integer power"
-include = true
 
 [431cac50-ab8b-4d58-8e73-319d5404b762]
 description = "Raise one to an integer power"
-include = true
 
 [7d164739-d68a-4a9c-b99f-dd77ce5d55e6]
 description = "Raise a positive rational number to the power of zero"
-include = true
 
 [eb6bd5f5-f880-4bcd-8103-e736cb6e41d1]
 description = "Raise a negative rational number to the power of zero"
-include = true
 
 [30b467dd-c158-46f5-9ffb-c106de2fd6fa]
 description = "Raise a real number to a positive rational number"
-include = true
 
 [6e026bcc-be40-4b7b-ae22-eeaafc5a1789]
 description = "Raise a real number to a negative rational number"
-include = true
 
 [9f866da7-e893-407f-8cd2-ee85d496eec5]
 description = "Raise a real number to a zero rational number"
-include = true
 
 [0a63fbde-b59c-4c26-8237-1e0c73354d0a]
 description = "Reduce a positive rational number to lowest terms"
-include = true
 
 [f87c2a4e-d29c-496e-a193-318c503e4402]
 description = "Reduce a negative rational number to lowest terms"
-include = true
 
 [3b92ffc0-5b70-4a43-8885-8acee79cdaaf]
 description = "Reduce a rational number with a negative denominator to lowest terms"
-include = true
 
 [c9dbd2e6-5ac0-4a41-84c1-48b645b4f663]
 description = "Reduce zero to lowest terms"
-include = true
 
 [297b45ad-2054-4874-84d4-0358dc1b8887]
 description = "Reduce an integer to lowest terms"
-include = true
 
 [a73a17fe-fe8c-4a1c-a63b-e7579e333d9e]
 description = "Reduce one to lowest terms"
-include = true

--- a/exercises/practice/resistor-color-trio/.meta/tests.toml
+++ b/exercises/practice/resistor-color-trio/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [d6863355-15b7-40bb-abe0-bfb1a25512ed]
 description = "Orange and orange and black"
-include = true
 
 [1224a3a9-8c8e-4032-843a-5224e04647d6]
 description = "Blue and grey and brown"
-include = true
 
 [b8bda7dc-6b95-4539-abb2-2ad51d66a207]
 description = "Red and black and red"
-include = true
 
 [5b1e74bc-d838-4eda-bbb3-eaba988e733b]
 description = "Green and brown and orange"
-include = true
 
 [f5d37ef9-1919-4719-a90d-a33c5a6934c9]
 description = "Yellow and violet and yellow"
-include = true

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [c3b7d806-dced-49ee-8543-933fd1719b1c]
 description = "an empty string"
-include = true
 
 [01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
 description = "a word"
-include = true
 
 [0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
 description = "a capitalized word"
-include = true
 
 [71854b9c-f200-4469-9f5c-1e8e5eff5614]
 description = "a sentence with punctuation"
-include = true
 
 [1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
 description = "a palindrome"
-include = true
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
-include = true

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
 description = "Empty RNA sequence"
-include = true
 
 [a9558a3c-318c-4240-9256-5d5ed47005a6]
 description = "RNA complement of cytosine is guanine"
-include = true
 
 [6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
 description = "RNA complement of guanine is cytosine"
-include = true
 
 [870bd3ec-8487-471d-8d9a-a25046488d3e]
 description = "RNA complement of thymine is adenine"
-include = true
 
 [aade8964-02e1-4073-872f-42d3ffd74c5f]
 description = "RNA complement of adenine is uracil"
-include = true
 
 [79ed2757-f018-4f47-a1d7-34a559392dbf]
 description = "RNA complement"
-include = true

--- a/exercises/practice/robot-simulator/.meta/tests.toml
+++ b/exercises/practice/robot-simulator/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [c557c16d-26c1-4e06-827c-f6602cd0785c]
 description = "at origin facing north"
-include = true
 
 [bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d]
 description = "at negative position facing south"
-include = true
 
 [8cbd0086-6392-4680-b9b9-73cf491e67e5]
 description = "changes north to east"
-include = true
 
 [8abc87fc-eab2-4276-93b7-9c009e866ba1]
 description = "changes east to south"
-include = true
 
 [3cfe1b85-bbf2-4bae-b54d-d73e7e93617a]
 description = "changes south to west"
-include = true
 
 [5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716]
 description = "changes west to north"
-include = true
 
 [fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63]
 description = "changes north to west"
-include = true
 
 [da33d734-831f-445c-9907-d66d7d2a92e2]
 description = "changes west to south"
-include = true
 
 [bd1ca4b9-4548-45f4-b32e-900fc7c19389]
 description = "changes south to east"
-include = true
 
 [2de27b67-a25c-4b59-9883-bc03b1b55bba]
 description = "changes east to north"
-include = true
 
 [f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8]
 description = "facing north increments Y"
-include = true
 
 [2786cf80-5bbf-44b0-9503-a89a9c5789da]
 description = "facing south decrements Y"
-include = true
 
 [84bf3c8c-241f-434d-883d-69817dbd6a48]
 description = "facing east increments X"
-include = true
 
 [bb69c4a7-3bbf-4f64-b415-666fa72d7b04]
 description = "facing west decrements X"
-include = true
 
 [e34ac672-4ed4-4be3-a0b8-d9af259cbaa1]
 description = "moving east and north from README"
-include = true
 
 [f30e4955-4b47-4aa3-8b39-ae98cfbd515b]
 description = "moving west and north"
-include = true
 
 [3e466bf6-20ab-4d79-8b51-264165182fca]
 description = "moving west and south"
-include = true
 
 [41f0bb96-c617-4e6b-acff-a4b279d44514]
 description = "moving east and north"
-include = true

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
 description = "1 is a single I"
-include = true
 
 [f088f064-2d35-4476-9a41-f576da3f7b03]
 description = "2 is two I's"
-include = true
 
 [b374a79c-3bea-43e6-8db8-1286f79c7106]
 description = "3 is three I's"
-include = true
 
 [05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
 description = "4, being 5 - 1, is IV"
-include = true
 
 [57c0f9ad-5024-46ab-975d-de18c430b290]
 description = "5 is a single V"
-include = true
 
 [20a2b47f-e57f-4797-a541-0b3825d7f249]
 description = "6, being 5 + 1, is VI"
-include = true
 
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9, being 10 - 1, is IX"
-include = true
 
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "20 is two X's"
-include = true
 
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
 description = "48 is not 50 - 2 but rather 40 + 8"
-include = true
 
 [607ead62-23d6-4c11-a396-ef821e2e5f75]
 description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
-include = true
 
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "50 is a single L"
-include = true
 
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "90, being 100 - 10, is XC"
-include = true
 
 [30494be1-9afb-4f84-9d71-db9df18b55e3]
 description = "100 is a single C"
-include = true
 
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "60, being 50 + 10, is LX"
-include = true
 
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "400, being 500 - 100, is CD"
-include = true
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "500 is a single D"
-include = true
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "900, being 1000 - 100, is CM"
-include = true
 
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1000 is a single M"
-include = true
 
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
 description = "3000 is three M's"
-include = true

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [74e58a38-e484-43f1-9466-877a7515e10f]
 description = "rotate a by 0, same output as input"
-include = true
 
 [7ee352c6-e6b0-4930-b903-d09943ecb8f5]
 description = "rotate a by 1"
-include = true
 
 [edf0a733-4231-4594-a5ee-46a4009ad764]
 description = "rotate a by 26, same output as input"
-include = true
 
 [e3e82cb9-2a5b-403f-9931-e43213879300]
 description = "rotate m by 13"
-include = true
 
 [19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
 description = "rotate n by 13 with wrap around alphabet"
-include = true
 
 [a116aef4-225b-4da9-884f-e8023ca6408a]
 description = "rotate capital letters"
-include = true
 
 [71b541bb-819c-4dc6-a9c3-132ef9bb737b]
 description = "rotate spaces"
-include = true
 
 [ef32601d-e9ef-4b29-b2b5-8971392282e6]
 description = "rotate numbers"
-include = true
 
 [32dd74f6-db2b-41a6-b02c-82eb4f93e549]
 description = "rotate punctuation"
-include = true
 
 [9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9]
 description = "rotate all letters"
-include = true

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [ad53b61b-6ffc-422f-81a6-61f7df92a231]
 description = "empty string"
-include = true
 
 [52012823-b7e6-4277-893c-5b96d42f82de]
 description = "single characters only are encoded without count"
-include = true
 
 [b7868492-7e3a-415f-8da3-d88f51f80409]
 description = "string with no single characters"
-include = true
 
 [859b822b-6e9f-44d6-9c46-6091ee6ae358]
 description = "single characters mixed with repeated characters"
-include = true
 
 [1b34de62-e152-47be-bc88-469746df63b3]
 description = "multiple whitespace mixed in string"
-include = true
 
 [abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
 description = "lowercase characters"
-include = true
 
 [7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
 description = "empty string"
-include = true
 
 [ad23f455-1ac2-4b0e-87d0-b85b10696098]
 description = "single characters only"
-include = true
 
 [21e37583-5a20-4a0e-826c-3dee2c375f54]
 description = "string with no single characters"
-include = true
 
 [1389ad09-c3a8-4813-9324-99363fba429c]
 description = "single characters with repeated characters"
-include = true
 
 [3f8e3c51-6aca-4670-b86c-a213bf4706b0]
 description = "multiple whitespace mixed in string"
-include = true
 
 [29f721de-9aad-435f-ba37-7662df4fb551]
 description = "lower case string"
-include = true
 
 [2a762efd-8695-4e04-b0d6-9736899fbc16]
 description = "encode followed by decode gives original string"
-include = true

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [f46cda29-1ca5-4ef2-bd45-388a767e3db2]
 description = "lowercase letter"
-include = true
 
 [f7794b49-f13e-45d1-a933-4e48459b2201]
 description = "uppercase letter"
-include = true
 
 [eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
 description = "valuable letter"
-include = true
 
 [f3c8c94e-bb48-4da2-b09f-e832e103151e]
 description = "short word"
-include = true
 
 [71e3d8fa-900d-4548-930e-68e7067c4615]
 description = "short, valuable word"
-include = true
 
 [d3088ad9-570c-4b51-8764-c75d5a430e99]
 description = "medium word"
-include = true
 
 [fa20c572-ad86-400a-8511-64512daac352]
 description = "medium, valuable word"
-include = true
 
 [9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
 description = "long, mixed-case word"
-include = true
 
 [1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
 description = "english-like word"
-include = true
 
 [4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
 description = "empty input"
-include = true
 
 [3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
 description = "entire alphabet available"
-include = true

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [b8496fbd-6778-468c-8054-648d03c4bb23]
 description = "wink for 1"
-include = true
 
 [83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
 description = "double blink for 10"
-include = true
 
 [0e20e466-3519-4134-8082-5639d85fef71]
 description = "close your eyes for 100"
-include = true
 
 [b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
 description = "jump for 1000"
-include = true
 
 [40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
 description = "combine two actions"
-include = true
 
 [9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
 description = "reverse two actions"
-include = true
 
 [0b828205-51ca-45cd-90d5-f2506013f25f]
 description = "reversing one action gives the same action"
-include = true
 
 [9949e2ac-6c9c-4330-b685-2089ab28b05f]
 description = "reversing no actions still gives no actions"
-include = true
 
 [23fdca98-676b-4848-970d-cfed7be39f81]
 description = "all possible actions"
-include = true
 
 [ae8fe006-d910-4d6f-be00-54b7c3799e79]
 description = "reverse all possible actions"
-include = true
 
 [3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
 description = "do nothing for zero"
-include = true

--- a/exercises/practice/sieve/.meta/tests.toml
+++ b/exercises/practice/sieve/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [88529125-c4ce-43cc-bb36-1eb4ddd7b44f]
 description = "no primes under two"
-include = true
 
 [4afe9474-c705-4477-9923-840e1024cc2b]
 description = "find first prime"
-include = true
 
 [974945d8-8cd9-4f00-9463-7d813c7f17b7]
 description = "find primes up to 10"
-include = true
 
 [2e2417b7-3f3a-452a-8594-b9af08af6d82]
 description = "limit is prime"
-include = true
 
 [92102a05-4c7c-47de-9ed0-b7d5fcd00f21]
 description = "find primes up to 1000"
-include = true

--- a/exercises/practice/spiral-matrix/.meta/tests.toml
+++ b/exercises/practice/spiral-matrix/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [8f584201-b446-4bc9-b132-811c8edd9040]
 description = "empty spiral"
-include = true
 
 [e40ae5f3-e2c9-4639-8116-8a119d632ab2]
 description = "trivial spiral"
-include = true
 
 [cf05e42d-eb78-4098-a36e-cdaf0991bc48]
 description = "spiral of size 2"
-include = true
 
 [1c475667-c896-4c23-82e2-e033929de939]
 description = "spiral of size 3"
-include = true
 
 [05ccbc48-d891-44f5-9137-f4ce462a759d]
 description = "spiral of size 4"
-include = true
 
 [f4d2165b-1738-4e0c-bed0-c459045ae50d]
 description = "spiral of size 5"
-include = true

--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [404b7262-c050-4df0-a2a2-0cb06cd6a821]
 description = "empty string"
-include = true
 
 [a89ce8a3-c940-4703-a688-3ea39412fbcb]
 description = "two characters in a row"
-include = true
 
 [855bb6ae-4180-457c-abd0-ce489803ce98]
 description = "two characters in a column"
-include = true
 
 [5ceda1c0-f940-441c-a244-0ced197769c8]
 description = "simple"
-include = true
 
 [a54675dd-ae7d-4a58-a9c4-0c20e99a7c1f]
 description = "single line"
-include = true
 
 [0dc2ec0b-549d-4047-aeeb-8029fec8d5c5]
 description = "first line longer than second line"
-include = true
 
 [984e2ec3-b3d3-4b53-8bd6-96f5ef404102]
 description = "second line longer than first line"
-include = true
 
 [eccd3784-45f0-4a3f-865a-360cb323d314]
 description = "mixed line length"
-include = true
 
 [85b96b3f-d00c-4f80-8ca2-c8a5c9216c2d]
 description = "square"
-include = true
 
 [b9257625-7a53-4748-8863-e08e9d27071d]
 description = "rectangle"
-include = true
 
 [b80badc9-057e-4543-bd07-ce1296a1ea2c]
 description = "triangle"
-include = true

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [8b2c43ac-7257-43f9-b552-7631a91988af]
 description = "all sides are equal"
-include = true
 
 [33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
 description = "any side is unequal"
-include = true
 
 [c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
 description = "no sides are equal"
-include = true
 
 [16e8ceb0-eadb-46d1-b892-c50327479251]
 description = "all zero sides is not a triangle"
-include = true
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
 description = "sides may be floats"
-include = true
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
 description = "last two sides are equal"
-include = true
 
 [e388ce93-f25e-4daf-b977-4b7ede992217]
 description = "first two sides are equal"
-include = true
 
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
 description = "first and last sides are equal"
-include = true
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
 description = "equilateral triangles are also isosceles"
-include = true
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
 description = "no sides are equal"
-include = true
 
 [2eba0cfb-6c65-4c40-8146-30b608905eae]
 description = "first triangle inequality violation"
-include = true
 
 [278469cb-ac6b-41f0-81d4-66d9b828f8ac]
 description = "second triangle inequality violation"
-include = true
 
 [90efb0c7-72bb-4514-b320-3a3892e278ff]
 description = "third triangle inequality violation"
-include = true
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
 description = "sides may be floats"
-include = true
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
 description = "no sides are equal"
-include = true
 
 [2510001f-b44d-4d18-9872-2303e7977dc1]
 description = "all sides are equal"
-include = true
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
 description = "two sides are equal"
-include = true
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
 description = "may not violate triangle inequality"
-include = true
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
 description = "sides may be floats"
-include = true

--- a/exercises/practice/trinary/.meta/tests.toml
+++ b/exercises/practice/trinary/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [a7a79a9e-5606-454c-9cdb-4f3c0ca46931]
 description = "trinary 1 is decimal 1"
-include = true
 
 [39240078-13e2-4eb8-87c4-aeffa7d64130]
 description = "trinary 2 is decimal 2"
-include = true
 
 [81900d67-7e07-4d41-a71e-86f1cd72ce1f]
 description = "trinary 10 is decimal 3"
-include = true
 
 [7a8d5341-f88a-4c60-9048-4d5e017fa701]
 description = "trinary 11 is decimal 4"
-include = true
 
 [6b3c37f6-d6b3-4575-85c0-19f48dd101af]
 description = "trinary 100 is decimal 9"
-include = true
 
 [a210b2b8-d333-4e19-9e59-87cabdd2a0ba]
 description = "trinary 112 is decimal 14"
-include = true
 
 [5ae03472-b942-42ce-ba00-e84a7dc86dd8]
 description = "trinary 222 is decimal 26"
-include = true
 
 [d4fabf94-6149-4d1e-b42f-b34dc3ddef8f]
 description = "trinary 1122000120 is decimal 32091"
-include = true
 
 [34be152d-38f3-4dcf-b5ab-9e14fe2f7161]
 description = "invalid trinary digits returns 0"
-include = true
 
 [b57aa24d-3da2-4787-9429-5bc94d3112d6]
 description = "invalid word as input returns 0"
-include = true
 
 [673c2057-5d89-483c-87fa-139da6927b90]
 description = "invalid numbers with letters as input returns 0"
-include = true

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [61559d5f-2cad-48fb-af53-d3973a9ee9ef]
 description = "count one word"
-include = true
 
 [5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
 description = "count one of each word"
-include = true
 
 [2a3091e5-952e-4099-9fac-8f85d9655c0e]
 description = "multiple occurrences of a word"
-include = true
 
 [e81877ae-d4da-4af4-931c-d923cd621ca6]
 description = "handles cramped lists"
-include = true
 
 [7349f682-9707-47c0-a9af-be56e1e7ff30]
 description = "handles expanded lists"
-include = true
 
 [a514a0f2-8589-4279-8892-887f76a14c82]
 description = "ignore punctuation"
-include = true
 
 [d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
 description = "include numbers"
-include = true
 
 [dac6bc6a-21ae-4954-945d-d7f716392dbf]
 description = "normalize case"
-include = true
 
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
-include = true
 
 [be72af2b-8afe-4337-b151-b297202e4a7b]
 description = "with quotations"
-include = true
 
 [8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
 description = "substrings from the beginning"
-include = true
 
 [c5f4ef26-f3f7-4725-b314-855c04fb4c13]
 description = "multiple spaces not detected as a word"
-include = true
 
 [50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
 description = "alternating word separators not detected as a word"
-include = true


### PR DESCRIPTION
This PR simplifies the `tests.toml` files by removing any `include = true` properties, which are redundant as the default value of this field is `true`.

As the vast majority of the test cases use `include = true`, omitting it makes the `tests.toml` files more readable and make the exceptional cases (`include = false`) easier to identify.

We've updated `configlet` to use this new behavior. See https://github.com/exercism/configlet/issues/186 and https://github.com/exercism/configlet/issues/207 for the corresponding discussion.

## Tracking

https://github.com/exercism/v3-launch/issues/31
