### PR TITLE
[sum-of-multiples] add a type to the empty vector in the test

### DIFF
--- a/exercises/practice/sum-of-multiples/runtests.jl
+++ b/exercises/practice/sum-of-multiples/runtests.jl
@@ -50,7 +50,7 @@ end
 end
 
 @testset "no factors means an empty sum" begin
-    @test sum_of_multiples(10000, Vector{Int}()) == 0
+    @test sum_of_multiples(10000, Int[]) == 0
 end
 
 @testset "the only multiple of 0 is 0" begin

--- a/exercises/practice/sum-of-multiples/runtests.jl
+++ b/exercises/practice/sum-of-multiples/runtests.jl
@@ -3,7 +3,7 @@ using Test
 
 @testset "no multiples within limit" begin
     @test sum_of_multiples(1, [3, 5]) == 0
- end
+end
 
 @testset "test one factor has multiples within limit" begin
     @test sum_of_multiples(4, [3, 5]) == 3
@@ -50,7 +50,7 @@ end
 end
 
 @testset "no factors means an empty sum" begin
-    @test sum_of_multiples(10000, []) == 0
+    @test sum_of_multiples(10000, Vector{Int}()) == 0
 end
 
 @testset "the only multiple of 0 is 0" begin


### PR DESCRIPTION
In `sum-of-multiples`, one of the tests pass an empty vector into the user's function. This is fine, but if the user adds types to their function arguments, you get an error:

```julia
function sum_of_multiples(limit::Int, factors::Vector{Int})::Int end

sum_of_multiples(20, [])

ERROR: MethodError: no method matching sum_of_multiples(::Int64, ::Vector{Any})
Closest candidates are:
  sum_of_multiples(::Int64, ::Vector{Int64}) at REPL[1]:1
Stacktrace:
 [1] top-level scope
```

This types the empty array in the test so that user functions will work whether or not they type them.