### PR TITLE
Make rational-numbers exercise easier

### DIFF
--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -28,9 +28,14 @@ Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) =
 
 Implement the following operations:
 
-- addition, subtraction, multiplication and division of two rational numbers,
-- absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number,
-- comparison (less than, equals, etc.) of two rational numbers, comparison of a rational number and an integer.
+- conversion and promotion of integers to rationals. Read the manual's chaper on [conversion and promotion](https://docs.julialang.org/en/v1/manual/conversion-and-promotion/) for details about how and why to do this.
+- addition, subtraction, multiplication and division of two rational numbers
+- absolute value, exponentiation of a given rational number to an integer power, exponentiation of a real number to a rational number
+- comparison (less than, equals, etc.) of two rational numbers, comparison of a rational number and an integer
+
+In Julia, there are fallback methods already defined for many arithmetic methods, comparisons, etc, especially for subtypes of `Real`.
+You do not need to write your own method for `>=` if you have already defined `<`; nor do you need to define `^(::RationalNumber, ::Integer)` if you have provided a method for multiplication; etc.
+You can examine the fallback methods for a given function by entering `methods(abs)` or `edit(abs, (RationalNumber, RationalNumber))` at the REPL.
 
 Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
 The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer). If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached. For example, `3/-4` should be reduced to `-3/4`

--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -29,7 +29,8 @@ Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) =
 Implement the following operations:
 
 - addition, subtraction, multiplication and division of two rational numbers,
-- absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
+- absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number,
+- comparison (less than, equals, etc.) of two rational numbers, comparison of a rational number and an integer.
 
 Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
 The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer). If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached. For example, `3/-4` should be reduced to `-3/4`

--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -122,7 +122,7 @@ end
 # https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/LICENSE.md
 @testset "Ordering" begin
     for a in -5:5, b in -5:5, c in -5:5
-        a == b == 0 && continue
+        b == 0 && continue
         
         r = RationalNumber(a, b)
 
@@ -134,7 +134,7 @@ end
         @test (r >  c) == (a / b >  c)
 
         for d in -5:5
-            c == d == 0 && continue
+            d == 0 && continue
 
             s = RationalNumber(c, d)
 

--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -5,6 +5,18 @@ include("rational-numbers.jl")
 @test RationalNumber <: Real
 @test_throws ArgumentError RationalNumber(0, 0)
 
+@testset "Conversion and promotion" begin
+    # To pass these tests you should define a promote_rule method and a
+    # constructor, you don't need to define methods such as
+    # `==(a::RationalNumber{Int}, b::Int)`, `promote_type`, `convert`, etc.
+    #
+    # Read the manual for how to do this and why:
+    # https://docs.julialang.org/en/v1/manual/conversion-and-promotion/
+    @test RationalNumber{Int}(10) == 10
+    @test promote_type(Int, RationalNumber{Int}) == RationalNumber{Int}
+    @test convert(RationalNumber{Int8}, 2) <: RationalNumber{Int8}
+end
+
 @testset "One- & Zero-elements" begin
     @test zero(RationalNumber{Int}) == RationalNumber(0, 1)
     @test one(RationalNumber{Int})  == RationalNumber(1, 1)
@@ -16,6 +28,8 @@ end
         @test RationalNumber( 1, 2) + RationalNumber(-2, 3) == RationalNumber(-1, 6)
         @test RationalNumber(-1, 2) + RationalNumber(-2, 3) == RationalNumber(-7, 6)
         @test RationalNumber( 1, 2) + RationalNumber(-1, 2) == RationalNumber( 0, 1)
+        @test RationalNumber(1, 2) + 4 == RationalNumber(9, 2)
+        @test 4 + RationalNumber(1, 2) == RationalNumber(9, 2)
     end
 
     @testset "Subtraction" begin
@@ -101,19 +115,6 @@ end
     r = RationalNumber(3, -4)
     @test numerator(r)   == -3
     @test denominator(r) ==  4
-end
-
-@testset "Conversion and promotion" begin
-    # To pass these tests you should define a promote_rule method and a
-    # constructor, you don't need to define methods such as
-    # `==(a::RationalNumber{Int}, b::Int)`, `convert`, `promote`, etc.
-    #
-    # Read the manual for how to do this and why:
-    # https://docs.julialang.org/en/v1/manual/conversion-and-promotion/
-    @test RationalNumber{Int}(10) == 10
-    @test RationalNumber(1, 2) + 4 == RationalNumber(9, 2)
-    @test 4 + RationalNumber(1, 2) == RationalNumber(9, 2)
-    @test promote_type(Int, RationalNumber{Int}) == RationalNumber{Int}
 end
 
 # The following testset is based on the tests for rational numbers in Julia Base (MIT license)

--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -116,7 +116,6 @@ end
     @test promote_type(Int, RationalNumber{Int}) == RationalNumber{Int}
 end
 
-# TODO add to problem spec
 # The following testset is based on the tests for rational numbers in Julia Base (MIT license)
 # https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/test/rational.jl
 # https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/LICENSE.md

--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -134,8 +134,3 @@ end
         end
     end
 end
-
-@testset "Showing RationalNumbers" begin
-    @test sprint(show, RationalNumber(23, 42)) == "23//42"
-    @test sprint(show, RationalNumber(-2500, 5000)) == "-1//2"
-end

--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -14,7 +14,7 @@ include("rational-numbers.jl")
     # https://docs.julialang.org/en/v1/manual/conversion-and-promotion/
     @test RationalNumber{Int}(10) == 10
     @test promote_type(Int, RationalNumber{Int}) == RationalNumber{Int}
-    @test convert(RationalNumber{Int8}, 2) <: RationalNumber{Int8}
+    @test convert(RationalNumber{Int8}, 2) isa RationalNumber{Int8}
 end
 
 @testset "One- & Zero-elements" begin

--- a/exercises/practice/rational-numbers/runtests.jl
+++ b/exercises/practice/rational-numbers/runtests.jl
@@ -103,6 +103,19 @@ end
     @test denominator(r) ==  4
 end
 
+@testset "Conversion and promotion" begin
+    # To pass these tests you should define a promote_rule method and a
+    # constructor, you don't need to define methods such as
+    # `==(a::RationalNumber{Int}, b::Int)`, `convert`, `promote`, etc.
+    #
+    # Read the manual for how to do this and why:
+    # https://docs.julialang.org/en/v1/manual/conversion-and-promotion/
+    @test RationalNumber{Int}(10) == 10
+    @test RationalNumber(1, 2) + 4 == RationalNumber(9, 2)
+    @test 4 + RationalNumber(1, 2) == RationalNumber(9, 2)
+    @test promote_type(Int, RationalNumber{Int}) == RationalNumber{Int}
+end
+
 # TODO add to problem spec
 # The following testset is based on the tests for rational numbers in Julia Base (MIT license)
 # https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/test/rational.jl


### PR DESCRIPTION
These revisions make the rational numbers exercise easier by:

- introducing more tests (to guide the student to good solutions)
- making instructions more explicit
- removing tests that required correct handling of infinities (not specified in instructions)
- removing tests that required a custom `show` method (just not a good idea).

TODO: add an approach.

Closes #646 