### PR TITLE
Add missing `factorial` method

### DIFF
--- a/exercises/practice/alphametics/permutations.jl
+++ b/exercises/practice/alphametics/permutations.jl
@@ -27,6 +27,30 @@
 #    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #    DEALINGS IN THE SOFTWARE.
 
+# Combinatorics/src/factorials.jl
+
+# TODO: This should really live in Base, otherwise it's type piracy
+"""
+    factorial(n, k)
+
+Compute ``n!/k!``.
+"""
+function Base.factorial(n::T, k::T) where T<:Integer
+    if k < 0 || n < 0 || k > n
+        throw(DomainError((n, k), "n and k must be nonnegative with k ≤ n"))
+    end
+    f = one(T)
+    while n > k
+        f = Base.checked_mul(f, n)
+        n -= 1
+    end
+    return f
+end
+
+Base.factorial(n::Integer, k::Integer) = factorial(promote(n, k)...)
+
+# Combinatorics/src/permutations.jl
+
 struct Permutations{T}
     a::T
     t::Int


### PR DESCRIPTION
defined in Combinatorics.jl and used in its `permutations`'s definition.

Solves this error:

```julia
julia> include("permutations.jl")
nextpermutation (generic function with 1 method)

julia> permutations([1,2,3]) |> collect
ERROR: MethodError: no method matching factorial(::Int64, ::Int64)
Closest candidates are:
  factorial(::Union{Int64, UInt64}) at combinatorics.jl:27
  factorial(::Integer) at intfuncs.jl:1007
Stacktrace:
 [1] length
   @ ~/exercism/julia/alphametics/permutations.jl:60 [inlined]
 [2] _similar_shape
   @ ./array.jl:663 [inlined]
 [3] _collect
   @ ./array.jl:718 [inlined]
 [4] collect
   @ ./array.jl:712 [inlined]
 [5] |>(x::Permutations{Vector{Int64}}, f::typeof(collect))
   @ Base ./operators.jl:911
 [6] top-level scope
   @ REPL[1]:1
```

With this fix:

```julia
julia> include("permutations.jl")
nextpermutation (generic function with 1 method)

julia> permutations([1,2,3]) |> collect
6-element Vector{Vector{Int64}}:
 [1, 2, 3]
 [1, 3, 2]
 [2, 1, 3]
 [2, 3, 1]
 [3, 1, 2]
 [3, 2, 1]
```