### PR TITLE
Use explicit macos runner version

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ["1.6", "1", nightly]
-        os: [ubuntu-22.04, windows-2022, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macos-14]
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
@@ -52,11 +52,11 @@ jobs:
 
       - name: Install Julia dependencies
         run: julia --color=yes --project -e "using Pkg; Pkg.instantiate()"
-      
+
       - name: Generate test reports using julia-test-runner
         id: generate-reports
         run: julia --color=yes --project runtestrunner.jl
-      
+
       - name: Upload reports as artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:


### PR DESCRIPTION
This reduces the odds of things accidentally breaking