### PR TITLE
Minor testset fix in roman numerals tests

### DIFF
--- a/exercises/practice/roman-numerals/runtests.jl
+++ b/exercises/practice/roman-numerals/runtests.jl
@@ -27,7 +27,7 @@ samples = Dict(
     3000 => "MMM"
 )
 
-@testset "convert $sample[1] to roman numeral" for sample in samples
+@testset "convert $(sample[1]) to roman numeral" for sample in samples
     @test to_roman(sample[1]) == sample[2]
 end
 


### PR DESCRIPTION
The testset name had a missing `()` around the string interpolation.