### PR TITLE
Make configlet annoying again

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -18,5 +18,4 @@ jobs:
       uses: exercism/github-actions/configlet-ci@main
         
     - name: Configlet Linter
-      continue-on-error: true
       run: configlet lint


### PR DESCRIPTION
New exercises should NOT introduce new configlet errors anymore, to prevent the number of errors from growing out of control before launch.

Making it annoying hopefully helps with that