### PR TITLE
Fix #488 use non-ascii punctuation, not letters

### DIFF
--- a/exercises/practice/pangram/runtests.jl
+++ b/exercises/practice/pangram/runtests.jl
@@ -54,6 +54,6 @@ end
     @test ispangram("the 1 quick brown fox jumps Over the 2 lazy dogs")
 end
 
-@testset "punctuation that isn't part of ASCII" begin
-    @test ispangram("Wow—the quick brown fox jumps over the lazy dog‽")
+@testset "An Arabic pangram is not an English pangram" begin
+    @test !ispangram("The scholar and poet Al Farāhīdi wrote this Arabic pangram: صِف خَلقَ خَودِ كَمِثلِ الشَمسِ إِذ بَزَغَت — يَحظى الضَجيعُ بِها نَجلاءَ مِعطارِ")
 end

--- a/exercises/practice/pangram/runtests.jl
+++ b/exercises/practice/pangram/runtests.jl
@@ -54,6 +54,6 @@ end
     @test ispangram("the 1 quick brown fox jumps Over the 2 lazy dogs")
 end
 
-@testset "letters that aren't part of ASCII" begin
-    @test !ispangram("the 1 qüick bröwn föx jümps över the 2 läzy dögs")
+@testset "punctuation that isn't part of ASCII" begin
+    @test ispangram("Wow—the quick brown fox jumps over the lazy dog‽")
 end


### PR DESCRIPTION
The instructions specify that the only input letters will be the 26 english language letters, but we were testing with unlauts.

I think it's worth changing the test rather than the instructions because it's ambiguous whether adding diacritics to a letter makes it a new letter or not.

I did think about adding a bonus test that makes a decision one way or the other (you could use unicode's NFKD transformation[1] to match letters, ignoring diacritics, or to require each unique glyph you could maybe use the NFC transformation + maybe splitting to graphemes (depending on if unicode has a codepoint for all "letters" in the alphabet)), but it's a bit complicated.

[1]: https://unicode.org/reports/tr15/