### PR TITLE
add practice exercise wordy

### DIFF
--- a/config.json
+++ b/config.json
@@ -977,6 +977,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3
+      },
+      {
+        "slug": "wordy",
+        "name": "Wordy",
+        "uuid": "1f6ffc9c-5996-4269-a9b8-cb4914e222dd",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       }
     ]
   },

--- a/exercises/practice/wordy/.docs/instructions.md
+++ b/exercises/practice/wordy/.docs/instructions.md
@@ -1,0 +1,59 @@
+# Instructions
+
+Parse and evaluate simple math word problems returning the answer as an integer.
+
+## Iteration 0 — Numbers
+
+Problems with no operations simply evaluate to the number given.
+
+> What is 5?
+
+Evaluates to 5.
+
+## Iteration 1 — Addition
+
+Add two numbers together.
+
+> What is 5 plus 13?
+
+Evaluates to 18.
+
+Handle large numbers and negative numbers.
+
+## Iteration 2 — Subtraction, Multiplication and Division
+
+Now, perform the other three operations.
+
+> What is 7 minus 5?
+
+2
+
+> What is 6 multiplied by 4?
+
+24
+
+> What is 25 divided by 5?
+
+5
+
+## Iteration 3 — Multiple Operations
+
+Handle a set of operations, in sequence.
+
+Since these are verbal word problems, evaluate the expression from left-to-right, _ignoring the typical order of operations._
+
+> What is 5 plus 13 plus 6?
+
+24
+
+> What is 3 plus 2 multiplied by 3?
+
+15 (i.e. not 9)
+
+## Iteration 4 — Errors
+
+The parser should reject:
+
+- Unsupported operations ("What is 52 cubed?")
+- Non-math questions ("Who is the President of the United States")
+- Word problems with invalid syntax ("What is 1 plus plus 2?")

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "wordy.jl"
+    ],
+    "test": [
+      "runtests.jl"
+    ],
+    "example": [
+      ".meta/example.jl"
+    ]
+  },
+  "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
+  "source": "Inspired by one of the generated questions in the Extreme Startup game.",
+  "source_url": "https://github.com/rchatley/extreme_startup"
+}

--- a/exercises/practice/wordy/.meta/example.jl
+++ b/exercises/practice/wordy/.meta/example.jl
@@ -1,0 +1,14 @@
+MATHEXPRESSION = r"-?\d+\.?\d* [-+*/] -?\d+\.?\d*"  #Regex which, for x,y ∈ R and op ∈ {+,-,/,*}, matches: "x op y" 
+NUMBER = r"^-?\d+\.?\d*$"                           #Regex which matches a string consisting solely of a single n ∈ R
+ENG2MATH = zip(("plus","minus","divided by","multiplied by","What is ","?"), ("+","-","/","*","",""))
+
+function evalwordy(eq)
+    expr = match(MATHEXPRESSION, eq)
+    isnothing(expr) ? match(NUMBER, eq) : evalwordy(replace(eq, expr.match => (Base.eval ∘ Meta.parse)(expr.match), count=1))
+end
+
+function wordy(problem)
+    foreach(op -> problem = replace(problem, first(op) => last(op)), ENG2MATH)
+    answer = evalwordy(problem)
+    isnothing(answer) ? throw(ArgumentError(problem)) : Meta.parse(answer.match)
+end

--- a/exercises/practice/wordy/.meta/tests.toml
+++ b/exercises/practice/wordy/.meta/tests.toml
@@ -1,0 +1,79 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[88bf4b28-0de3-4883-93c7-db1b14aa806e]
+description = "just a number"
+
+[bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0]
+description = "addition"
+
+[79e49e06-c5ae-40aa-a352-7a3a01f70015]
+description = "more addition"
+
+[b345dbe0-f733-44e1-863c-5ae3568f3803]
+description = "addition with negative numbers"
+
+[cd070f39-c4cc-45c4-97fb-1be5e5846f87]
+description = "large addition"
+
+[0d86474a-cd93-4649-a4fa-f6109a011191]
+description = "subtraction"
+
+[30bc8395-5500-4712-a0cf-1d788a529be5]
+description = "multiplication"
+
+[34c36b08-8605-4217-bb57-9a01472c427f]
+description = "division"
+
+[da6d2ce4-fb94-4d26-8f5f-b078adad0596]
+description = "multiple additions"
+
+[7fd74c50-9911-4597-be09-8de7f2fea2bb]
+description = "addition and subtraction"
+
+[b120ffd5-bad6-4e22-81c8-5512e8faf905]
+description = "multiple subtraction"
+
+[4f4a5749-ef0c-4f60-841f-abcfaf05d2ae]
+description = "subtraction then addition"
+
+[312d908c-f68f-42c9-aa75-961623cc033f]
+description = "multiple multiplication"
+
+[38e33587-8940-4cc1-bc28-bfd7e3966276]
+description = "addition and multiplication"
+
+[3c854f97-9311-46e8-b574-92b60d17d394]
+description = "multiple division"
+
+[3ad3e433-8af7-41ec-aa9b-97b42ab49357]
+description = "unknown operation"
+
+[8a7e85a8-9e7b-4d46-868f-6d759f4648f8]
+description = "Non math question"
+
+[42d78b5f-dbd7-4cdb-8b30-00f794bb24cf]
+description = "reject problem missing an operand"
+
+[c2c3cbfc-1a72-42f2-b597-246e617e66f5]
+description = "reject problem with no operands or operators"
+
+[4b3df66d-6ed5-4c95-a0a1-d38891fbdab6]
+description = "reject two operations in a row"
+
+[6abd7a50-75b4-4665-aa33-2030fd08bab1]
+description = "reject two numbers in a row"
+
+[10a56c22-e0aa-405f-b1d2-c642d9c4c9de]
+description = "reject postfix notation"
+
+[0035bc63-ac43-4bb5-ad6d-e8651b7d954e]
+description = "reject prefix notation"

