### PR TITLE
Update instructions to reflect tests and mentor notes

### DIFF
--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -5,5 +5,5 @@ Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan
 The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
-The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
-insensitive. Input will not contain non-ASCII symbols.
+The alphabet used consists of UTF-8 letters `a` to `z`, inclusive, and is case
+insensitive. Input can contain non-ASCII symbols.

--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -5,5 +5,5 @@ Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan
 The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
-The alphabet used consists of UTF-8 letters `a` to `z`, inclusive, and is case
-insensitive. Input can contain non-ASCII symbols.
+The alphabet used consists of letters `a` to `z`, inclusive, and is case
+insensitive.


### PR DESCRIPTION
Contrary to what the current instructions say the tests do input non-ASCII characters, specifically test 14. 
In my personal opinion this only complicates the exercise without providing any sort of benefit to beginners, which are those most likely to attempt such an easy exercise.
Instead of removing the offending test I have decided to change the instructions instead, as I am unsure how to change the mentor notes, and the code solutions they contain.