### PR TITLE
add practice exercise meetup

### DIFF
--- a/config.json
+++ b/config.json
@@ -995,6 +995,14 @@
         "difficulty": 2
       },
       {
+        "slug": "meetup",
+        "name": "Meetup",
+        "uuid": "c620a897-b054-4d8e-a2e3-17a4c0a6f6fa",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
         "slug": "palindrome-products",
         "name": "Palindrome Products",
         "uuid": "7ab2d0e6-6a39-4edf-86e9-1e49dfb8908e",

--- a/exercises/practice/meetup/.docs/instructions.md
+++ b/exercises/practice/meetup/.docs/instructions.md
@@ -1,0 +1,34 @@
+# Instructions
+
+Your task is to find the exact date of a meetup, given a month, year, weekday and week.
+
+There are five week values to consider: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
+
+For example, you might be asked to find the date for the meetup on the first Monday in January 2018 (January 1, 2018).
+
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
+- the teenth Saturday of August 1953 (August 15, 1953)
+
+## Teenth
+
+The teenth week refers to the seven days in a month that end in '-teenth' (13th, 14th, 15th, 16th, 17th, 18th and 19th).
+
+If asked to find the teenth Saturday of August, 1953, we check its calendar:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+From this we find that the teenth Saturday is August 15, 1953.

--- a/exercises/practice/meetup/.docs/introduction.md
+++ b/exercises/practice/meetup/.docs/introduction.md
@@ -1,0 +1,29 @@
+# Introduction
+
+Every month, your partner meets up with their best friend.
+Both of them have very busy schedules, making it challenging to find a suitable date!
+Given your own busy schedule, your partner always double-checks potential meetup dates with you:
+
+- "Can I meet up on the first Friday of next month?"
+- "What about the third Wednesday?"
+- "Maybe the last Sunday?"
+
+In this month's call, your partner asked you this question:
+
+- "I'd like to meet up on the teenth Thursday; is that okay?"
+
+Confused, you ask what a "teenth" day is.
+Your partner explains that a teenth day, a concept they made up, refers to the days in a month that end in '-teenth':
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+As there are also seven weekdays, it is guaranteed that each day of the week has _exactly one_ teenth day each month.
+
+Now that you understand the concept of a teenth day, you check your calendar.
+You don't have anything planned on the teenth Thursday, so you happily confirm the date with your partner.

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,0 +1,18 @@
+{
+  "authors": [
+    "colinleach"
+  ],
+  "files": {
+    "solution": [
+      "meetup.jl"
+    ],
+    "test": [
+      "runtests.jl"
+    ],
+    "example": [
+      ".meta/example.jl"
+    ]
+  },
+  "blurb": "Calculate the date of meetups.",
+  "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month"
+}

--- a/exercises/practice/meetup/.meta/example.jl
+++ b/exercises/practice/meetup/.meta/example.jl
@@ -1,0 +1,3 @@
+function meetup(year, month, week, dayofweek)
+
+end

--- a/exercises/practice/meetup/.meta/example.jl
+++ b/exercises/practice/meetup/.meta/example.jl
@@ -1,3 +1,25 @@
-function meetup(year, month, week, dayofweek)
+using Dates
 
+const week_specifiers = Dict("first" => 1, "second" => 2, "third" => 3, "fourth" => 4, "fifth" => 5)
+
+function meetup(year, month, week, dayofweek)
+    currmonth = Date(year, month)
+    days = [Date(year, month, d) for d in 1:Dates.daysinmonth(currmonth)]
+    valid_dates = [d for d in days if Dates.dayname(d) == dayofweek]
+
+    if week ∈ keys(week_specifiers) && length(valid_dates) ≥ week_specifiers[week]
+        return valid_dates[week_specifiers[week]]
+    end
+
+    if week == "last"
+        return valid_dates[end]
+    end
+
+    if week == "teenth"
+        teenth = [d for d in valid_dates if 13 <= Dates.day(d) <= 19]
+        @assert length(teenth) == 1
+        return teenth[1]
+    end
+
+    throw(DomainError(week, "That day does not exist"))
 end

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -1,0 +1,295 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
+description = "when teenth Monday is the 13th, the first day of the teenth week"
+
+[f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
+description = "when teenth Monday is the 19th, the last day of the teenth week"
+
+[8c78bea7-a116-425b-9c6b-c9898266d92a]
+description = "when teenth Monday is some day in the middle of the teenth week"
+
+[cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
+description = "when teenth Tuesday is the 19th, the last day of the teenth week"
+
+[69048961-3b00-41f9-97ee-eb6d83a8e92b]
+description = "when teenth Tuesday is some day in the middle of the teenth week"
+
+[d30bade8-3622-466a-b7be-587414e0caa6]
+description = "when teenth Tuesday is the 13th, the first day of the teenth week"
+
+[8db4b58b-92f3-4687-867b-82ee1a04f851]
+description = "when teenth Wednesday is some day in the middle of the teenth week"
+
+[6c27a2a2-28f8-487f-ae81-35d08c4664f7]
+description = "when teenth Wednesday is the 13th, the first day of the teenth week"
+
+[008a8674-1958-45b5-b8e6-c2c9960d973a]
+description = "when teenth Wednesday is the 19th, the last day of the teenth week"
+
+[e4abd5e3-57cb-4091-8420-d97e955c0dbd]
+description = "when teenth Thursday is some day in the middle of the teenth week"
+
+[85da0b0f-eace-4297-a6dd-63588d5055b4]
+description = "when teenth Thursday is the 13th, the first day of the teenth week"
+
+[ecf64f9b-8413-489b-bf6e-128045f70bcc]
+description = "when teenth Thursday is the 19th, the last day of the teenth week"
+
+[ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
+description = "when teenth Friday is the 19th, the last day of the teenth week"
+
+[b79101c7-83ad-4f8f-8ec8-591683296315]
+description = "when teenth Friday is some day in the middle of the teenth week"
+
+[6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
+description = "when teenth Friday is the 13th, the first day of the teenth week"
+
+[dfae03ed-9610-47de-a632-655ab01e1e7c]
+description = "when teenth Saturday is some day in the middle of the teenth week"
+
+[ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
+description = "when teenth Saturday is the 13th, the first day of the teenth week"
+
+[d983094b-7259-4195-b84e-5d09578c89d9]
+description = "when teenth Saturday is the 19th, the last day of the teenth week"
+
+[d84a2a2e-f745-443a-9368-30051be60c2e]
+description = "when teenth Sunday is the 19th, the last day of the teenth week"
+
+[0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
+description = "when teenth Sunday is some day in the middle of the teenth week"
+
+[de87652c-185e-4854-b3ae-04cf6150eead]
+description = "when teenth Sunday is the 13th, the first day of the teenth week"
+
+[2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
+description = "when first Monday is some day in the middle of the first week"
+
+[a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
+description = "when first Monday is the 1st, the first day of the first week"
+
+[1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
+description = "when first Tuesday is the 7th, the last day of the first week"
+
+[12959c10-7362-4ca0-a048-50cf1c06e3e2]
+description = "when first Tuesday is some day in the middle of the first week"
+
+[1033dc66-8d0b-48a1-90cb-270703d59d1d]
+description = "when first Wednesday is some day in the middle of the first week"
+
+[b89185b9-2f32-46f4-a602-de20b09058f6]
+description = "when first Wednesday is the 7th, the last day of the first week"
+
+[53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
+description = "when first Thursday is some day in the middle of the first week"
+
+[b420a7e3-a94c-4226-870a-9eb3a92647f0]
+description = "when first Thursday is another day in the middle of the first week"
+
+[61df3270-28b4-4713-bee2-566fa27302ca]
+description = "when first Friday is the 1st, the first day of the first week"
+
+[cad33d4d-595c-412f-85cf-3874c6e07abf]
+description = "when first Friday is some day in the middle of the first week"
+
+[a2869b52-5bba-44f0-a863-07bd1f67eadb]
+description = "when first Saturday is some day in the middle of the first week"
+
+[3585315a-d0db-4ea1-822e-0f22e2a645f5]
+description = "when first Saturday is another day in the middle of the first week"
+
+[c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
+description = "when first Sunday is some day in the middle of the first week"
+
+[1513328b-df53-4714-8677-df68c4f9366c]
+description = "when first Sunday is the 7th, the last day of the first week"
+
+[49e083af-47ec-4018-b807-62ef411efed7]
+description = "when second Monday is some day in the middle of the second week"
+
+[6cb79a73-38fe-4475-9101-9eec36cf79e5]
+description = "when second Monday is the 8th, the first day of the second week"
+
+[4c39b594-af7e-4445-aa03-bf4f8effd9a1]
+description = "when second Tuesday is the 14th, the last day of the second week"
+
+[41b32c34-2e39-40e3-b790-93539aaeb6dd]
+description = "when second Tuesday is some day in the middle of the second week"
+
+[90a160c5-b5d9-4831-927f-63a78b17843d]
+description = "when second Wednesday is some day in the middle of the second week"
+
+[23b98ce7-8dd5-41a1-9310-ef27209741cb]
+description = "when second Wednesday is the 14th, the last day of the second week"
+
+[447f1960-27ca-4729-bc3f-f36043f43ed0]
+description = "when second Thursday is some day in the middle of the second week"
+
+[c9aa2687-300c-4e79-86ca-077849a81bde]
+description = "when second Thursday is another day in the middle of the second week"
+
+[a7e11ef3-6625-4134-acda-3e7195421c09]
+description = "when second Friday is the 8th, the first day of the second week"
+
+[8b420e5f-9290-4106-b5ae-022f3e2a3e41]
+description = "when second Friday is some day in the middle of the second week"
+
+[80631afc-fc11-4546-8b5f-c12aaeb72b4f]
+description = "when second Saturday is some day in the middle of the second week"
+
+[e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
+description = "when second Saturday is another day in the middle of the second week"
+
+[a57d59fd-1023-47ad-b0df-a6feb21b44fc]
+description = "when second Sunday is some day in the middle of the second week"
+
+[a829a8b0-abdd-4ad1-b66c-5560d843c91a]
+description = "when second Sunday is the 14th, the last day of the second week"
+
+[501a8a77-6038-4fc0-b74c-33634906c29d]
+description = "when third Monday is some day in the middle of the third week"
+
+[49e4516e-cf32-4a58-8bbc-494b7e851c92]
+description = "when third Monday is the 15th, the first day of the third week"
+
+[4db61095-f7c7-493c-85f1-9996ad3012c7]
+description = "when third Tuesday is the 21st, the last day of the third week"
+
+[714fc2e3-58d0-4b91-90fd-61eefd2892c0]
+description = "when third Tuesday is some day in the middle of the third week"
+
+[b08a051a-2c80-445b-9b0e-524171a166d1]
+description = "when third Wednesday is some day in the middle of the third week"
+
+[80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
+description = "when third Wednesday is the 21st, the last day of the third week"
+
+[fa52a299-f77f-4784-b290-ba9189fbd9c9]
+description = "when third Thursday is some day in the middle of the third week"
+
+[f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
+description = "when third Thursday is another day in the middle of the third week"
+
+[8900f3b0-801a-466b-a866-f42d64667abd]
+description = "when third Friday is the 15th, the first day of the third week"
+
+[538ac405-a091-4314-9ccd-920c4e38e85e]
+description = "when third Friday is some day in the middle of the third week"
+
+[244db35c-2716-4fa0-88ce-afd58e5cf910]
+description = "when third Saturday is some day in the middle of the third week"
+
+[dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
+description = "when third Saturday is another day in the middle of the third week"
+
+[be71dcc6-00d2-4b53-a369-cbfae55b312f]
+description = "when third Sunday is some day in the middle of the third week"
+
+[b7d2da84-4290-4ee6-a618-ee124ae78be7]
+description = "when third Sunday is the 21st, the last day of the third week"
+
+[4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
+description = "when fourth Monday is some day in the middle of the fourth week"
+
+[ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
+description = "when fourth Monday is the 22nd, the first day of the fourth week"
+
+[eb714ef4-1656-47cc-913c-844dba4ebddd]
+description = "when fourth Tuesday is the 28th, the last day of the fourth week"
+
+[16648435-7937-4d2d-b118-c3e38fd084bd]
+description = "when fourth Tuesday is some day in the middle of the fourth week"
+
+[de062bdc-9484-437a-a8c5-5253c6f6785a]
+description = "when fourth Wednesday is some day in the middle of the fourth week"
+
+[c2ce6821-169c-4832-8d37-690ef5d9514a]
+description = "when fourth Wednesday is the 28th, the last day of the fourth week"
+
+[d462c631-2894-4391-a8e3-dbb98b7a7303]
+description = "when fourth Thursday is some day in the middle of the fourth week"
+
+[9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
+description = "when fourth Thursday is another day in the middle of the fourth week"
+
+[83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
+description = "when fourth Friday is the 22nd, the first day of the fourth week"
+
+[de752d2a-a95e-48d2-835b-93363dac3710]
+description = "when fourth Friday is some day in the middle of the fourth week"
+
+[eedd90ad-d581-45db-8312-4c6dcf9cf560]
+description = "when fourth Saturday is some day in the middle of the fourth week"
+
+[669fedcd-912e-48c7-a0a1-228b34af91d0]
+description = "when fourth Saturday is another day in the middle of the fourth week"
+
+[648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
+description = "when fourth Sunday is some day in the middle of the fourth week"
+
+[f81321b3-99ab-4db6-9267-69c5da5a7823]
+description = "when fourth Sunday is the 28th, the last day of the fourth week"
+
+[1af5e51f-5488-4548-aee8-11d7d4a730dc]
+description = "last Monday in a month with four Mondays"
+
+[f29999f2-235e-4ec7-9dab-26f137146526]
+description = "last Monday in a month with five Mondays"
+
+[31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
+description = "last Tuesday in a month with four Tuesdays"
+
+[8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
+description = "last Tuesday in another month with four Tuesdays"
+
+[0e762194-672a-4bdf-8a37-1e59fdacef12]
+description = "last Wednesday in a month with five Wednesdays"
+
+[5016386a-f24e-4bd7-b439-95358f491b66]
+description = "last Wednesday in a month with four Wednesdays"
+
+[12ead1a5-cdf9-4192-9a56-2229e93dd149]
+description = "last Thursday in a month with four Thursdays"
+
+[7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
+description = "last Thursday in a month with five Thursdays"
+
+[e47a739e-b979-460d-9c8a-75c35ca2290b]
+description = "last Friday in a month with five Fridays"
+
+[5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
+description = "last Friday in a month with four Fridays"
+
+[61e54cba-76f3-4772-a2b1-bf443fda2137]
+description = "last Saturday in a month with four Saturdays"
+
+[8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
+description = "last Saturday in another month with four Saturdays"
+
+[0b63e682-f429-4d19-9809-4a45bd0242dc]
+description = "last Sunday in a month with five Sundays"
+
+[5232307e-d3e3-4afc-8ba6-4084ad987c00]
+description = "last Sunday in a month with four Sundays"
+
+[0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
+description = "when last Wednesday in February in a leap year is the 29th"
+
+[fe0936de-7eee-4a48-88dd-66c07ab1fefc]
+description = "last Wednesday in December that is also the last day of the year"
+
+[2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
+description = "when last Sunday in February in a non-leap year is not the 29th"
+
+[00c3ce9f-cf36-4b70-90d8-92b32be6830e]
+description = "when first Friday is the 7th, the last day of the first week"

--- a/exercises/practice/meetup/meetup.jl
+++ b/exercises/practice/meetup/meetup.jl
@@ -1,25 +1,3 @@
-using Dates
-
-const week_specifiers = Dict("first" => 1, "second" => 2, "third" => 3, "fourth" => 4, "fifth" => 5)
-
 function meetup(year, month, week, dayofweek)
-    currmonth = Date(year, month)
-    days = [Date(year, month, d) for d in 1:Dates.daysinmonth(currmonth)]
-    valid_dates = [d for d in days if Dates.dayname(d) == dayofweek]
 
-    if week ∈ keys(week_specifiers) && length(valid_dates) ≥ week_specifiers[week]
-        return valid_dates[week_specifiers[week]]
-    end
-
-    if week == "last"
-        return valid_dates[end]
-    end
-
-    if week == "teenth"
-        teenth = [d for d in valid_dates if 13 <= Dates.day(d) <= 19]
-        @assert length(teenth) == 1
-        return teenth[1]
-    end
-
-    throw(DomainError(week, "That day does not exist"))
 end

--- a/exercises/practice/meetup/meetup.jl
+++ b/exercises/practice/meetup/meetup.jl
@@ -1,0 +1,25 @@
+using Dates
+
+const week_specifiers = Dict("first" => 1, "second" => 2, "third" => 3, "fourth" => 4, "fifth" => 5)
+
+function meetup(year, month, week, dayofweek)
+    currmonth = Date(year, month)
+    days = [Date(year, month, d) for d in 1:Dates.daysinmonth(currmonth)]
+    valid_dates = [d for d in days if Dates.dayname(d) == dayofweek]
+
+    if week ∈ keys(week_specifiers) && length(valid_dates) ≥ week_specifiers[week]
+        return valid_dates[week_specifiers[week]]
+    end
+
+    if week == "last"
+        return valid_dates[end]
+    end
+
+    if week == "teenth"
+        teenth = [d for d in valid_dates if 13 <= Dates.day(d) <= 19]
+        @assert length(teenth) == 1
+        return teenth[1]
+    end
+
+    throw(DomainError(week, "That day does not exist"))
+end

--- a/exercises/practice/meetup/runtests.jl
+++ b/exercises/practice/meetup/runtests.jl
@@ -1,0 +1,388 @@
+using Test
+using Dates
+
+include("meetup.jl")
+
+@testset verbose = true "tests" begin
+
+    @testset "when teenth Monday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 5, "teenth", "Monday") == Date("2013-05-13", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Monday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 8, "teenth", "Monday") == Date("2013-08-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Monday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 9, "teenth", "Monday") == Date("2013-09-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Tuesday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 3, "teenth", "Tuesday") == Date("2013-03-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Tuesday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 4, "teenth", "Tuesday") == Date("2013-04-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Tuesday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 8, "teenth", "Tuesday") == Date("2013-08-13", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Wednesday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 1, "teenth", "Wednesday") == Date("2013-01-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Wednesday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 2, "teenth", "Wednesday") == Date("2013-02-13", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Wednesday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 6, "teenth", "Wednesday") == Date("2013-06-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Thursday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 5, "teenth", "Thursday") == Date("2013-05-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Thursday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 6, "teenth", "Thursday") == Date("2013-06-13", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Thursday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 9, "teenth", "Thursday") == Date("2013-09-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Friday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 4, "teenth", "Friday") == Date("2013-04-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Friday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 8, "teenth", "Friday") == Date("2013-08-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Friday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 9, "teenth", "Friday") == Date("2013-09-13", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Saturday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 2, "teenth", "Saturday") == Date("2013-02-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Saturday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 4, "teenth", "Saturday") == Date("2013-04-13", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Saturday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 10, "teenth", "Saturday") == Date("2013-10-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Sunday is the 19th, the last day of the teenth week" begin
+        @test meetup(2013, 5, "teenth", "Sunday") == Date("2013-05-19", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Sunday is some day in the middle of the teenth week" begin
+        @test meetup(2013, 6, "teenth", "Sunday") == Date("2013-06-16", dateformat"y-m-d")
+    end
+
+    @testset "when teenth Sunday is the 13th, the first day of the teenth week" begin
+        @test meetup(2013, 10, "teenth", "Sunday") == Date("2013-10-13", dateformat"y-m-d")
+    end
+
+    @testset "when first Monday is some day in the middle of the first week" begin
+        @test meetup(2013, 3, "first", "Monday") == Date("2013-03-04", dateformat"y-m-d")
+    end
+
+    @testset "when first Monday is the 1st, the first day of the first week" begin
+        @test meetup(2013, 4, "first", "Monday") == Date("2013-04-01", dateformat"y-m-d")
+    end
+
+    @testset "when first Tuesday is the 7th, the last day of the first week" begin
+        @test meetup(2013, 5, "first", "Tuesday") == Date("2013-05-07", dateformat"y-m-d")
+    end
+
+    @testset "when first Tuesday is some day in the middle of the first week" begin
+        @test meetup(2013, 6, "first", "Tuesday") == Date("2013-06-04", dateformat"y-m-d")
+    end
+
+    @testset "when first Wednesday is some day in the middle of the first week" begin
+        @test meetup(2013, 7, "first", "Wednesday") == Date("2013-07-03", dateformat"y-m-d")
+    end
+
+    @testset "when first Wednesday is the 7th, the last day of the first week" begin
+        @test meetup(2013, 8, "first", "Wednesday") == Date("2013-08-07", dateformat"y-m-d")
+    end
+
+    @testset "when first Thursday is some day in the middle of the first week" begin
+        @test meetup(2013, 9, "first", "Thursday") == Date("2013-09-05", dateformat"y-m-d")
+    end
+
+    @testset "when first Thursday is another day in the middle of the first week" begin
+        @test meetup(2013, 10, "first", "Thursday") == Date("2013-10-03", dateformat"y-m-d")
+    end
+
+    @testset "when first Friday is the 1st, the first day of the first week" begin
+        @test meetup(2013, 11, "first", "Friday") == Date("2013-11-01", dateformat"y-m-d")
+    end
+
+    @testset "when first Friday is some day in the middle of the first week" begin
+        @test meetup(2013, 12, "first", "Friday") == Date("2013-12-06", dateformat"y-m-d")
+    end
+
+    @testset "when first Saturday is some day in the middle of the first week" begin
+        @test meetup(2013, 1, "first", "Saturday") == Date("2013-01-05", dateformat"y-m-d")
+    end
+
+    @testset "when first Saturday is another day in the middle of the first week" begin
+        @test meetup(2013, 2, "first", "Saturday") == Date("2013-02-02", dateformat"y-m-d")
+    end
+
+    @testset "when first Sunday is some day in the middle of the first week" begin
+        @test meetup(2013, 3, "first", "Sunday") == Date("2013-03-03", dateformat"y-m-d")
+    end
+
+    @testset "when first Sunday is the 7th, the last day of the first week" begin
+        @test meetup(2013, 4, "first", "Sunday") == Date("2013-04-07", dateformat"y-m-d")
+    end
+
+    @testset "when second Monday is some day in the middle of the second week" begin
+        @test meetup(2013, 3, "second", "Monday") == Date("2013-03-11", dateformat"y-m-d")
+    end
+
+    @testset "when second Monday is the 8th, the first day of the second week" begin
+        @test meetup(2013, 4, "second", "Monday") == Date("2013-04-08", dateformat"y-m-d")
+    end
+
+    @testset "when second Tuesday is the 14th, the last day of the second week" begin
+        @test meetup(2013, 5, "second", "Tuesday") == Date("2013-05-14", dateformat"y-m-d")
+    end
+
+    @testset "when second Tuesday is some day in the middle of the second week" begin
+        @test meetup(2013, 6, "second", "Tuesday") == Date("2013-06-11", dateformat"y-m-d")
+    end
+
+    @testset "when second Wednesday is some day in the middle of the second week" begin
+        @test meetup(2013, 7, "second", "Wednesday") == Date("2013-07-10", dateformat"y-m-d")
+    end
+
+    @testset "when second Wednesday is the 14th, the last day of the second week" begin
+        @test meetup(2013, 8, "second", "Wednesday") == Date("2013-08-14", dateformat"y-m-d")
+    end
+
+    @testset "when second Thursday is some day in the middle of the second week" begin
+        @test meetup(2013, 9, "second", "Thursday") == Date("2013-09-12", dateformat"y-m-d")
+    end
+
+    @testset "when second Thursday is another day in the middle of the second week" begin
+        @test meetup(2013, 10, "second", "Thursday") == Date("2013-10-10", dateformat"y-m-d")
+    end
+
+    @testset "when second Friday is the 8th, the first day of the second week" begin
+        @test meetup(2013, 11, "second", "Friday") == Date("2013-11-08", dateformat"y-m-d")
+    end
+
+    @testset "when second Friday is some day in the middle of the second week" begin
+        @test meetup(2013, 12, "second", "Friday") == Date("2013-12-13", dateformat"y-m-d")
+    end
+
+    @testset "when second Saturday is some day in the middle of the second week" begin
+        @test meetup(2013, 1, "second", "Saturday") == Date("2013-01-12", dateformat"y-m-d")
+    end
+
+    @testset "when second Saturday is another day in the middle of the second week" begin
+        @test meetup(2013, 2, "second", "Saturday") == Date("2013-02-09", dateformat"y-m-d")
+    end
+
+    @testset "when second Sunday is some day in the middle of the second week" begin
+        @test meetup(2013, 3, "second", "Sunday") == Date("2013-03-10", dateformat"y-m-d")
+    end
+
+    @testset "when second Sunday is the 14th, the last day of the second week" begin
+        @test meetup(2013, 4, "second", "Sunday") == Date("2013-04-14", dateformat"y-m-d")
+    end
+
+    @testset "when third Monday is some day in the middle of the third week" begin
+        @test meetup(2013, 3, "third", "Monday") == Date("2013-03-18", dateformat"y-m-d")
+    end
+
+    @testset "when third Monday is the 15th, the first day of the third week" begin
+        @test meetup(2013, 4, "third", "Monday") == Date("2013-04-15", dateformat"y-m-d")
+    end
+
+    @testset "when third Tuesday is the 21st, the last day of the third week" begin
+        @test meetup(2013, 5, "third", "Tuesday") == Date("2013-05-21", dateformat"y-m-d")
+    end
+
+    @testset "when third Tuesday is some day in the middle of the third week" begin
+        @test meetup(2013, 6, "third", "Tuesday") == Date("2013-06-18", dateformat"y-m-d")
+    end
+
+    @testset "when third Wednesday is some day in the middle of the third week" begin
+        @test meetup(2013, 7, "third", "Wednesday") == Date("2013-07-17", dateformat"y-m-d")
+    end
+
+    @testset "when third Wednesday is the 21st, the last day of the third week" begin
+        @test meetup(2013, 8, "third", "Wednesday") == Date("2013-08-21", dateformat"y-m-d")
+    end
+
+    @testset "when third Thursday is some day in the middle of the third week" begin
+        @test meetup(2013, 9, "third", "Thursday") == Date("2013-09-19", dateformat"y-m-d")
+    end
+
+    @testset "when third Thursday is another day in the middle of the third week" begin
+        @test meetup(2013, 10, "third", "Thursday") == Date("2013-10-17", dateformat"y-m-d")
+    end
+
+    @testset "when third Friday is the 15th, the first day of the third week" begin
+        @test meetup(2013, 11, "third", "Friday") == Date("2013-11-15", dateformat"y-m-d")
+    end
+
+    @testset "when third Friday is some day in the middle of the third week" begin
+        @test meetup(2013, 12, "third", "Friday") == Date("2013-12-20", dateformat"y-m-d")
+    end
+
+    @testset "when third Saturday is some day in the middle of the third week" begin
+        @test meetup(2013, 1, "third", "Saturday") == Date("2013-01-19", dateformat"y-m-d")
+    end
+
+    @testset "when third Saturday is another day in the middle of the third week" begin
+        @test meetup(2013, 2, "third", "Saturday") == Date("2013-02-16", dateformat"y-m-d")
+    end
+
+    @testset "when third Sunday is some day in the middle of the third week" begin
+        @test meetup(2013, 3, "third", "Sunday") == Date("2013-03-17", dateformat"y-m-d")
+    end
+
+    @testset "when third Sunday is the 21st, the last day of the third week" begin
+        @test meetup(2013, 4, "third", "Sunday") == Date("2013-04-21", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Monday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 3, "fourth", "Monday") == Date("2013-03-25", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Monday is the 22nd, the first day of the fourth week" begin
+        @test meetup(2013, 4, "fourth", "Monday") == Date("2013-04-22", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Tuesday is the 28th, the last day of the fourth week" begin
+        @test meetup(2013, 5, "fourth", "Tuesday") == Date("2013-05-28", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Tuesday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 6, "fourth", "Tuesday") == Date("2013-06-25", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Wednesday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 7, "fourth", "Wednesday") == Date("2013-07-24", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Wednesday is the 28th, the last day of the fourth week" begin
+        @test meetup(2013, 8, "fourth", "Wednesday") == Date("2013-08-28", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Thursday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 9, "fourth", "Thursday") == Date("2013-09-26", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Thursday is another day in the middle of the fourth week" begin
+        @test meetup(2013, 10, "fourth", "Thursday") == Date("2013-10-24", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Friday is the 22nd, the first day of the fourth week" begin
+        @test meetup(2013, 11, "fourth", "Friday") == Date("2013-11-22", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Friday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 12, "fourth", "Friday") == Date("2013-12-27", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Saturday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 1, "fourth", "Saturday") == Date("2013-01-26", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Saturday is another day in the middle of the fourth week" begin
+        @test meetup(2013, 2, "fourth", "Saturday") == Date("2013-02-23", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Sunday is some day in the middle of the fourth week" begin
+        @test meetup(2013, 3, "fourth", "Sunday") == Date("2013-03-24", dateformat"y-m-d")
+    end
+
+    @testset "when fourth Sunday is the 28th, the last day of the fourth week" begin
+        @test meetup(2013, 4, "fourth", "Sunday") == Date("2013-04-28", dateformat"y-m-d")
+    end
+
+    @testset "last Monday in a month with four Mondays" begin
+        @test meetup(2013, 3, "last", "Monday") == Date("2013-03-25", dateformat"y-m-d")
+    end
+
+    @testset "last Monday in a month with five Mondays" begin
+        @test meetup(2013, 4, "last", "Monday") == Date("2013-04-29", dateformat"y-m-d")
+    end
+
+    @testset "last Tuesday in a month with four Tuesdays" begin
+        @test meetup(2013, 5, "last", "Tuesday") == Date("2013-05-28", dateformat"y-m-d")
+    end
+
+    @testset "last Tuesday in another month with four Tuesdays" begin
+        @test meetup(2013, 6, "last", "Tuesday") == Date("2013-06-25", dateformat"y-m-d")
+    end
+
+    @testset "last Wednesday in a month with five Wednesdays" begin
+        @test meetup(2013, 7, "last", "Wednesday") == Date("2013-07-31", dateformat"y-m-d")
+    end
+
+    @testset "last Wednesday in a month with four Wednesdays" begin
+        @test meetup(2013, 8, "last", "Wednesday") == Date("2013-08-28", dateformat"y-m-d")
+    end
+
+    @testset "last Thursday in a month with four Thursdays" begin
+        @test meetup(2013, 9, "last", "Thursday") == Date("2013-09-26", dateformat"y-m-d")
+    end
+
+    @testset "last Thursday in a month with five Thursdays" begin
+        @test meetup(2013, 10, "last", "Thursday") == Date("2013-10-31", dateformat"y-m-d")
+    end
+
+    @testset "last Friday in a month with five Fridays" begin
+        @test meetup(2013, 11, "last", "Friday") == Date("2013-11-29", dateformat"y-m-d")
+    end
+
+    @testset "last Friday in a month with four Fridays" begin
+        @test meetup(2013, 12, "last", "Friday") == Date("2013-12-27", dateformat"y-m-d")
+    end
+
+    @testset "last Saturday in a month with four Saturdays" begin
+        @test meetup(2013, 1, "last", "Saturday") == Date("2013-01-26", dateformat"y-m-d")
+    end
+
+    @testset "last Saturday in another month with four Saturdays" begin
+        @test meetup(2013, 2, "last", "Saturday") == Date("2013-02-23", dateformat"y-m-d")
+    end
+
+    @testset "last Sunday in a month with five Sundays" begin
+        @test meetup(2013, 3, "last", "Sunday") == Date("2013-03-31", dateformat"y-m-d")
+    end
+
+    @testset "last Sunday in a month with four Sundays" begin
+        @test meetup(2013, 4, "last", "Sunday") == Date("2013-04-28", dateformat"y-m-d")
+    end
+
+    @testset "when last Wednesday in February in a leap year is the 29th" begin
+        @test meetup(2012, 2, "last", "Wednesday") == Date("2012-02-29", dateformat"y-m-d")
+    end
+
+    @testset "last Wednesday in December that is also the last day of the year" begin
+        @test meetup(2014, 12, "last", "Wednesday") == Date("2014-12-31", dateformat"y-m-d")
+    end
+
+    @testset "when last Sunday in February in a non-leap year is not the 29th" begin
+        @test meetup(2015, 2, "last", "Sunday") == Date("2015-02-22", dateformat"y-m-d")
+    end
+
+    @testset "when first Friday is the 7th, the last day of the first week" begin
+        @test meetup(2012, 12, "first", "Friday") == Date("2012-12-07", dateformat"y-m-d")
+    end
+end
+

--- a/generators/meetup.jl
+++ b/generators/meetup.jl
@@ -1,0 +1,49 @@
+# This is enough to generate some tests, but may not meet all track requirements
+
+using Test
+using Dates
+
+using LazyJSON
+
+dir = @__DIR__
+jsonfileurl = "https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/meetup/canonical-data.json"
+jsonfilename = "canonical-data.json"
+jsonfile = download(jsonfileurl, joinpath(dir,jsonfilename))
+outputfile = "parse_code.jl"
+df = DateFormat("y-m-d")
+
+
+f = LazyJSON.parse(read(joinpath(dir,jsonfile)))
+
+CODE = """
+using Test
+using Dates
+
+include("meetup.jl")
+
+@testset verbose = true "tests" begin
+"""
+
+for i in f["cases"]
+    des = String(i["description"])
+    year = i["input"]["year"]
+    month = i["input"]["month"]
+    week = i["input"]["week"]
+    dayofweek = i["input"]["dayofweek"]
+    exped = i["expected"]
+    property = i["property"]
+
+    global CODE *= """
+
+        @testset \"$des\" begin
+            @test $(property)($(year), $(month), "$(week)", "$(dayofweek)") == Date("$(exped)", $(df))
+        end
+    """
+end
+
+global CODE *= """
+end
+
+"""
+
+write(joinpath(dir,outputfile), CODE)


### PR DESCRIPTION
A #48in24 exercise, highlighted in the week of August 20th.

Difficulty is provisionally set to 4, copying Python, C# and Crystal. I could easily be persuaded to drop to 3, copying Ruby.

The many tests are taking directly from `problem-specifications`. Unlike several other tracks, there are no additional tests of invalid input. Should these be added?

The file `generators/meetup.jl` created the tests adequately for present purposes, but is clunky. It's not clear to me that the track has agreed standards for these generator files?