--- a/exercises/practice/wordy/runtests.jl
+++ b/exercises/practice/wordy/runtests.jl
@@ -1,0 +1,97 @@
+using Test
+
+include("wordy.jl")
+
+@testset verbose = true "tests" begin
+    @testset "just a number" begin
+        @test wordy("What is 5?") == 5
+    end
+    
+    @testset "addition" begin
+        @test wordy("What is 1 plus 1?") == 2
+    end
+    
+    @testset "more addition" begin
+        @test wordy("What is 53 plus 2?") == 55
+    end
+    
+    @testset "addition with negative numbers" begin
+        @test wordy("What is -1 plus -10?") == -11
+    end
+    
+    @testset "large addition" begin
+        @test wordy("What is 123 plus 45678?") == 45801
+    end
+    
+    @testset "subtraction" begin
+        @test wordy("What is 4 minus -12?") == 16
+    end
+    
+    @testset "multiplication" begin
+        @test wordy("What is -3 multiplied by 25?") == -75
+    end
+    
+    @testset "division" begin
+        @test wordy("What is 33 divided by -3?") == -11
+    end
+    
+    @testset "multiple additions" begin
+        @test wordy("What is 1 plus 1 plus 1?") == 3
+    end
+    
+    @testset "addition and subtraction" begin
+        @test wordy("What is 1 plus 5 minus -2?") == 8
+    end
+    
+    @testset "multiple subtraction" begin
+        @test wordy("What is 20 minus 4 minus 13?") == 3
+    end
+    
+    @testset "subtraction then addition" begin
+        @test wordy("What is 17 minus 6 plus 3?") == 14
+    end
+    
+    @testset "multiple multiplication" begin
+        @test wordy("What is 2 multiplied by -2 multiplied by 3?") == -12
+    end
+    
+    @testset "addition and multiplication" begin
+        @test wordy("What is -3 plus 7 multiplied by -2?") == -8
+    end
+    
+    @testset "multiple division" begin
+        @test wordy("What is -12 divided by 2 divided by -3?") == 2
+    end
+    
+    @testset "unknown operation" begin
+        @test_throws ArgumentError wordy("What is 52 cubed?")
+    end
+    
+    @testset "Non math question" begin
+        @test_throws ArgumentError wordy("Who is the President of the United States?")
+    end
+    
+    @testset "reject problem missing an operand" begin
+        @test_throws ArgumentError wordy("What is 1 plus?")
+    end
+    
+    @testset "reject problem with no operands or operators" begin
+        @test_throws ArgumentError wordy("What is?")
+    end
+    
+    @testset "reject two operations in a row" begin
+        @test_throws ArgumentError wordy("What is 1 plus plus 2?")
+    end
+    
+    @testset "reject two numbers in a row" begin
+        @test_throws ArgumentError wordy("What is 1 plus 2 1?")
+    end
+    
+    @testset "reject postfix notation" begin
+        @test_throws ArgumentError wordy("What is 1 2 plus?")
+    end
+    
+    @testset "reject prefix notation" begin
+        @test_throws ArgumentError wordy("What is plus 1 2?")
+    end
+end

--- a/exercises/practice/wordy/wordy.jl
+++ b/exercises/practice/wordy/wordy.jl
@@ -1,0 +1,3 @@
+function wordy(problem)
+    # your code here
+end


### PR DESCRIPTION
Adding practice exercise `wordy` according to `problem-specifications`. A couple things to note:

- Difficulty set at 3, but 4 could be possible due to needing regex or otherwise having slightly complicated error handling.

That is all for the note for the implementation, but there is something I've found about being able to "hack" the error handling questions.

Below is an algorithm which doesn't use regex. Please note the line which is commented out:

```julia

ENG2MATH = zip(("plus","minus","divided by","multiplied by","What is ","?"), ("+","-","/","*","",""))
ops = Dict(zip(("+","-","/","*"), (+,-,/,*)))

function wordy(problem)
    foreach(op -> problem = replace(problem, first(op) => last(op)), ENG2MATH)
    terms = split(problem)
    #iseven(length(terms)) && throw(ArgumentError(problem)) 
    total, operands = parse(Int, first(terms)), [+, 0]
    for (i, term) in enumerate(terms[2:end])
        try 
            operands[mod1(i, 2)] = isodd(i) ? ops[term] : parse(Int, term)
        catch error
            throw(ArgumentError(problem)) 
        end 
        iseven(i) && (total = first(operands)(total, last(operands)))
    end
    iseven(length(terms)) ? throw(ArgumentError(problem)) : total
end

```

When that line is commented in, and other error handling isn't implemented (i.e. try/catch block and final trinary), this will pass 7 out of 8 of the error handling tests, while it is only valid for two of them. The others that pass are "happy coincidences". For example, it passes with input `"Who is the President of the United States?"` but wouldn't pass `"Who is the Prime Minister of India"`, simply because of word count (since a valid math expression has to have an odd number of operands). I'm not sure if this loophole should be changed or not