### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/atbash-cipher/.approaches/introduction.md
+++ b/exercises/practice/atbash-cipher/.approaches/introduction.md
@@ -170,7 +170,7 @@ end
 
 A solution by [halfdan](https://exercism.io/tracks/julia/exercises/atbash-cipher/solutions/419b6f4d04974a63b7f8531e8ad2808c).
 
-```exercism/warning
+~~~~exercism/warning
 
 This solution will mangle non-[ascii][ascii] letter characters and pass-through symbols, separators, etc.
 because it assumes that `isletter(c)` is the same as `c in 'a':'z' || c in 'A':'Z'` (it actually matches all unicode letters).
@@ -178,7 +178,7 @@ This is a common mistake and can cause real issues!
 
 If you want to ensure your input is ascii you can use `ascii()`, or `isascii()`, or the Strs.jl package.
 
-```
+~~~~
 
 ```julia
 encode(input) = atbash(input, group=true)

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/rotational-cipher/.approaches/introduction.md
+++ b/exercises/practice/rotational-cipher/.approaches/introduction.md
@@ -56,7 +56,7 @@ This works because:
  └─ The beginning/base of the alphabet.
 ```
 
-```exercism/advanced
+~~~~exercism/advanced
 
 Iterating a UTF-8 string is slow because it's a variable length encoding. It is often faster to iterate a collection with elements of a fixed size (a vector of `UInt8`s from `transcode()` or an `ASCIIStr` (from Strs.jl), perhaps).
 
@@ -67,7 +67,7 @@ See the dig deeper pages for the [pangram][dd-pg], [nucleotide count][dd-nc], an
 [dd-nc]: https://exercism.org/tracks/julia/exercises/nucleotide-count/dig_deeper
 [dd-l]: https://exercism.org/tracks/julia/exercises/luhn/dig_deeper
 
-```
+~~~~
 
 ## Bonus macro task
 


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705