### PR TITLE
roman-numerals: remove redundant line from instructions

### DIFF
--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -40,6 +40,4 @@ In Roman numerals 1990 is MCMXC:
 2000=MM
 8=VIII
 
-There is no need to be able to convert numbers larger than about 3000.
-
 See also: [http://www.novaroma.org/via_romana/numbers.html](http://www.novaroma.org/via_romana/numbers.html)


### PR DESCRIPTION
It is part of instructions.append.md so currently shows up twice on the website.