### PR TITLE
update CI versions to Julia 1.11 (current) and 1.10 LTS

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -22,11 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1.6", "1", nightly]
+        julia-version: ["1.10", "1.11", nightly]
         os: [ubuntu-22.04, windows-2022, macos-14]
-        exclude:
-          - julia-version: 1.6
-            os: macos-14
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
Some extracts from a recent Julia Language notification:

> The Julia developers are pleased to announce the release of Julia v1.11.0, the eleventh minor release in the 1.x series. 

> As a minor release, v1.11.0 contains no breaking changes, only new features, performance improvements, and marginal, non-disruptive changes in behavior. 

> We are also pleased to announce that Julia 1.10 is now the current long-term support (LTS) release, replacing 1.6. 

> With this, Julia 1.6 is now officially unmaintained. 

I propose to drop 1.6 testing, switching to 1.11, 1.10 and nightly. I ran the CI workflow on my branch: it completed successfully in under 3 minutes.

With 1.6, we had both MacOS compatibility issues and very slow (15-20 min) CI on Windows, so I will be very happy to remove it.

@exercism/cross-track-maintainers, there was a suggestion in #793 to do cross-OS testing only on the LTS branch and Ubuntu-only on the newer versions. Is that something to consider here? It's less urgent once we have much faster CI overall (also, I'm unsure how best to code it in `exercise-test.yml`, and I'm trying to minimize destructive trial and error).