### PR TITLE
Update circular-buffer example.jl

### DIFF
--- a/exercises/practice/circular-buffer/.meta/example.jl
+++ b/exercises/practice/circular-buffer/.meta/example.jl
@@ -2,8 +2,6 @@
 # tasks. The lengthier CircularBuffer afterward completes the bonus tasks and is optimized
 # for performance.
 
-module CircularDeques
-
 """
     CircularDeque{T}(n)
 
@@ -42,17 +40,9 @@ function Base.popfirst!(cd::CircularDeque)
     return cd.data[i]
 end
 
-end  # module CircularDeques
-
-using .CircularDeques
-
-
-module CircularBuffers
 
 using Base: @propagate_inbounds
 using Printf
-
-export CircularBuffer, capacity, isfull
 
 """
     CircularBuffer{T}(n) <: AbstractVector{T}
@@ -180,9 +170,5 @@ end
     cb.lastindex = (i == 1 ? capacity(cb) : i - 1)
     return out
 end
-
-end  # module CircularBuffers
-
-using .CircularBuffers
 
 enable_bonus_tests = true


### PR DESCRIPTION
Unwrapped the modules in example.jl in an attempt to resolve error occurring in `Julia nightly - OS` check suite.

Initial error read:
```
WARNING: both CircularBuffers and Base export "isfull"; uses of it in module anonymous must be qualified
When empty: Error During Test at /home/runner/work/julia/julia/exercises/practice/circular-buffer/runtests.jl:160
  Test threw exception
  Expression: isfull(cb) == false
  UndefVarError: `isfull` not defined in `Main.anonymous`
  Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. Try explicitly importing it from a particular module, or qualifying the name with the module it should come from.
  Hint: a global variable of this name also exists in Base.
```

I am unaware of an `isfull` method in Base, however, for my first attempt at a fix, I tried to add change the `isfull` methods to `Base.isfull`, which fixed the `Julia nightly - OS` checks, but broke the others, with the following error message:

```
circular-buffer: Error During Test at /home/runner/work/julia/julia/runtests.jl:19
  Got exception outside of a @test
  LoadError: LoadError: UndefVarError: isfull not defined
```

Disposing off the module wrappers in `example.jl` seems to have fixed the issue. However, why this issue appeared should probably be looked into.