### PR TITLE
Simplify CI-workflow to run on Ubuntu only

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -17,16 +17,12 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
+    name: Julia ${{ matrix.julia-version }} - ${{ runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1.6", "1", nightly]
-        os: [ubuntu-22.04, windows-2022, macos-14]
-        exclude:
-          - julia-version: 1.6
-            os: macos-14
+        julia-version: ["lts", "1", nightly]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
   test:
+    name: Julia ${{ matrix.julia-version }}
     runs-on: ubuntu-22.04
-    name: Julia ${{ matrix.julia-version }} - ${{ runs-on }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["lts", "1", nightly]
+        julia-version: ["1.6", "1", nightly]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
Two relatively small changes to a GHA workflow:

- Test only on Ubuntu, as proposed in Issue #787.
- In response to an advice message that popped up while I was testing this on GH, change Julia "1.6" to "lts". Those are currently the same, but "lts" should automatically update to 1.10 in the next few months.

I should warn that I have no previous experience of GHA, so getting someone from @exercism/cross-track-maintainers to cast a skeptical eye over it would be good. I see that @ErikSchierboom is on the reviewers list, and it won't let me remove him - apologies for any disturbance!

I ran this manually on my fork, and everything passed (admittedly, not at the first attempt).

