### PR TITLE
Fix broken admonitions

### DIFF
--- a/concepts/integer-introduction/about.md
+++ b/concepts/integer-introduction/about.md
@@ -73,7 +73,7 @@ julia> 16 ÷ 6
 2
 ```
 
-~~~~note
+~~~~exercism/note
 It's natural to use Unicode symbols in Julia source files, typically in mathematical expressions.
 When using the Julia REPL, or in other Julia editing environments, the division symbol can be entered by typing `\div` followed by the `Tab` key.
 More details can be found in the manual at [Unicode Input][unicode].

--- a/concepts/integer-introduction/introduction.md
+++ b/concepts/integer-introduction/introduction.md
@@ -57,7 +57,7 @@ julia> 16 ÷ 6
 2
 ```
 
-~~~~note
+~~~~exercism/note
 It's natural to use Unicode symbols in Julia source files, typically in mathematical expressions.
 When using the Julia REPL, or in other Julia editing environments, the division symbol can be entered by typing `\div` followed by the `Tab` key.
 More details can be found in the manual at [Unicode Input][unicode].

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -96,7 +96,7 @@ julia> 16 ÷ 6
 2
 ```
 
-~~~~note
+~~~~exercism/note
 It's natural to use Unicode symbols in Julia source files, typically in mathematical expressions.
 When using the Julia REPL, or in other Julia editing environments, the division symbol can be entered by typing `\div` followed by the `Tab` key.
 More details can be found in the manual at [Unicode Input][unicode].


### PR DESCRIPTION
Turn every `~~~~note` into `~~~~exercism/note`.

Currently broken on e.g. https://exercism.org/tracks/julia/concepts/integer-introduction

From the [Exercism Markdown docs][1]:

> We support special types of blocks that can be added to documents to pull out commentary that doesn't fit with the main body of the text.
> 
> We support three types of blocks:
> 
> - **exercism/note:** Blocks that pull out some extra special information
> - **exercism/caution:** Things that people should know about or tread carefully with
> - **exercism/advanced:** Information that is only relevant for people who want to dig more deeply into something or are expected to have more advanced knowledge.
> 
> All blocks are written using 4 tildes, in the form of:
> 
> ````
> ~~~~exercism/note
> Content goes here
> 
> You can include code:
> ```ruby
> str = "Hello, World"
> ```
> ~~~~
> ````
> 
> (Note: You may also use backticks or other levels of tildes in exceptional circumstances)

Closes: #606

[1]: https://github.com/exercism/docs/blob/73835d5d918f/building/markdown/markdown.md#special-blocks-sometimes-called-admonitions