### PR TITLE
Fix runtests for rational-numbers

### DIFF
--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -102,7 +102,7 @@ end
 # https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/LICENSE.md
 @testset "Ordering" begin
     for a in -5:5, b in -5:5, c in -5:5
-        a == b == 0 && continue
+        b == 0 && continue
         
         r = RationalNumber(a, b)
 
@@ -114,7 +114,7 @@ end
         @test (r >  c) == (a / b >  c)
 
         for d in -5:5
-            c == d == 0 && continue
+            d == 0 && continue
 
             s = RationalNumber(c, d)
 


### PR DESCRIPTION
Only the denominators cannot be 0. The test case of having the numerator 0 is valid. If we only skip the test when `a == b` we get a domainerror as required by the exercises before.