### PR TITLE
Add extra contraction test for word-count.jl

### DIFF
--- a/exercises/practice/word-count/runtests.jl
+++ b/exercises/practice/word-count/runtests.jl
@@ -40,6 +40,7 @@ end
 
 @testset "with apostrophes" begin
     @test wordcount("First: don't laugh. Then: don't cry.") == Dict("first" => 1, "don't" => 2, "laugh" => 1, "then" => 1, "cry" => 1)
+    @test wordcount("Should've could've would've") == Dict("should've" => 1, "could've" => 1, "would've" => 1)
 end
 
 @testset "with quotations" begin


### PR DESCRIPTION
I noticed this edge case (contractions with more than one letter after the apostrophe) while mentoring. Happy to use different/more examples or incorporate them into the original test if that is preferred