### PR TITLE
Add shared exercise docs

### DIFF
--- a/exercises/shared/.docs/cli.md
+++ b/exercises/shared/.docs/cli.md
@@ -1,9 +1,0 @@
-# CLI
-
-To run the tests, run the command `julia runtests.jl` from within the exercise directory.
-
-Once all tests pass, you can submit your solution using `exercism submit encounters.jl`.
-
-## Links
-
-- [exercism CLI documentation](https://exercism.io/cli)

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,0 +1,3 @@
+# Help
+
+If you're having trouble, feel free to ask help in the [Exercism support gitter channel](https://gitter.im/exercism/support).

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,3 +1,1 @@
-# Help
 
-If you're having trouble, feel free to ask help in the [Exercism support gitter channel](https://gitter.im/exercism/support).

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -2,6 +2,6 @@
 
 To run the tests, run this command from within the exercise directory:
 
-```
+```bash
 $ julia runtests.js
 ```

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,0 +1,7 @@
+# Running tests
+
+To run the tests, run this command from within the exercise directory:
+
+```
+$ julia runtests.js
+```

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -3,5 +3,5 @@
 To run the tests, run this command from within the exercise directory:
 
 ```bash
-$ julia runtests.js
+$ julia runtests.jl
 ```


### PR DESCRIPTION
This resolves two of the linting problems.

As per https://github.com/exercism/docs/blob/main/building/tracks/shared-files.md, `help.md` and `tests.md` are necessary.

`cli.md` is not the responsibility of the track, it's a global file.

When I downloaded `bob` just now, this is the `HELP.md` file that was generated:

```markdown
# Help

## Running the tests

## Submitting your solution

You can submit your solution using the `exercism submit bob.jl` command.
This command will upload your solution to the Exercism website and print the solution page's URL.

It's possible to submit an incomplete solution which allows you to:

- See how others have completed the exercise
- Request help from a mentor

## Need to get help?

If you'd like help solving the exercise, check the following pages:

- The [Julia track's documentation](https://exercism.io/docs/tracks/julia)
- [Exercism's support channel on gitter](https://gitter.im/exercism/support)
- The [Frequently Asked Questions](https://exercism.io/docs/faq) TODO: (Required) use correct link

Should those resources not suffice, you could submit your (incomplete) solution to request mentoring.
```

`## Running the tests` is empty because `exercises/shared/.docs/tests.md` was missing. But looking at the general `## Need to get help?`, I wonder if Julia'ss `exercises/shared/.docs/help.md` should really link the gitter channel because it's already linked in the general help. I don't know what else could be in `exercises/shared/.docs/help.md`. Should it just be empty? The docs say:

> Describe how a student can get help, specifically for this track (not Exercism-wide).

I don't know if there is any Julia-specific way to get help.

Btw. If the test runner has the capability to capture IO and return it to the user, an optional ` `exercises/shared/.docs/debug.md` could also be created (e.g. https://github.com/exercism/elixir/blob/main/exercises/shared/.docs/debug.md). But that file is only for the web editor.