### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -363,7 +363,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "16550822-4751-4bb3-9e15-80361006e2d6",
         "practices": [],
         "prerequisites": [],
@@ -451,7 +451,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "0d5f865c-b704-445c-ac31-df34168f54aa",
         "practices": [],
         "prerequisites": [],
@@ -465,7 +465,7 @@
       },
       {
         "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
+        "name": "Run-Length Encoding",
         "uuid": "9814f832-8bd1-4a2b-9a1e-fc0e3e8541b5",
         "practices": [],
         "prerequisites": [],
@@ -505,7 +505,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "bccc00fa-811c-4bf9-8e55-07a0d0affb08",
         "practices": [],
         "prerequisites": [],
@@ -640,7 +640,7 @@
       },
       {
         "slug": "pascals-triangle",
-        "name": "Pascals Triangle",
+        "name": "Pascal's Triangle",
         "uuid": "bf709fe6-d269-467a-a3da-5bbdaf674f91",
         "practices": [],
         "prerequisites": [],
@@ -707,7 +707,7 @@
       },
       {
         "slug": "isbn-verifier",
-        "name": "Isbn Verifier",
+        "name": "ISBN Verifier",
         "uuid": "22b64a2b-7f08-444d-be6e-8b42e5c9207c",
         "practices": [],
         "prerequisites": [],
@@ -778,7 +778,7 @@
         "practices": [],
         "prerequisites": [],
         "slug": "dnd-character",
-        "name": "Dnd Character",
+        "name": "D&D Character",
         "difficulty": 5,
         "topics": [
           "variables",


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579