### PR TITLE
Update tests in runtests.jl for perfect-numbers

### DIFF
--- a/exercises/practice/perfect-numbers/runtests.jl
+++ b/exercises/practice/perfect-numbers/runtests.jl
@@ -15,6 +15,11 @@ include("perfect-numbers.jl")
     @testset "Large perfect number is classified correctly" begin
         @test isperfect(33550336)
     end
+    
+    @testset "Correctly handles non-perfect numbers" begin
+        @test !isperfect(12)
+        @test !isperfect(4)
+    end
 end
 
 @testset "Abundant numbers" begin
@@ -29,6 +34,11 @@ end
 
     @testset "Large abundant number is classified correctly" begin
         @test isabundant(33550335)
+    end
+
+    @testset "Correctly handles non-abundant numbers" begin
+        @test !isabundant(6)
+        @test !isabundant(32)
     end
 end
 
@@ -52,6 +62,11 @@ end
 
     @testset "Edge case (no factors other than itself) is classified correctly" begin
         @test isdeficient(1)
+    end
+
+    @testset "Correctly handles non-deficient numbers" begin
+        @test !isdeficient(28)
+        @test !isdeficient(30)
     end
 end
 


### PR DESCRIPTION
Adds six tests which require the functions to return `false`, supplementing the previous testing whose inputs returned `true`, resolving [this issue](https://github.com/exercism/julia/issues/710)