### PR TITLE
Disable concept exercises for testing

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "slug": "julia",
   "active": true,
   "status": {
-    "concept_exercises": true,
+    "concept_exercises": false,
     "test_runner": true,
     "representer": false,
     "analyzer": false


### PR DESCRIPTION
Track isn't in a state where it's likely to be launch-ready in time.