### PR TITLE
🤖 Update name of `dnd-character` exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -748,7 +748,7 @@
         "practices": [],
         "prerequisites": [],
         "slug": "dnd-character",
-        "name": "Dnd Character",
+        "name": "D&D Character",
         "difficulty": 5,
         "topics": [
           "variables",


### PR DESCRIPTION
This PR correct the name of the `dnd-character` exercise to its correct value: "D&D Character"