### PR TITLE
robot-simulator: Remove type parameter from tests

### DIFF
--- a/exercises/practice/robot-simulator/runtests.jl
+++ b/exercises/practice/robot-simulator/runtests.jl
@@ -8,7 +8,7 @@ include("robot-simulator.jl")
     @test heading(r) == NORTH
 
     r = Robot((-1, -1), SOUTH)
-    @test position(r) == Point{Int}(-1, -1)
+    @test position(r) == Point(-1, -1)
     @test heading(r) == SOUTH
 end
 


### PR DESCRIPTION
As pointed out by PoliticalSatyr in their mentoring request, this isn't really needed.