### PR TITLE
Reverse-string: remove repeated bonus instruction

### DIFF
--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -5,16 +5,3 @@ Reverse a string
 For example:
 input: "cool"
 output: "looc"
-
-## Bonus
-
-Preserve grapheme clusters, i.e.
-
-```julia
-myreverse("hi 👋🏾") == "👋🏾 ih"
-myreverse("as⃝df̅") == "f̅ds⃝a"
-```
-
-You will probably find the `Unicode` stdlib useful for this bonus task.
-
-To enable the graphemes test, add `const TEST_GRAPHEMES = true` to the global scope of your file.


### PR DESCRIPTION
The bonus instruction appeared twice:
![image](https://user-images.githubusercontent.com/4361758/234495867-2cdd2eaa-457e-434f-b4db-f74dbc96025d.png)

corrected by removing once of the occurences.