### PR TITLE
add cater-waiter concept exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -155,10 +155,11 @@
       },
       {
         "slug": "cater-waiter",
-        "name": "cater-waiter",
+        "name": "Cater Waiter",
         "uuid": "61e3bb88-a9a5-4978-bc55-1d87de9f2b70",
-        "concepts": [],
-        "prerequisites": []
+        "concepts": ["sets"],
+        "prerequisites": [],
+        "status": "wip"
       }
     ],
     "practice": [

--- a/config.json
+++ b/config.json
@@ -157,8 +157,12 @@
         "slug": "cater-waiter",
         "name": "Cater Waiter",
         "uuid": "61e3bb88-a9a5-4978-bc55-1d87de9f2b70",
-        "concepts": ["sets"],
-        "prerequisites": [],
+        "concepts": [
+          "sets"
+        ],
+        "prerequisites": [
+          "loops"
+        ],
         "status": "wip"
       }
     ],

--- a/config.json
+++ b/config.json
@@ -142,9 +142,9 @@
         "status": "wip"
       },
       {
-        "uuid": "e12feb9d-1235-4a7b-8c89-edf5c1577ef6",
         "slug": "log-levels",
         "name": "Log Levels",
+        "uuid": "e12feb9d-1235-4a7b-8c89-edf5c1577ef6",
         "concepts": [
           "strings"
         ],
@@ -152,6 +152,13 @@
           "ranges"
         ],
         "status": "wip"
+      },
+      {
+        "slug": "cater-waiter",
+        "name": "cater-waiter",
+        "uuid": "61e3bb88-a9a5-4978-bc55-1d87de9f2b70",
+        "concepts": [],
+        "prerequisites": []
       }
     ],
     "practice": [

--- a/exercises/concept/cater-waiter/.docs/hints.md
+++ b/exercises/concept/cater-waiter/.docs/hints.md
@@ -1,0 +1,61 @@
+# Hints
+
+## General
+
+- [Sets][sets] are mutable, unordered collections with no duplicate elements.
+- Sets can contain any data type.
+- Sets are [iterable][iterable].
+- Sets are most often used to quickly dedupe other collections or for membership testing.
+- Sets also support mathematical operations like `union`, `intersection`, `difference`, and `symmetric difference`
+
+## 1. Clean up Dish Ingredients
+
+- The `set()` constructor can take any [iterable][iterable] as an argument. Vectors are iterable.
+- Remember: Tuples can be formed using `(<element_1>, <element_2>)`.
+
+## 2. Cocktails and Mocktails
+
+- A `Set` is _disjoint_ from another set if the two sets share no elements.
+- The `Set()` constructor can take any [iterable][iterable] as an argument. Vectors are iterable.
+- Strings can be concatenated with the `*` sign and interpolation can be done via `$()`.
+
+## 3. Categorize Dishes
+
+- Using loops to iterate through the available meal categories might be useful here.
+- If all the elements of `<set_1>` are contained within `<set_2>`, then `<set_1> ⊆ <set_2>`.
+- The method equivalent of `⊆` is `issubset(<set>, <iterable>)`
+- Tuples can contain any data type, including other tuples.  Tuples can be formed using `(<element_1>, <element_2>)`.
+- Elements within Tuples can be accessed from the left using a 1-based index number, or from the right using an `end`-based index number (e.g. `<tuple>[end]`).
+- The `Set()` constructor can take any [iterable][iterable] as an argument. Vectors are iterable.
+- Strings can be concatenated with the `*` sign and interpolation can be done via `$()`.
+
+## 4. Label Allergens and Restricted Foods
+
+- A set _intersection_ are the elements shared between `<set_1>` and `<set_2>`.
+- The set method equivalent of `∩` is `intersect(<set>, <iterable>)` or `∩(<set>, <iterable>)`.
+- Elements within Tuples can be accessed from the left using a 1-based index number, or from the right using an `end`-based index number (e.g. `<tuple>[end]`).
+- The `Set()` constructor can take any [iterable][iterable] as an argument. Vectors are iterable.
+- Tuples can be formed using `(<element_1>, <element_2>)`.
+
+## 5. Compile a "Master List" of Ingredients
+
+- A set _union_ is where elements of `<set_1`> and `<set_2>` are combined into a single `set`
+- The set method equivalent of `∪` is `union(<set>, <iterable>)` or `∪(<set>, <iterable>)`
+- Using loops to iterate through the various dishes might be useful here.
+
+## 6. Pull out Appetizers for Passing on Trays
+
+- A set _difference_ is where the elements of  `<set_2>`  are removed from `<set_1>`, e.g. `setdiff(<set_1>, <set_2>)`.
+- The `Set()` constructor can take any [iterable][iterable] as an argument. Vectors are iterable.
+- The Vector constructor can take any [iterable][iterable] as an argument. Sets are iterable.
+
+## 7. Find Ingredients Used in Only One Recipe
+
+- A set _symmetric difference_ is where  elements appear in `<set_1>` or `<set_2>`, but not **_both_** sets.
+- A set _symmetric difference_ is the same as subtracting the `set` _intersection_ from the `set` _union_, e.g. `setdiff(<set_1> ∪ <set_2>, <set_1> ∩ <set_2>)`
+- A _symmetric difference_ of more than two `Sets` will include elements that are repeated more than two times across the input `Sets`.  To remove these cross-set repeated elements, the _intersections_ between set pairs needs to be subtracted from the symmetric difference.
+- Using looops to iterate through the various dishes might be useful here.
+
+
+[iterable]: https://docs.julialang.org/en/v1/base/collections/#Iterable-Collections
+[sets]: https://docs.julialang.org/en/v1/base/collections/#Base.Set

--- a/exercises/concept/cater-waiter/.docs/instructions.md
+++ b/exercises/concept/cater-waiter/.docs/instructions.md
@@ -1,0 +1,133 @@
+# Instructions
+
+You and your business partners operate a small catering company. You've just agreed to run an event for a local cooking club that features "club favorite" dishes. The club is inexperienced in hosting large events, and needs help with organizing, shopping, prepping and serving. You've decided to write some small Python scripts to speed the whole planning process along.
+
+## 1. Clean up Dish Ingredients
+
+The event recipes were added from various sources and their ingredients appear to have duplicate (_or more_) entries — you don't want to end up purchasing excess items!
+ Before the shopping and cooking can commence, each dish's ingredient list needs to be "cleaned".
+
+Implement the `clean_ingredients(<dish_name>, <dish_ingredients>)` function that takes the name of a dish and a `vector` of ingredients.
+ This function should return a `tuple` with the name of the dish as the first item, followed by the de-duped `set` of ingredients.
+
+
+```julia-repl
+julia> clean_ingredients("Punjabi-Style Chole", ["onions", "tomatoes", "ginger paste", "garlic paste", "ginger paste", "vegetable oil", "bay leaves", "cloves", "cardamom", "cilantro", "peppercorns", "cumin powder", "chickpeas", "coriander powder", "red chili powder", "ground turmeric", "garam masala", "chickpeas", "ginger", "cilantro"])
+("Punjabi-Style Chole", Set(["garam masala", "bay leaves", "ground turmeric", "ginger", "garlic paste", "peppercorns", "ginger paste", "red chili powder", "cardamom", "chickpeas", "cumin powder", "vegetable oil", "tomatoes", "coriander powder", "onions", "cilantro", "cloves"]))
+```
+
+## 2. Cocktails and Mocktails
+
+The event is going to include both cocktails and "mocktails" - mixed drinks _without_ the alcohol.
+ You need to ensure that "mocktail" drinks are truly non-alcoholic and the cocktails do indeed _include_ alcohol.
+
+Implement the `check_drinks(<drink_name>, <drink_ingredients>)` function that takes the name of a drink and a `vector` of ingredients.
+ The function should return the name of the drink followed by "Mocktail" if the drink has no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
+  For the purposes of this exercise, cocktails will only include alcohols from the ALCOHOLS constant in `sets_categories_data.jl`:
+
+```julia-repl
+julia> include("sets_categories_data.jl") 
+julia> check_drinks("Honeydew Cucumber", ["honeydew", "coconut water", "mint leaves", "lime juice", "salt", "english cucumber"])
+...
+"Honeydew Cucumber Mocktail"
+julia> check_drinks("Shirley Tonic", ["cinnamon stick", "scotch", "whole cloves", "ginger", "pomegranate juice", "sugar", "club soda"])
+...
+"Shirley Tonic Cocktail"
+```
+
+## 3. Categorize Dishes
+
+The guest list includes diners with different dietary needs, and your staff will need to separate the dishes into Vegan, Vegetarian, Paleo, Keto, and Omnivore.
+
+Implement the `categorize_dish(<dish_name>, <dish_ingredients>)` function that takes a dish name and a `set` of that dish's ingredients.
+The function should return a string with the `dish name: <CATEGORY>` (_which meal category the dish belongs to_).
+All dishes will "fit" into one of the categories found in `sets_categories_data.jl` (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
+
+```julia-repl
+julia> include("sets_categories_data.jl")
+julia> categorize_dish("Sticky Lemon Tofu", Set(["tofu", "soy sauce", "salt", "black pepper", "cornstarch", "vegetable oil", "garlic", "ginger", "water", "vegetable stock", "lemon juice", "lemon zest", "sugar"]))
+...
+"Sticky Lemon Tofu: VEGAN"
+>>> categorize_dish("Shrimp Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["shrimp", "bacon", "avocado", "chickpeas", "fresh tortillas", "sea salt", "guajillo chile", "slivered almonds", "olive oil", "butter", "black pepper", "garlic", "onion"]))
+...
+"Shrimp Bacon and Crispy Chickpea Tacos with Salsa de Guacamole: OMNIVORE"
+```
+
+## 4. Label Allergens and Restricted Foods
+
+Some guests have allergies and additional dietary restrictions.
+These ingredients need to be tagged/annotated for each dish so that they don't cause issues.
+
+Implement the `tag_special_ingredients(<dish>)` function that takes a `tuple` with the dish name in the first position, and a `vector` or `set` of ingredients for that dish in the second position.
+Return the dish name followed by the `set` of ingredients that require a special note on the dish description.
+Dish ingredients inside a `vector` may or may not have duplicates.
+ For the purposes of this exercise, all allergens or special ingredients that need to be labeled are in the SPECIAL_INGREDIENTS constant found in `sets_categories_data.py`.
+
+```julia-reple
+julia> include("sets_categories_data.jl")
+julia> tag_special_ingredients(("Ginger Glazed Tofu Cutlets", ["tofu", "soy sauce", "ginger", "corn starch", "garlic", "brown sugar", "sesame seeds", "lemon juice"]))
+...
+("Ginger Glazed Tofu Cutlets", Set(["garlic","soy sauce","tofu"]))
+>>> tag_special_ingredients(("Arugula and Roasted Pork Salad", ["pork tenderloin", "arugula", "pears", "blue cheese", "pine nuts", "balsamic vinegar", "onions", "black pepper"
+]))
+...
+("Arugula and Roasted Pork Salad", Set(["pork tenderloin", "blue cheese", "pine nuts", "onions"]))
+```
+
+## 5. Compile a "Master List" of Ingredients
+
+In preparation for ordering and shopping, you'll need to compile a "master list" of ingredients for everything on the menu (_quantities to be filled in later_).
+
+Implement the `compile_ingredients(<dishes>)` function that takes a `vector` of dishes and returns a set of all ingredients in all listed dishes.
+Each individual dish is represented by its `set` of ingredients.
+
+```julia-repl
+dishes = [Set(["tofu", "soy sauce", "ginger", "corn starch", "garlic", "brown sugar", "sesame seeds", "lemon juice"]),
+          Set(["pork tenderloin", "arugula", "pears", "blue cheese", "pine nuts",
+             "balsamic vinegar", "onions", "black pepper"]),
+          Set(["honeydew", "coconut water", "mint leaves", "lime juice", "salt", "english cucumber"])]
+julia> compile_ingredients(dishes)
+...
+Set(["arugula", "brown sugar", "honeydew", "coconut water", "english cucumber", "balsamic vinegar", "mint leaves", "pears", "pork tenderloin", "ginger", "blue cheese", "soy sauce", "sesame seeds", "black pepper", "garlic", "lime juice", "corn starch", "pine nuts", "lemon juice", "onions", "salt", "tofu"])
+```
+
+## 6. Pull out Appetizers for Passing on Trays
+
+The hosts have given you a list of dishes they'd like prepped as "bite-sized" appetizers to be served on trays.
+ You need to pull these from the main list of dishes being prepared as larger servings.
+
+Implement the `separate_appetizers(<dishes>, <appetizers>)` function that takes a `vector` of dish names and a `vector` of appetizer names.
+The function should return a `vector` with the list of dish names with appetizer names removed.
+Either the `<dishes>` or `<appetizers>` `vector` could contain duplicates and may require de-duping.
+
+```julia-repl
+dishes =    ["Avocado Deviled Eggs","Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups",
+             "Grilled Flank Steak with Caesar Salad","Vegetarian Khoresh Bademjan","Avocado Deviled Eggs",
+             "Barley Risotto","Kingfish Lettuce Cups"]
+          
+appetizers = ["Kingfish Lettuce Cups","Avocado Deviled Eggs","Satay Steak Skewers",
+              "Dahi Puri with Black Chickpeas","Avocado Deviled Eggs","Asparagus Puffs",
+              "Asparagus Puffs"]
+              
+julia> separate_appetizers(dishes, appetizers)
+...
+["Vegetarian Khoresh Bademjan", "Barley Risotto", "Flank Steak with Chimichurri and Asparagus", 
+ "Grilled Flank Steak with Caesar Salad"]
+```
+
+## 7. Find Ingredients Used in Only One Recipe
+
+Within each category (_Vegan, Vegetarian, Paleo, Keto, Omnivore_), you're going to pull out ingredients that appear in only one dish.
+These "singleton" ingredients will be assigned a special shopper to ensure they're not forgotten in the rush to get everything else done.
+
+Implement the `singleton_ingredients(<dishes>, <INTERSECTIONS>)` function that takes a `vector` of dishes and a `<CATEGORY>_INTERSECTIONS` constant for the same category.
+Each dish is represented by a `set` of its ingredients.
+Each `<CATEGORY>_INTERSECTIONS` is a `set` of ingredients that appear in more than one dish in the category.
+Using set operations, your function should return a `set` of "singleton" ingredients (_ingredients appearing in only one dish in the category_).
+
+```julia-repl
+julia> include("sets_categories_data.jl")
+julia> singleton_ingredients(example_dishes, EXAMPLE_INTERSECTION)
+...
+Set(["garlic powder", "sunflower oil", "mixed herbs", "cornstarch", "celeriac", "honey", "mushrooms", "bell pepper", "rosemary", "parsley", "lemon", "yeast", "vegetable oil", "vegetable stock", "silken tofu", "tofu", "cashews", "lemon zest", "smoked tofu", "spaghetti", "ginger", "breadcrumbs", "tomatoes", "barley malt", "red pepper flakes", "oregano", "red onion", "fresh basil"])
+```

--- a/exercises/concept/cater-waiter/.docs/introduction.md
+++ b/exercises/concept/cater-waiter/.docs/introduction.md
@@ -1,0 +1,109 @@
+# Introduction
+
+A [`Set`][set] is a collection of items with the following properties:
+
+- Unordered.
+- Entries are unique, so attempts to add duplicates are silently ignored.
+- Supports many of the operations common with mathematical sets.
+
+Create them with the `Set()` constructor, using any iterator as the parameter.
+
+```julia-repl
+julia> s1 = Set(1:4)
+Set{Int64} with 4 elements:
+  4
+  2
+  3
+  1
+```
+
+Add new elements with `push!()` (the same as with arrays), and remove them with `delete!()`.
+
+```julia-repl
+julia> push!(s1, 5)
+Set{Int64} with 5 elements:
+  5
+  4
+  2
+  3
+  1
+# Duplicates are ignored
+julia> push!(s1, 3)
+Set{Int64} with 5 elements:
+  5
+  4
+  2
+  3
+  1
+julia> delete!(s1, 5)
+Set{Int64} with 4 elements:
+  4
+  2
+  3
+  1
+julia> length(s1)  # length counts entries, despite the non-sequential type
+4
+```
+
+## Set operations
+
+As with several other collection types, check membership with the `in` or `∈` operator (use `\in` then tab for the symbol).
+
+```julia-repl
+julia> 3 ∈ s1
+true
+```
+
+The following operations on pairs of Sets are supported (shortcuts to the operator symbol are shown in parentheses).
+
+- `union(A, B)` or `A ∪ B` (`\cup`): all entries in A or B or both.
+- `intersect(A, B)` or `A ∩ B` (`\cap`): all entries common to both A and B.
+- `setdiff(A, B)` (no symbol): entries in A but not in B.
+- `symdiff(A, B)` (no symbol): entries in either A or B but not both.
+- `issubset(A, B)` or `A ⊆ B` (`\subseteq`) or `B ⊇ A` (`\supseteq`): `true` if all entries in A are also in B.
+- `issetequal(A, B)` (no symbol): `true` if A and B contain exactly the same entries.
+- `isdisjoint(A, B)` (no symbol): `true` if A and B contain no entries in common (so intersect is empty).
+
+```julia-repl
+s1 = Set(1:4)
+s2 = Set(3:6)
+julia> s1 ∪ s2  # union
+Set{Int64} with 6 elements:
+  5
+  4
+  6
+  2
+  3
+  1
+julia> s1 ∩ s2  # intersect
+Set{Int64} with 2 elements:
+  4
+  3
+  
+julia> setdiff(s1, s2)
+Set{Int64} with 2 elements:
+  2
+  1
+julia> symdiff(s1, s2)
+Set{Int64} with 4 elements:
+  5
+  6
+  2
+  1
+  
+julia> s1 ⊇ s2  # issubset
+false
+```
+
+There are also mutating versions of many of these, with `!` added to the function name.
+See the [manual][set] for a full list of functions.
+
+
+[set]: https://docs.julialang.org/en/v1/base/collections/#Set-Like-Collections
+[union]: https://docs.julialang.org/en/v1/base/collections/#Base.union
+[intersect]: https://docs.julialang.org/en/v1/base/collections/#Base.intersect
+[setdiff]: https://docs.julialang.org/en/v1/base/collections/#Base.setdiff
+[symdiff]: https://docs.julialang.org/en/v1/base/collections/#Base.symdiff
+[issubset]: https://docs.julialang.org/en/v1/base/collections/#Base.issubset
+[issetequal]: https://docs.julialang.org/en/v1/base/collections/#Base.issetequal
+[isdisjoint]: https://docs.julialang.org/en/v1/base/collections/#Base.isdisjoint

--- a/exercises/concept/cater-waiter/.meta/config.json
+++ b/exercises/concept/cater-waiter/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "cater-waiter.jl"
+    ],
+    "test": [
+      "runtests.jl"
+    ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
+    "editor": [
+      "sets_categories_data.jl"
+    ]
+  },
+  "icon": "meetup",
+  "blurb": "Learn about sets by managing the menus and ingredients for your catering company's event."
+}

--- a/exercises/concept/cater-waiter/.meta/config.json
+++ b/exercises/concept/cater-waiter/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "authors": [],
+  "authors": ["depial"],
   "files": {
     "solution": [
       "cater-waiter.jl"

--- a/exercises/concept/cater-waiter/.meta/exemplar.jl
+++ b/exercises/concept/cater-waiter/.meta/exemplar.jl
@@ -1,0 +1,762 @@
+VEGAN = Set([
+            "chives", "nutritional yeast", "tomato", "orange zest", "pareve puff pastry", "cashews", "tofu",
+            "rice vinegar", "black pepper", "cardamom powder", "mustard seeds", "parev shortcrust pastry",
+            "scallions", "water", "chinese eggplants", "lemon juice", "smoked paprika", "cloves", "basmati rice",
+            "cayenne pepper", "green onions", "sunflower oil", "mixed herbs", "garlic paste", "parsley",
+            "fresh red chili", "flour", "garlic", "oregano", "green beans", "harissa", "brandy", "fresh basil",
+            "coriander",  "vinegar", "thyme", "coriander seeds", "clove powder", "pomegranate seeds",
+            "sugar", "yukon gold potato", "sesame oil", "cinnamon powder", "butternut squash", "allspice powder",
+            "red pepper flakes", "soy sauce", "sesame seeds", "cornstarch", "mango powder", "vegetable stock",
+            "raisins", "barley malt", "olive oil", "ground almonds", "white rice", "garlic powder", "walnuts",
+            "saffron powder", "red chili powder", "turmeric powder", "spring onions", "yeast", "khmeli suneli",
+            "peanuts", "bulgur", "cilantro", "onion", "calabash nutmeg", "black-eyed peas", "grains of selim",
+            "zucchini", "currants", "spaghetti", "figs", "red bell pepper", "lemon zest", "ground turmeric",
+            "chili flakes", "chickpea flour", "hing", "slivered almonds", "vegetable oil", "serrano chili",
+            "salt", "yellow onions", "salt", "coriander powder", "orange zest", "garam masala", "yellow onion",
+            "smoked tofu", "bell pepper", "apples", "brown sugar", "coconut oil", "orange juice",
+            "sorghum stems", "dried blueberries", "tomato paste", "curry leaves", "vegetarian worcestershire sauce",
+            "hot water", "fresh ginger", "firm tofu", "eggplants", "bell pepper", "siracha", "carrot", "nigella seeds",
+            "vegan butter", "za'atar", "baking soda", "brown sugar", "dried cranberries", "kosher salt", "mangoes",
+            "vegan unsweetened yoghurt", "black peppercorn", "vinegar", "dill", "barberries", "honey", "tomatoes",
+            "yellow split peas", "persian cucumber", "turmeric", "lemon", "cumin", "oil", "mushrooms", "spring onion",
+            "pomegranate concentrate", "cumin seeds", "balsamic vinegar", "ripe plantains", "celeriac", "breadcrumbs",
+            "ginger", "dried cherries", "red onion", "rosemary", "chopped parsley", "corn", "cumin powder", "pecans",
+            "silken tofu", "pomegranate molasses", "carrot", "corn flour", "mashed potatoes"
+            ])
+
+
+VEGETARIAN = Set([
+                "almonds", "chives", "limes", "puff pastry", "onion", "cashews", "red cabbage", "red wine vinegar",
+                "brussel sprouts", "fresh corn", "black pepper", "lemon juice", "roasted corn", "eggs",
+                "fresh cilantro leaves", "shiitake mushrooms", "sunflower oil", "sage", "dijon mustard",
+                "blanched almonds", "dates", "flour", "fresh pea tendrils", "garlic", "egg", "green beans",
+                "yukon gold potato", "vermicelli noodles", "onions", "avocado", "dried lasagna noodles",
+                "thyme", "cauliflower", "basil", "watercress", "black beans", "butternut squash", "red thai chili",
+                "masa", "red chili", "red onions", "jalapeño chili", "grated nutmeg", "feta cheese", "hazelnuts",
+                "soy sauce", "shallots", "chipotle chili", "vegetable bullion", "fresh cherry tomatoes", "olive oil",
+                "milk", "fresh cherry bocconcini", "crema", "marmite", "walnuts", "nutmeg", "ricotta cheese",
+                "chestnuts", "mint leaves", "lime juice", "white wine", "apples", "pearl barley", "cotija cheese",
+                "zucchini", "currants", "leek", "pomegranate", "lemon zest", "avocados", "parmesan cheese", "mint",
+                "leeks", "fresh artichoke hearts", "vegetable oil", "brazil nuts", "red chili", "sharp white cheddar",
+                "salt", "pepitas", "green lentils", "beets", "celery", "smoked tofu", "fresh tomatoes",
+                "puff pastry sheets", "palm sugar", "vegetarian fish sauce", "oil marinated artichokes", "hot water",
+                "chickpeas", "firm tofu", "wombok", "carrot", "asparagus", "bean sprouts", "kosher salt",
+                "pasilla chili", "tomatillos", "parmesan rind", "pasta sheets", "cream", "butter", "croutons",
+                "lacinato kale", "fresh or frozen fava beans", "fresh pumpkin", "honey", "tomatoes", "olives",
+                "capers", "pine nuts", "lemon", "cumin", "ancho chili", "fresh peas", "spring roll wrappers",
+                "balsamic vinegar", "portobello mushrooms", "breadcrumbs", "blue cheese", "red onion",
+                "rosemary", "pecans", "carrot", "corn flour", "toasted peanuts"
+                ])
+
+PALEO = Set([
+            "cinnamon", "chiles de árbol", "chives", "limes", "allspice", "zucchini", "seranno chili", "lemon zest",
+            "apple cider vinegar", "avocados", "cashews", "mango", "cilantro leaves", "pepitas", "white chicken",
+            "chipotles", "black pepper", "scallions", "pumpkin puree", "water", "serrano chili", "lemon juice",
+            "smoked paprika", "homemade apricot honey preserves", "eggs", "salt", "flank steak", "fresh cilantro leaves",
+            "cider vinegar", "cloves", "purple sweet potato", "coconut yogurt", "green onions", "tilapia",
+            "yellow bell pepper", "coconut oil", "whole chicken", "coconut oil", "safflower oil", "roma tomatoes",
+            "fresh red chili", "fresh thai chili", "shrimp", "garlic", "onions", "lime", "avocado", "fresh parsley",
+            "cauliflower", "shredded red cabbage", "basil", "baking soda", "serrano chili",
+            "cherry tomatoes", "kale", "bacon", "kosher salt", "mangoes", "lacinato kale", "shallots", "pineapple",
+            "chipotle chili", "white vinegar", "honey", "tomatoes", "homemade tamarind concentrate",
+            "mexican oregano", "olive oil", "pine nuts", "garlic powder", "coconut flour", "green bell pepper",
+            "dried apricots", "cumin", "nutmeg", "kosher salt", "onions", "mustard seed", "lemons", "lime zest",
+            "ground cumin", "almond butter", "chili powder", "lime juice", "paleo mayonnaise", "pork chops",
+            "cilantro", "onion", "red bell pepper", "paleo parmesan cheese", "radishes", "avocado oil",
+            "dijon mustard", "avocado mayonnaise", "castelfranco radicchio", "worcestershire sauce", "treviso"
+            ])
+
+KETO = Set([
+            "cinnamon", "avocado oil", "chives", "sriacha", "almond flour", "crunchy peanut butter",
+            "cucumbers", "cream cheese", "red cabbage", "red wine vinegar", "brussel sprouts", "black pepper",
+            "cardamom powder", "mustard seeds", "scallions", "kecap manis", "lemon juice", "eggs", "tahini",
+            "cloves", "green onions", "dijon mustard", "garlic paste", "watermelon radishes", "parmesan",
+            "parsley", "star anise", "fresh cucumber", "fresh red chili", "shrimp", "garlic", "oregano",
+            "fennel bulb", "harissa", "dutch carrot", "fresh basil", "avocado", "clove powder", "coriander seeds",
+            "thyme", "fresh parsley", "chicken", "cauliflower", "basil", "watercress", "cinnamon powder",
+            "cherry tomatoes", "soy sauce", "sesame seeds", "micro cilantro", "mozzarella cheese", "shallots",
+            "mango powder", "chipotle chili", "olive oil", "spinach", "pink peppercorns", "coconut flour",
+            "salmon steaks", "dark soy sauce", "red chili powder", "turmeric powder", "spring onions",
+            "lime juice", "ginger garlic paste", "pork chops", "peanuts", "dried fenugreek leaves", "cilantro",
+            "onion", "salmon fillets", "toasted buckwheat", "whole small crimini mushrooms", "caster sugar",
+            "granny smith apples", "green cabbage", "apple cider vinegar", "chili flakes", "parmesan cheese",
+            "hing", "castelfranco radicchio", "cilantro leaves", "fresh greek yogurt", "roasted chicken", "ghee",
+            "flaxmeal", "flank steak", "salt", "coriander powder", "boned chicken", "red chili flakes",
+            "garam masala", "almond meal", "peanut oil", "tomato paste", "oyster sauce",
+            "curry leaves", "fresh ginger", "cardamom", "radishes", "little gem lettuce heads",
+            "grilled king fish", "carrot", "cinnamon sticks", "heavy cream", "asparagus", "nigella seeds",
+            "light soy sauce", "pork belly", "green chili", "mangoes", "red and green thai chili", "butter",
+            "vinegar", "dill", "fish sauce", "white vinegar", "tomatoes", "mirin",
+            "avocado mayonnaise", "turmeric", "lemon", "cumin", "fennel seeds", "lemon juice",  "salt",
+            "roasted peanuts", "ginger", "red onion", "rosemary", "cumin powder", "cashew nuts", "pecans",
+            "green chili","whole small crimini mushrooms", "monk fruit", "sour cream"
+            ])
+
+OMNIVORE = Set([
+                "clams", "prawns", "white wine vinegar", "date syrup", "limes", "tomato", "coriander",
+                "black chickpeas", "yellow bell pepper", "black cardamom", "baby squid", "pepitas",
+                "red cabbage", "baby scallops", "green cardamom", "black pepper", "chaat masala", "water",
+                "lemon juice", "tahini", "cloves", "white pepper", "fennel bulbs", "tomato puree",
+                "maggi cubes", "couscous", "yellow mustard", "parsley", "sriracha", "roma tomatoes",
+                "shrimp", "garlic", "oregano", "chicken wings", "yukon gold potato", "harissa", "onions",
+                "avocado", "thyme", "chicken", "sugar", "flat-leaf parsley", "celery seeds", "cherry tomatoes",
+                "mayonnaise", "scallion chutney", "red pepper flakes", "hazelnuts", "soy sauce", "sesame seeds",
+                "red snapper", "white onion", "vegetable bullion", "marjoram", "pani puri", "olive oil", "rice",
+                "serrano chili", "tamarind concentrate", "lime juice", "white wine", "beef brisket", "cilantro",
+                "onion", "crushed red pepper flakes", "chiles de árbol", "fresh mint", "zucchini", "red bell pepper",
+                "yoghurt", "apple cider vinegar", "parmesan cheese", "slivered almonds", "whole-milk yogurt",
+                "anchovy fillets", "fresh ricotta", "mint", "chile manzano", "roasted chicken", "sea salt",
+                "fresh thyme", "vegetable oil", "salt", "mexican crema", "celery", "yellow onion",
+                "worcestershire sauce", "fresh tortillas", "tomato paste", "oranges", "chickpeas",
+                "scotch bonnet pepper", "shelled large shrimp", "mussels", "summer squash", "salsa",
+                "garlic cloves", "fish stock", "bell pepper", "green bell pepper", "carrot", "cinnamon sticks",
+                "thin sev", "brown sugar", "baby carrot", "bacon", "kosher salt", "bay leaves", "anaheim chili",
+                "oaxaca cheese", "butter", "vinegar", "crab legs", "white vinegar", "honey", "tomatoes",
+                "green cabbage", "toasted bread", "turmeric", "lemon", "cumin", "black peppercorns", "poblano chili",
+                "arborio risotto rice", "fresh corn tortillas", "balsamic vinegar", "rhubarb", "ginger",
+                "guajillo chile", "filo pastry", "leg of lamb", "red onion", "chipotle adobo sauce", "rosemary",
+                "chili powder", "beer", "carrot"
+                ])
+
+SPECIAL_INGREDIENTS = Set([
+                            "cream","bacon", "garlic", "baby scallops", "mussels", "baby squid", "cashews", "salmon fillets",
+                            "filo pastry", "almonds", "milk", "blue cheese", "clams", "shrimp", "tomato puree", "chocolate",
+                            "honey", "anchovy fillets", "bulgur", "prawns", "parmesan cheese", "fish", "shelled large shrimp",
+                            "gluten", "crab legs", "feta cheese", "whole-milk yogurt", "crema", "firm tofu", "fish stock",
+                            "fresh ricotta", "tomato paste", "fresh cherry tomatoes", "pork chops", "eggs", "greek yogurt",
+                            "hazelnuts", "pecans", "brie cheese", "oaxaca cheese", "yellow onion", "whey", "silken tofu",
+                            "toasted bread", "parmesan", "beef", "tofu", "flour", "tomatoes", "red onion", "slivered almonds",
+                            "strawberries", "onions", "pine nuts", "cherry tomatoes", "soy sauce", "oyster sauce",
+                            "mozzarella cheese", "roma tomatoes", "heavy cream", "paneer", "pork tenderloin", "garlic cloves",
+                            "swiss cheese", "grilled king fish", "ground almonds", "tilapia", "sprint onion", "couscous",
+                            "walnuts", "semolina", "yogurt", "cotija cheese", "oysters", "spaghetti", "cheddar cheese",
+                            "butter", "lobster", "smoked tofu", "peanuts", "ground pork", "fresh cherry bocconcini",
+                            "pork belly", "toasted peanuts", "roasted peanuts"
+                            ])
+
+ALCOHOLS = Set([
+                "whiskey", "whisky", "white rum", "dark rum", "bourbon", "rye", "scotch", "vodka",
+                "tequila", "gin", "dry vermouth", "sweet vermouth", "prosecco","aperol", "brandy", "mezcal",
+                "triple sec", "coffee liqueur", "almond liqueur", "champagne", "orange curacao", "rum"
+                ])
+
+
+VEGAN_INTERSECTIONS = Set([
+                            "brown sugar", "carrot", "sugar", "vegetable stock", "fresh ginger", "nutritional yeast",
+                            "cayenne pepper", "olive oil", "lemon", "ginger", "red onion", "pomegranate molasses",
+                            "onion", "water", "chickpea flour", "orange zest", "coconut oil", "smoked paprika",
+                            "lemon zest", "sunflower oil", "orange juice", "black pepper", "cinnamon powder",
+                            "mushrooms", "cloves", "salt", "oil", "vegan butter", "turmeric", "tomato paste",
+                            "mustard seeds", "bell pepper", "rosemary", "vinegar", "tomatoes", "flour", "soy sauce",
+                            "lemon juice", "garlic"
+                            ])
+
+VEGETARIAN_INTERSECTIONS = Set([
+                                "carrot", "milk", "basil", "green lentils", "vegetable bullion", "red onions",
+                                "balsamic vinegar", "lemon", "olive oil", "butter", "honey", "red chili",
+                                "red onion", "breadcrumbs", "lemon zest", "pepitas", "black pepper", "fresh peas",
+                                "salt", "firm tofu", "ricotta cheese", "kosher salt", "watercress", "cream",
+                                "parmesan cheese", "shallots", "rosemary", "sage", "tomatoes", "walnuts",
+                                "lemon juice", "thyme", "garlic", "eggs", "red wine vinegar"
+                                ])
+
+PALEO_INTERSECTIONS = Set([
+                            "basil", "olive oil", "honey", "pine nuts", "baking soda", "shrimp", "cherry tomatoes",
+                            "coconut oil", "cinnamon", "lemon zest", "cumin", "black pepper", "lime", "salt",
+                            "zucchini", "kosher salt", "chipotle chili", "eggs", "coconut flour", "avocado",
+                            "cauliflower", "serrano chili", "safflower oil", "tomatoes", "lemon juice", "onions",
+                            "garlic"
+                            ])
+
+KETO_INTERSECTIONS = Set([
+                            "fresh cucumber", "red cabbage", "olive oil", "ginger", "butter", "dill", "red onion",
+                            "monk fruit", "cherry tomatoes", "spring onions", "lime juice", "fish sauce",
+                            "sesame seeds", "black pepper", "salt", "chives", "asparagus", "eggs",
+                            "avocado mayonnaise", "rosemary", "cauliflower", "flank steak", "lemon juice", "garlic"
+                            ])
+
+OMNIVORE_INTERSECTIONS = Set([
+                                "mint", "carrot", "fresh mint", "olive oil", "lemon", "ginger", "butter", "honey",
+                                "leg of lamb", "red onion", "bay leaves", "tamarind concentrate",
+                                "worcestershire sauce", "onion", "lime juice", "water", "anchovy fillets", "celery",
+                                "black pepper", "cilantro", "chili powder", "salt", "mayonnaise", "garlic cloves",
+                                "kosher salt", "white onion", "turmeric", "rosemary", "vinegar", "tomatoes",
+                                "sea salt", "soy sauce", "lemon juice", "onions", "thyme", "garlic", "avocado",
+                                "fresh corn tortillas", "tomato paste"
+                                ])
+
+
+EXAMPLE_INTERSECTION = Set([
+                            "fresh red chili", "sugar", "nutritional yeast", "fresh ginger", "red chili powder", "garlic",
+                            "olive oil", "mashed potatoes", "garam masala", "clove powder", "cumin powder", "onion",
+                            "chickpea flour", "water", "turmeric powder", "hing", "black pepper", "cinnamon powder",
+                            "cilantro", "salt", "oil", "cardamom powder", "turmeric", "garlic paste", "mustard seeds",
+                            "vinegar", "mangoes", "nigella seeds", "serrano chili", "flour", "soy sauce", "coriander seeds",
+                            "coriander powder", "lemon juice", "mango powder", "curry leaves"
+                            ])
+
+example_dishes = (
+                  Set(["salt", "breadcrumbs", "water", "flour", "celeriac", "chickpea flour", "soy sauce", "parsley",
+                       "sunflower oil", "lemon", "black pepper"]),
+
+                  Set(["cornstarch", "salt", "vegetable oil", "sugar", "vegetable stock", "water", "tofu", "soy sauce",
+                       "lemon zest", "lemon juice", "black pepper", "ginger", "garlic"]),
+
+                  Set(["salt", "mixed herbs", "silken tofu", "smoked tofu", "nutritional yeast", "turmeric", "soy sauce",
+                       "garlic", "lemon juice", "olive oil", "black pepper", "spaghetti"]),
+
+                  Set(["salt", "mushrooms", "sugar", "barley malt", "nutritional yeast", "fresh basil", "olive oil",
+                       "honey", "yeast", "red onion", "bell pepper", "cashews", "oregano", "rosemary", "garlic powder",
+                       "tomatoes", "water", "flour", "red pepper flakes", "garlic"]),
+
+                  Set(["mango powder", "oil", "salt", "cardamom powder", "fresh red chili", "sugar", "fresh ginger",
+                       "turmeric", "red chili powder", "curry leaves", "garlic paste", "mustard seeds", "vinegar",
+                       "mashed potatoes", "garam masala", "mangoes", "nigella seeds", "clove powder", "serrano chili",
+                       "cumin powder", "onion", "water", "chickpea flour", "coriander seeds", "turmeric powder", "hing",
+                       "coriander powder", "cinnamon powder", "cilantro", "garlic"]),
+
+                  Set(["mango powder", "oil", "salt", "cardamom powder", "fresh red chili", "sugar", "fresh ginger",
+                       "turmeric", "red chili powder", "curry leaves", "garlic paste", "mustard seeds", "vinegar",
+                       "mashed potatoes", "garam masala", "mangoes", "nigella seeds", "clove powder", "serrano chili",
+                       "cumin powder", "onion", "water", "chickpea flour", "coriander seeds", "turmeric powder", "hing",
+                       "coriander powder", "cinnamon powder", "cilantro", "garlic"])
+                  )
+
+
+#####################################
+# Data from original sets_test_data #
+#####################################
+
+recipes_with_duplicates  =  [("Kisir with Warm Pita", ["bulgur", "pomegranate molasses", "chopped parsley", "lemon juice", "tomato", "persian cucumber", "tomato paste", "spring onion", "water", "olive oil", "bulgur", "bulgur", "pomegranate molasses", "pomegranate molasses", "pomegranate molasses", "chopped parsley", "lemon juice", "tomato", "tomato", "persian cucumber", "tomato paste", "tomato paste", "tomato paste"]),
+                             ("Shakshuka", ["vegan unsweetened yoghurt", "yellow onion", "firm tofu", "smoked paprika", "tomatoes", "tomato paste", "sugar", "cloves", "cumin", "za'atar", "olive oil", "harissa", "red bell pepper"]),
+                             ("Vegetarian Khoresh Bademjan", ["yellow split peas", "tomato paste", "black pepper", "pomegranate concentrate", "yellow onions", "slivered almonds", "ground turmeric", "barberries", "basmati rice", "lemon juice", "hot water", "cayenne pepper", "chinese eggplants", "salt", "orange juice", "saffron powder", "vegan butter", "orange zest", "kosher salt", "yellow split peas", "yellow split peas", "tomato paste", "tomato paste", "tomato paste", "black pepper"]),
+                             ("Baked Kelewele", ["smoked paprika", "black peppercorn", "red onion", "grains of selim", "cayenne pepper", "calabash nutmeg", "coconut oil", "cloves", "fresh ginger", "salt", "ripe plantains", "smoked paprika", "black peppercorn", "black peppercorn", "red onion", "grains of selim", "grains of selim", "grains of selim"]),
+                             ("Waakye", ["baking soda", "sorghum stems", "coconut oil", "black-eyed peas", "water", "salt", "white rice", "baking soda", "baking soda", "sorghum stems", "sorghum stems", "sorghum stems", "coconut oil"]),
+                             ("Georgian Eggplant Rolls with Walnuts", ["pomegranate seeds", "oil", "coriander", "garlic", "khmeli suneli", "eggplants", "black pepper", "vinegar", "walnuts", "water", "salt"]),
+                             ("Burmese Tofu with Garlic, Ginger and Chili Sauce", ["soy sauce", "oil", "chili flakes", "garlic", "brown sugar", "ginger", "peanuts", "rice vinegar", "spring onions", "water", "turmeric", "salt", "chickpea flour", "soy sauce", "soy sauce", "oil", "oil", "oil", "chili flakes", "garlic", "brown sugar", "brown sugar", "ginger", "peanuts", "peanuts", "peanuts"]),
+                             ("Celeriac Schnitzel", ["soy sauce", "parsley", "lemon", "sunflower oil", "black pepper", "celeriac", "breadcrumbs", "water", "salt", "flour", "chickpea flour"]),
+                             ("Sticky Lemon Tofu", ["soy sauce", "vegetable stock", "tofu", "cornstarch", "lemon juice", "lemon zest", "garlic", "ginger", "black pepper", "sugar", "water", "salt", "vegetable oil", "soy sauce", "soy sauce", "vegetable stock", "vegetable stock", "vegetable stock", "tofu"]),
+                             ("Vegan Carbonara", ["soy sauce", "smoked tofu", "lemon juice", "nutritional yeast", "mixed herbs", "garlic", "black pepper", "silken tofu", "turmeric", "salt", "olive oil", "spaghetti", "soy sauce", "smoked tofu", "smoked tofu", "lemon juice", "nutritional yeast", "nutritional yeast", "nutritional yeast"]),
+                             ("Vegan Pizza with Caramelized Onions", ["mushrooms", "rosemary", "garlic", "red pepper flakes", "yeast", "barley malt", "water", "olive oil", "garlic powder", "oregano", "honey", "nutritional yeast", "red onion", "tomatoes", "cashews", "sugar", "bell pepper", "flour", "salt", "fresh basil", "mushrooms", "mushrooms", "rosemary", "rosemary", "rosemary", "garlic"]),
+                             ("Cheela with Spicy Mango Chutney", ["clove powder", "oil", "cinnamon powder", "nigella seeds", "curry leaves", "coriander seeds", "garlic", "mangoes", "mashed potatoes", "cardamom powder", "vinegar", "water", "mustard seeds", "coriander powder", "cumin powder", "mango powder", "garam masala", "red chili powder", "hing", "garlic paste", "turmeric powder", "cilantro", "sugar", "onion", "serrano chili", "fresh ginger", "turmeric", "salt", "fresh red chili", "chickpea flour"]),
+                             ("Sweet and Spicy Crispy Green Beans", ["soy sauce", "pomegranate molasses", "sesame oil", "green beans", "sunflower oil", "scallions", "garlic", "carrot", "ginger", "sesame seeds", "tomato paste", "bell pepper", "siracha", "soy sauce", "soy sauce", "pomegranate molasses", "pomegranate molasses", "pomegranate molasses", "sesame oil", "green beans", "sunflower oil", "sunflower oil", "scallions", "garlic", "garlic", "garlic"]),
+                             ("Vegan Mini Savory Mince Pies", ["mushrooms", "cinnamon powder", "rosemary", "corn flour", "ginger", "brown sugar", "carrot", "black pepper", "raisins", "butternut squash", "vegetarian worcestershire sauce", "parev shortcrust pastry", "olive oil", "vegetable stock", "dried cherries", "lemon juice", "lemon zest", "figs", "dried cranberries", "apples", "pecans", "onion", "orange juice", "currants", "dried blueberries", "salt", "brandy", "orange zest", "allspice powder"]),
+                             ("Roasted Corn and Zucchini Salad", ["green onions", "lemon juice", "lemon zest", "dill", "corn", "tomatoes", "black pepper", "zucchini", "olive oil", "green onions", "green onions", "lemon juice", "lemon juice", "lemon juice", "lemon zest"]),
+                             ("Golden Potato Salad", ["mustard seeds", "cumin seeds", "lemon juice", "garlic", "black pepper", "balsamic vinegar", "yukon gold potato", "chives", "turmeric", "salt", "olive oil", "mustard seeds", "cumin seeds", "cumin seeds", "lemon juice", "garlic", "garlic", "garlic"]),
+                             ("Carrot Puff Pastry Tart", ["olive oil", "lemon", "lemon juice", "pareve puff pastry", "brown sugar", "red onion", "carrot", "garlic", "black pepper", "thyme", "vegan butter", "water", "salt", "ground almonds", "olive oil", "olive oil", "lemon", "lemon", "lemon", "lemon juice"]),
+
+                             ("Mushroom Lasagna", ["nutmeg", "garlic", "black pepper", "onions", "butter", "parmesan cheese", "portobello mushrooms", "flour", "dried lasagna noodles", "olive oil", "milk", "kosher salt"]),
+                             ("Nut Wellington", ["sage", "puff pastry sheets", "hazelnuts", "almonds", "black pepper", "thyme", "marmite", "breadcrumbs", "walnuts", "dates", "eggs", "olive oil", "brazil nuts", "leeks", "chestnuts", "cashews", "apples", "pecans", "butter", "salt", "sage", "sage", "puff pastry sheets", "puff pastry sheets", "puff pastry sheets", "hazelnuts", "almonds", "black pepper", "black pepper", "thyme", "marmite", "marmite", "marmite"]),
+                             ("White Cheddar Scalloped Potatoes", ["shallots", "garlic", "cream", "thyme", "breadcrumbs", "sharp white cheddar", "yukon gold potato", "milk", "kosher salt"]),
+                             ("Winter Cobb Salad", ["smoked tofu", "shiitake mushrooms", "red wine vinegar", "garlic", "tomatoes", "black pepper", "avocados", "blue cheese", "onion", "lacinato kale", "eggs", "olive oil", "smoked tofu", "smoked tofu", "shiitake mushrooms", "shiitake mushrooms", "shiitake mushrooms", "red wine vinegar"]),
+                             ("Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", ["honey", "lemon", "dijon mustard", "feta cheese", "red wine vinegar", "red onion", "watercress", "green lentils", "currants", "capers", "pepitas", "fresh pumpkin", "olive oil", "honey", "lemon", "lemon", "dijon mustard", "feta cheese", "feta cheese", "feta cheese"]),
+                             ("Cambodian-Style Vegetable Spring Rolls", ["lime juice", "toasted peanuts", "firm tofu", "garlic", "corn flour", "bean sprouts", "carrot", "palm sugar", "shallots", "red chili", "vermicelli noodles", "wombok", "soy sauce", "sunflower oil", "spring roll wrappers", "vegetarian fish sauce", "lime juice", "lime juice", "toasted peanuts", "toasted peanuts", "toasted peanuts", "firm tofu"]),
+                             ("Summer Minestrone Cups", ["fresh peas", "rosemary", "garlic", "chickpeas", "carrot", "leek", "green lentils", "red chili", "olive oil", "croutons", "fresh corn", "lemon zest", "green beans", "parmesan rind", "basil", "tomatoes", "vegetable bullion", "parmesan cheese", "celery", "mint"]),
+                             ("Fried Zucchini with Balsamic and Chili Dressing", ["honey", "lemon juice", "garlic", "red onion", "red thai chili", "pomegranate", "balsamic vinegar", "mint leaves", "zucchini", "olive oil", "honey", "honey", "lemon juice", "lemon juice", "lemon juice", "garlic", "red onion", "red thai chili", "red thai chili", "pomegranate", "balsamic vinegar", "balsamic vinegar", "balsamic vinegar"]),
+                             ("Barley Risotto", ["sage", "beets", "pearl barley", "brussel sprouts", "rosemary", "garlic", "carrot", "red onion", "black pepper", "thyme", "butternut squash", "vegetable bullion", "parmesan cheese", "olive oil", "white wine"]),
+                             ("Cherry Tomato, Watercress and Fava Bean Salad", ["fresh peas", "fresh cherry tomatoes", "garlic", "watercress", "balsamic vinegar", "fresh or frozen fava beans", "fresh cherry bocconcini", "salt", "olive oil", "fresh peas", "fresh peas", "fresh cherry tomatoes", "fresh cherry tomatoes", "fresh cherry tomatoes", "garlic"]),
+                             ("Fresh Garden Peas over Cauliflower Almond Puree", ["red onions", "lemon", "fresh peas", "garlic", "grated nutmeg", "cream", "cauliflower", "blanched almonds", "fresh pea tendrils", "olive oil", "vegetable oil", "red onions", "lemon", "lemon", "fresh peas", "garlic", "garlic", "garlic"]),
+                             ("Walnut Ravioli with Artichokes and Tomatoes", ["pine nuts", "oil marinated artichokes", "olives", "rosemary", "fresh tomatoes", "ricotta cheese", "black pepper", "fresh artichoke hearts", "walnuts", "pasta sheets", "lemon juice", "lemon zest", "basil", "red onion", "butter", "salt", "pine nuts", "pine nuts", "oil marinated artichokes", "oil marinated artichokes", "oil marinated artichokes", "olives"]),
+                             ("Asparagus Puffs", ["eggs", "asparagus", "lemon juice", "red onion", "ricotta cheese", "black pepper", "thyme", "salt", "parmesan cheese", "puff pastry", "chives"]),
+                             ("Grilled Tofu Tacos", ["cotija cheese", "masa", "fresh cilantro leaves", "jalapeño chili", "chipotle chili", "firm tofu", "garlic", "carrot", "roasted corn", "tomatillos", "pepitas", "ancho chili", "crema", "red onions", "pasilla chili", "lemon", "hot water", "lemon juice", "tomatoes", "avocado", "cumin", "red cabbage", "limes", "black beans", "cotija cheese", "cotija cheese", "masa", "masa", "masa", "fresh cilantro leaves", "jalapeño chili", "chipotle chili", "chipotle chili", "firm tofu", "garlic", "garlic", "garlic"]),
+
+                             ("Zucchini Fritters with Lemon-Thyme Coconut Yogurt", ["baking soda", "coconut flour", "lemon juice", "lemon zest", "eggs", "coconut yogurt", "black pepper", "fresh thai chili", "coconut oil", "chives", "zucchini", "salt"]),
+                             ("Avocado Deviled Eggs", ["lime juice", "fresh cilantro leaves", "eggs", "seranno chili", "avocado", "pepitas", "salt", "garlic powder", "lime juice", "lime juice", "fresh cilantro leaves", "fresh cilantro leaves", "fresh cilantro leaves", "eggs"]),
+                             ("Grilled Flank Steak with Caesar Salad", ["pine nuts", "white vinegar", "chipotle chili", "scallions", "garlic", "paleo parmesan cheese", "black pepper", "avocado oil", "treviso", "olive oil", "radishes", "flank steak", "dijon mustard", "castelfranco radicchio", "worcestershire sauce", "fresh parsley", "cherry tomatoes", "salt", "avocado mayonnaise", "pine nuts", "white vinegar", "white vinegar", "chipotle chili", "scallions", "scallions", "scallions"]),
+                             ("Pumpkin Bread Crostini", ["coconut flour", "garlic", "black pepper", "cloves", "eggs", "olive oil", "onions", "honey", "apple cider vinegar", "almond butter", "baking soda", "nutmeg", "pumpkin puree", "cinnamon", "shrimp", "basil", "coconut oil", "cherry tomatoes", "salt", "fresh red chili", "coconut flour", "coconut flour", "garlic", "garlic", "garlic", "black pepper"]),
+                             ("BLT Bites", ["mustard seed", "onion", "kale", "cherry tomatoes", "bacon", "paleo mayonnaise"]),
+                             ("Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", ["purple sweet potato", "chiles de árbol", "garlic", "tomatoes", "safflower oil", "black pepper", "mexican oregano", "avocados", "shallots", "cumin", "olive oil", "lemons", "whole chicken", "limes", "kosher salt", "purple sweet potato", "purple sweet potato", "chiles de árbol", "chiles de árbol", "chiles de árbol", "garlic", "tomatoes", "safflower oil", "safflower oil", "black pepper", "mexican oregano", "mexican oregano", "mexican oregano"]),
+                             ("Chicken with Tamarind and Apricot Sauce", ["garlic", "black pepper", "dried apricots", "roma tomatoes", "water", "olive oil", "honey", "cinnamon", "ground cumin", "cider vinegar", "chili powder", "safflower oil", "homemade tamarind concentrate", "white chicken", "allspice", "chipotles", "salt", "homemade apricot honey preserves", "kosher salt"]),
+                             ("Grilled Fish Tacos with Cauliflower Tortillas", ["green onions", "serrano chili", "shredded red cabbage", "smoked paprika", "mango", "eggs", "black pepper", "cilantro", "cauliflower", "avocado", "lime", "cumin", "salt", "tilapia", "green onions", "green onions", "serrano chili", "serrano chili", "serrano chili", "shredded red cabbage"]),
+                             ("Grilled Pork Chops with Mango Pineapple Salsa", ["cilantro leaves", "lime", "pineapple", "chipotle chili", "garlic", "mangoes", "cauliflower", "avocado", "serrano chili", "pork chops", "lime zest", "lacinato kale", "onions", "cilantro leaves", "lime", "lime", "pineapple", "chipotle chili", "chipotle chili", "chipotle chili"]),
+                             ("Grilled Shrimp and Pesto over Zucchini Noodles", ["pine nuts", "shrimp", "green bell pepper", "lemon juice", "basil", "lemon zest", "garlic", "tomatoes", "cashews", "yellow bell pepper", "cumin", "zucchini", "salt", "olive oil", "red bell pepper", "pine nuts", "pine nuts", "shrimp", "shrimp", "shrimp", "green bell pepper"]),
+
+                             ("Cauliflower Pizza with Roasted Tomatoes and Chicken", ["parmesan", "almond meal", "rosemary", "mozzarella cheese", "roasted chicken", "tomato paste", "cauliflower", "cherry tomatoes", "eggs", "fresh basil", "olive oil"]),
+                             ("Flank Steak with Chimichurri and Asparagus", ["white vinegar", "asparagus", "flank steak", "chipotle chili", "scallions", "garlic", "black pepper", "cauliflower", "sour cream", "fresh parsley", "salt", "olive oil", "white vinegar", "white vinegar", "asparagus", "asparagus", "asparagus", "flank steak", "chipotle chili", "scallions", "scallions", "garlic", "black pepper", "black pepper", "black pepper"]),
+                             ("Kingfish Lettuce Cups", ["soy sauce", "watermelon radishes", "lime juice", "fish sauce", "mirin", "little gem lettuce heads", "peanut oil", "garlic", "sesame seeds", "oyster sauce", "spring onions", "avocado", "grilled king fish", "red cabbage"]),
+                             ("Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", ["clove powder", "curry leaves", "coriander seeds", "ginger", "cardamom powder", "vinegar", "mustard seeds", "mango powder", "garam masala", "red chili powder", "chicken", "hing", "turmeric powder", "tomatoes", "ginger garlic paste", "fresh greek yogurt", "fresh ginger", "monk fruit", "turmeric", "cashew nuts", "salt", "fresh red chili", "cinnamon powder", "nigella seeds", "whole small crimini mushrooms", "brussel sprouts", "garlic", "mangoes", "heavy cream", "cloves", "coriander powder", "cumin powder", "cardamom", "green chili", "cinnamon", "garlic paste", "red chili flakes", "lemon juice", "cilantro", "butter", "dried fenugreek leaves", "boned chicken", "clove powder", "clove powder", "curry leaves", "curry leaves", "curry leaves", "coriander seeds"]),
+                             ("Prawn and Herb Omelette", ["green onions", "parsley", "sesame seeds", "black pepper", "chives", "eggs", "fennel bulb", "tahini", "olive oil", "harissa", "shrimp", "lemon juice", "dill", "butter", "onion", "fresh cucumber", "monk fruit", "salt", "green onions", "parsley", "parsley", "sesame seeds", "black pepper", "black pepper", "black pepper"]),
+                             ("Satay Steak Skewers", ["sriacha", "apple cider vinegar", "lime juice", "fish sauce", "red and green thai chili", "flank steak", "carrot", "peanuts", "cucumbers", "roasted peanuts", "crunchy peanut butter", "kecap manis", "monk fruit", "micro cilantro", "olive oil", "sriacha", "sriacha", "apple cider vinegar", "apple cider vinegar", "apple cider vinegar", "lime juice"]),
+                             ("Parmesan Crackers and Spinach Crackers with Salmon Pate", ["spinach", "parmesan cheese", "coconut flour", "chili flakes", "garlic", "black pepper", "cream cheese", "ghee", "lemon juice", "flaxmeal", "red onion", "salt", "salmon fillets", "pecans", "almond flour", "cumin", "fresh cucumber", "cherry tomatoes", "chives", "avocado mayonnaise"]),
+                             ("Pork Chops with Grilled Castelfranco Radicchio and Asparagus", ["rosemary", "garlic", "black pepper", "thyme", "avocado oil", "eggs", "oregano", "asparagus", "lemon", "dijon mustard", "basil", "castelfranco radicchio", "dill", "butter", "pork chops", "monk fruit", "salt", "avocado mayonnaise", "rosemary", "rosemary", "garlic", "garlic", "garlic", "black pepper", "thyme", "avocado oil", "avocado oil", "eggs", "oregano", "oregano", "oregano"]),
+                             ("Seared Salmon with Pickled Vegetable and Watercress Salad", ["lime juice", "caster sugar", "toasted buckwheat", "lemon juice", "red wine vinegar", "red onion", "dutch carrot", "salmon steaks", "watercress", "pink peppercorns", "shallots", "fennel seeds", "red cabbage", "radishes"]),
+                             ("Braised Pork Belly with Apple Salad", ["cilantro leaves", "green cabbage", "lemon juice", "pork belly", "dark soy sauce", "granny smith apples", "ginger", "light soy sauce", "sesame seeds", "black pepper", "cinnamon sticks", "spring onions", "star anise", "monk fruit", "olive oil", "cilantro leaves", "cilantro leaves", "green cabbage", "green cabbage", "green cabbage", "lemon juice"]),
+
+                             ("Beachside Snapper", ["lime juice", "salsa", "green bell pepper", "anaheim chili", "black pepper", "olive oil", "yellow mustard", "red bell pepper", "soy sauce", "mexican crema", "mayonnaise", "white onion", "garlic cloves", "fresh corn tortillas", "red onion", "tomatoes", "limes", "worcestershire sauce", "butter", "yellow bell pepper", "salt", "red snapper", "lime juice", "salsa", "salsa", "green bell pepper", "anaheim chili", "anaheim chili", "anaheim chili"]),
+                             ("Governor Shrimp Tacos", ["lime juice", "poblano chili", "tomato paste", "black pepper", "chipotle adobo sauce", "chile manzano", "roma tomatoes", "pepitas", "oaxaca cheese", "white onion", "shelled large shrimp", "garlic cloves", "fresh corn tortillas", "red onion", "worcestershire sauce", "avocado", "butter", "kosher salt", "lime juice", "lime juice", "poblano chili", "poblano chili", "poblano chili", "tomato paste"]),
+                             ("Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", ["fresh tortillas", "shrimp", "garlic", "chickpeas", "black pepper", "slivered almonds", "guajillo chile", "bacon", "sea salt", "butter", "onion", "avocado", "olive oil"]),
+                             ("Burnt Masala Wings with Classic Coleslaw", ["lime juice", "green cabbage", "chiles de árbol", "green cardamom", "ginger", "carrot", "sriracha", "black pepper", "cinnamon sticks", "celery seeds", "cloves", "black cardamom", "olive oil", "chicken wings", "apple cider vinegar", "mayonnaise", "honey", "black peppercorns", "lemon juice", "garlic cloves", "tamarind concentrate", "cilantro", "butter", "serrano chili", "red cabbage", "kosher salt", "lime juice", "lime juice", "green cabbage", "green cabbage", "green cabbage", "chiles de árbol", "green cardamom", "ginger", "ginger", "carrot", "sriracha", "sriracha", "sriracha"]),
+                             ("Dahi Puri with Black Chickpeas", ["whole-milk yogurt", "chaat masala", "ginger", "pani puri", "scallion chutney", "yukon gold potato", "black chickpeas", "thin sev", "date syrup", "red onion", "roasted chicken", "chili powder", "tamarind concentrate", "cumin", "turmeric", "mint"]),
+                             ("Brisket with Grilled Rhubarb, Onions, and Fennel", ["white vinegar", "parsley", "yellow onion", "rhubarb", "garlic", "brown sugar", "black pepper", "thyme", "crushed red pepper flakes", "fennel bulbs", "beer", "marjoram", "vegetable oil", "soy sauce", "oregano", "lemon", "red onion", "chili powder", "cilantro", "beef brisket", "balsamic vinegar", "worcestershire sauce", "celery", "mint", "kosher salt", "white vinegar", "white vinegar", "parsley", "parsley", "parsley", "yellow onion"]),
+                             ("Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", ["oranges", "rosemary", "garlic", "anchovy fillets", "couscous", "carrot", "sesame seeds", "fresh thyme", "vinegar", "olive oil", "tahini", "harissa", "onions", "honey", "fresh mint", "leg of lamb", "tomatoes", "baby carrot", "vegetable bullion", "filo pastry", "celery", "bay leaves", "yoghurt", "oranges", "rosemary", "rosemary", "garlic", "anchovy fillets", "anchovy fillets", "anchovy fillets"]),
+                             ("Baked Chicken Jollof Rice", ["tomato puree", "garlic", "ginger", "tomato", "carrot", "thyme", "white pepper", "water", "maggi cubes", "chicken", "rice", "coriander", "scotch bonnet pepper", "bell pepper", "onion", "turmeric", "salt", "tomato puree", "tomato puree", "garlic", "garlic", "garlic", "ginger"]),
+                             ("Seafood Risotto", ["garlic", "tomato paste", "baby scallops", "mussels", "water", "crab legs", "olive oil", "baby squid", "fish stock", "lemon juice", "white onion", "arborio risotto rice", "clams", "parmesan cheese", "flat-leaf parsley", "cherry tomatoes", "prawns", "white wine"]),
+                             ("Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", ["toasted bread", "rosemary", "hazelnuts", "anchovy fillets", "garlic", "carrot", "summer squash", "black pepper", "red pepper flakes", "vinegar", "sea salt", "zucchini", "olive oil", "onions", "white wine vinegar", "fresh mint", "leg of lamb", "lemon", "fresh ricotta", "sugar", "celery", "bay leaves", "kosher salt", "toasted bread", "toasted bread", "rosemary", "rosemary", "rosemary", "hazelnuts", "anchovy fillets", "garlic", "garlic", "carrot", "summer squash", "summer squash", "summer squash"])
+                             ]
+
+recipes_without_duplicates  =  [("kisir_with_warm_pita", "Kisir with Warm Pita", Set(["water", "chopped parsley", "pomegranate molasses", "spring onion", "lemon juice", "olive oil", "bulgur", "tomato paste", "tomato", "persian cucumber"])),
+                             ("shakshuka", "Shakshuka", Set(["smoked paprika", "tomatoes", "cumin", "firm tofu", "olive oil", "harissa", "yellow onion", "sugar", "za'atar", "tomato paste", "cloves", "red bell pepper", "vegan unsweetened yoghurt"])),
+                             ("vegetarian_khoresh_bademjan", "Vegetarian Khoresh Bademjan", Set(["pomegranate concentrate", "saffron powder", "cayenne pepper", "barberries", "salt", "yellow onions", "yellow split peas", "slivered almonds", "ground turmeric", "orange zest", "lemon juice", "kosher salt", "hot water", "basmati rice", "black pepper", "orange juice", "tomato paste", "vegan butter", "chinese eggplants"])),
+                             ("baked_kelewele", "Baked Kelewele", Set(["salt", "coconut oil", "smoked paprika", "cayenne pepper", "red onion", "fresh ginger", "calabash nutmeg", "grains of selim", "black peppercorn", "cloves", "ripe plantains"])),
+                             ("waakye", "Waakye", Set(["salt", "coconut oil", "water", "white rice", "sorghum stems", "black-eyed peas", "baking soda"])),
+                             ("georgian_eggplant_rolls_with_walnuts", "Georgian Eggplant Rolls with Walnuts", Set(["salt", "coriander", "pomegranate seeds", "oil", "water", "vinegar", "garlic", "eggplants", "black pepper", "khmeli suneli", "walnuts"])),
+                             ("burmese_tofu_with_garlic,_ginger_and_chili_sauce", "Burmese Tofu with Garlic, Ginger and Chili Sauce", Set(["salt", "rice vinegar", "oil", "water", "turmeric", "chili flakes", "spring onions", "brown sugar", "garlic", "chickpea flour", "ginger", "soy sauce", "peanuts"])),
+                             ("celeriac_schnitzel", "Celeriac Schnitzel", Set(["salt", "parsley", "water", "sunflower oil", "flour", "breadcrumbs", "lemon", "celeriac", "chickpea flour", "soy sauce", "black pepper"])),
+                             ("sticky_lemon_tofu", "Sticky Lemon Tofu", Set(["salt", "water", "tofu", "cornstarch", "vegetable stock", "vegetable oil", "lemon juice", "garlic", "black pepper", "ginger", "soy sauce", "sugar", "lemon zest"])),
+                             ("vegan_carbonara", "Vegan Carbonara", Set(["salt", "turmeric", "spaghetti", "lemon juice", "olive oil", "garlic", "black pepper", "nutritional yeast", "soy sauce", "smoked tofu", "silken tofu", "mixed herbs"])),
+                             ("vegan_pizza_with_caramelized_onions", "Vegan Pizza with Caramelized Onions", Set(["red pepper flakes", "garlic", "cashews", "fresh basil", "flour", "tomatoes", "red onion", "oregano", "nutritional yeast", "rosemary", "water", "bell pepper", "honey", "barley malt", "olive oil", "salt", "garlic powder", "mushrooms", "yeast", "sugar"])),
+                             ("cheela_with_spicy_mango_chutney", "Cheela with Spicy Mango Chutney", Set(["hing", "curry leaves", "mangoes", "garlic", "nigella seeds", "garlic paste", "coriander seeds", "oil", "turmeric", "red chili powder", "coriander powder", "cardamom powder", "turmeric powder", "clove powder", "water", "cumin powder", "fresh ginger", "vinegar", "cinnamon powder", "cilantro", "chickpea flour", "onion", "salt", "mango powder", "fresh red chili", "mashed potatoes", "mustard seeds", "serrano chili", "garam masala", "sugar"])),
+                             ("sweet_and_spicy_crispy_green_beans", "Sweet and Spicy Crispy Green Beans", Set(["sesame oil", "siracha", "sunflower oil", "pomegranate molasses", "sesame seeds", "green beans", "carrot", "scallions", "garlic", "ginger", "soy sauce", "tomato paste", "bell pepper"])),
+                             ("vegan_mini_savory_mince_pies", "Vegan Mini Savory Mince Pies", Set(["apples", "brandy", "pecans", "raisins", "brown sugar", "lemon zest", "dried blueberries", "vegetarian worcestershire sauce", "orange zest", "butternut squash", "corn flour", "rosemary", "vegetable stock", "carrot", "figs", "cinnamon powder", "olive oil", "orange juice", "black pepper", "onion", "dried cherries", "salt", "dried cranberries", "parev shortcrust pastry", "mushrooms", "allspice powder", "lemon juice", "ginger", "currants"])),
+                             ("roasted_corn_and_zucchini_salad", "Roasted Corn and Zucchini Salad", Set(["zucchini", "tomatoes", "green onions", "corn", "lemon juice", "olive oil", "black pepper", "lemon zest", "dill"])),
+                             ("golden_potato_salad", "Golden Potato Salad", Set(["salt", "yukon gold potato", "turmeric", "balsamic vinegar", "cumin seeds", "lemon juice", "olive oil", "garlic", "mustard seeds", "black pepper", "chives"])),
+                             ("carrot_puff_pastry_tart", "Carrot Puff Pastry Tart", Set(["salt", "water", "lemon", "thyme", "red onion", "carrot", "lemon juice", "pareve puff pastry", "ground almonds", "brown sugar", "olive oil", "garlic", "black pepper", "vegan butter"])),
+
+                             ("mushroom_lasagna", "Mushroom Lasagna", Set(["dried lasagna noodles", "portobello mushrooms", "nutmeg", "flour", "kosher salt", "milk", "olive oil", "garlic", "onions", "butter", "black pepper", "parmesan cheese"])),
+                             ("nut_wellington", "Nut Wellington", Set(["apples", "eggs", "hazelnuts", "pecans", "thyme", "dates", "cashews", "breadcrumbs", "almonds", "marmite", "sage", "leeks", "olive oil", "black pepper", "walnuts", "salt", "chestnuts", "brazil nuts", "butter", "puff pastry sheets"])),
+                             ("white_cheddar_scalloped_potatoes", "White Cheddar Scalloped Potatoes", Set(["yukon gold potato", "shallots", "cream", "thyme", "breadcrumbs", "sharp white cheddar", "kosher salt", "milk", "garlic"])),
+                             ("winter_cobb_salad", "Winter Cobb Salad", Set(["lacinato kale", "eggs", "red wine vinegar", "shiitake mushrooms", "tomatoes", "avocados", "olive oil", "blue cheese", "garlic", "black pepper", "onion", "smoked tofu"])),
+                             ("roast_pumpkin_and_lentil_salad_with_roasted_lemon_dressing", "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", Set(["red wine vinegar", "dijon mustard", "lemon", "honey", "red onion", "feta cheese", "olive oil", "capers", "pepitas", "fresh pumpkin", "watercress", "green lentils", "currants"])),
+                             ("cambodian-style_vegetable_spring_rolls", "Cambodian-Style Vegetable Spring Rolls", Set(["sunflower oil", "vegetarian fish sauce", "shallots", "vermicelli noodles", "wombok", "firm tofu", "lime juice", "corn flour", "palm sugar", "bean sprouts", "spring roll wrappers", "garlic", "red chili", "soy sauce", "toasted peanuts", "carrot"])),
+                             ("summer_minestrone_cups", "Summer Minestrone Cups", Set(["leek", "garlic", "lemon zest", "tomatoes", "red chili", "chickpeas", "rosemary", "carrot", "vegetable bullion", "fresh corn", "fresh peas", "green beans", "olive oil", "parmesan cheese", "croutons", "celery", "mint", "basil", "green lentils", "parmesan rind"])),
+                             ("fried_zucchini_with_balsamic_and_chili_dressing", "Fried Zucchini with Balsamic and Chili Dressing", Set(["zucchini", "balsamic vinegar", "honey", "red onion", "lemon juice", "olive oil", "mint leaves", "garlic", "red thai chili", "pomegranate"])),
+                             ("barley_risotto", "Barley Risotto", Set(["beets", "white wine", "thyme", "red onion", "carrot", "butternut squash", "olive oil", "sage", "garlic", "brussel sprouts", "rosemary", "black pepper", "parmesan cheese", "pearl barley", "vegetable bullion"])),
+                             ("cherry_tomato,_watercress_and_fava_bean_salad", "Cherry Tomato, Watercress and Fava Bean Salad", Set(["salt", "fresh or frozen fava beans", "fresh peas", "balsamic vinegar", "olive oil", "garlic", "watercress", "fresh cherry bocconcini", "fresh cherry tomatoes"])),
+                             ("fresh_garden_peas_over_cauliflower_almond_puree", "Fresh Garden Peas over Cauliflower Almond Puree", Set(["grated nutmeg", "red onions", "lemon", "fresh peas", "cream", "vegetable oil", "olive oil", "garlic", "blanched almonds", "cauliflower", "fresh pea tendrils"])),
+                             ("walnut_ravioli_with_artichokes_and_tomatoes", "Walnut Ravioli with Artichokes and Tomatoes", Set(["salt", "fresh tomatoes", "ricotta cheese", "lemon zest", "olives", "red onion", "lemon juice", "black pepper", "rosemary", "butter", "basil", "fresh artichoke hearts", "pasta sheets", "pine nuts", "walnuts", "oil marinated artichokes"])),
+                             ("asparagus_puffs", "Asparagus Puffs", Set(["salt", "asparagus", "ricotta cheese", "thyme", "puff pastry", "red onion", "eggs", "lemon juice", "black pepper", "parmesan cheese", "chives"])),
+                             ("grilled_tofu_tacos", "Grilled Tofu Tacos", Set(["carrot", "red cabbage", "ancho chili", "limes", "hot water", "garlic", "roasted corn", "masa", "pasilla chili", "lemon", "tomatoes", "cumin", "fresh cilantro leaves", "chipotle chili", "red onions", "pepitas", "tomatillos", "black beans", "cotija cheese", "crema", "firm tofu", "lemon juice", "jalapeño chili", "avocado"])),
+
+                             ("zucchini_fritters_with_lemon-thyme_coconut_yogurt", "Zucchini Fritters with Lemon-Thyme Coconut Yogurt", Set(["salt", "coconut oil", "eggs", "fresh thai chili", "coconut yogurt", "zucchini", "lemon juice", "black pepper", "coconut flour", "chives", "lemon zest", "baking soda"])),
+                             ("avocado_deviled_eggs", "Avocado Deviled Eggs", Set(["salt", "eggs", "garlic powder", "seranno chili", "avocado", "lime juice", "pepitas", "fresh cilantro leaves"])),
+                             ("grilled_flank_steak_with_caesar_salad", "Grilled Flank Steak with Caesar Salad", Set(["flank steak", "avocado oil", "treviso", "scallions", "garlic", "cherry tomatoes", "pine nuts", "white vinegar", "chipotle chili", "dijon mustard", "olive oil", "avocado mayonnaise", "black pepper", "paleo parmesan cheese", "castelfranco radicchio", "fresh parsley", "salt", "worcestershire sauce", "radishes"])),
+                             ("pumpkin_bread_crostini", "Pumpkin Bread Crostini", Set(["eggs", "nutmeg", "cinnamon", "garlic", "pumpkin puree", "apple cider vinegar", "cherry tomatoes", "onions", "coconut flour", "cloves", "shrimp", "coconut oil", "honey", "olive oil", "black pepper", "almond butter", "salt", "fresh red chili", "basil", "baking soda"])),
+                             ("blt_bites", "BLT Bites", Set(["paleo mayonnaise", "bacon", "kale", "cherry tomatoes", "mustard seed", "onion"])),
+                             ("roasted_chicken_with_roasted_tomatoes,_avocado,_and_sweet_potatoes", "Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", Set(["safflower oil", "shallots", "whole chicken", "lemons", "tomatoes", "purple sweet potato", "avocados", "limes", "kosher salt", "olive oil", "mexican oregano", "garlic", "black pepper", "cumin", "chiles de árbol"])),
+                             ("chicken_with_tamarind_and_apricot_sauce", "Chicken with Tamarind and Apricot Sauce", Set(["cinnamon", "garlic", "cider vinegar", "chipotles", "homemade tamarind concentrate", "roma tomatoes", "white chicken", "ground cumin", "water", "safflower oil", "allspice", "dried apricots", "honey", "olive oil", "black pepper", "salt", "homemade apricot honey preserves", "kosher salt", "chili powder"])),
+                             ("grilled_fish_tacos_with_cauliflower_tortillas", "Grilled Fish Tacos with Cauliflower Tortillas", Set(["salt", "eggs", "smoked paprika", "shredded red cabbage", "mango", "green onions", "lime", "cumin", "tilapia", "cilantro", "black pepper", "serrano chili", "cauliflower", "avocado"])),
+                             ("grilled_pork_chops_with_mango_pineapple_salsa", "Grilled Pork Chops with Mango Pineapple Salsa", Set(["pork chops", "lacinato kale", "chipotle chili", "serrano chili", "lime zest", "pineapple", "lime", "garlic", "onions", "mangoes", "cauliflower", "avocado", "cilantro leaves"])),
+                             ("grilled_shrimp_and_pesto_over_zucchini_noodles", "Grilled Shrimp and Pesto over Zucchini Noodles", Set(["salt", "green bell pepper", "cashews", "zucchini", "tomatoes", "red bell pepper", "cumin", "lemon juice", "yellow bell pepper", "olive oil", "garlic", "pine nuts", "basil", "lemon zest", "shrimp"])),
+
+                             ("cauliflower_pizza_with_roasted_tomatoes_and_chicken", "Cauliflower Pizza with Roasted Tomatoes and Chicken", Set(["roasted chicken", "eggs", "fresh basil", "olive oil", "almond meal", "cherry tomatoes", "rosemary", "cauliflower", "mozzarella cheese", "tomato paste", "parmesan"])),
+                             ("flank_steak_with_chimichurri_and_asparagus", "Flank Steak with Chimichurri and Asparagus", Set(["fresh parsley", "salt", "asparagus", "chipotle chili", "flank steak", "scallions", "olive oil", "garlic", "black pepper", "cauliflower", "white vinegar", "sour cream"])),
+                             ("kingfish_lettuce_cups", "Kingfish Lettuce Cups", Set(["oyster sauce", "fish sauce", "spring onions", "sesame seeds", "grilled king fish", "little gem lettuce heads", "mirin", "red cabbage", "lime juice", "peanut oil", "garlic", "watermelon radishes", "soy sauce", "avocado"])),
+                             ("butter_chicken_with_grilled_mushrooms,_brussel_sprouts_and_mango_chutney", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", Set(["hing", "curry leaves", "cashew nuts", "green chili", "cinnamon", "mangoes", "garlic", "nigella seeds", "garlic paste", "coriander seeds", "turmeric", "ginger garlic paste", "tomatoes", "red chili powder", "coriander powder", "cardamom powder", "turmeric powder", "clove powder", "cloves", "heavy cream", "cardamom", "fresh greek yogurt", "monk fruit", "fresh ginger", "cumin powder", "vinegar", "cinnamon powder", "cilantro", "brussel sprouts", "whole small crimini mushrooms", "salt", "boned chicken", "red chili flakes", "mango powder", "fresh red chili", "lemon juice", "garam masala", "butter", "ginger", "mustard seeds", "chicken", "dried fenugreek leaves"])),
+                             ("prawn_and_herb_omelette", "Prawn and Herb Omelette", Set(["salt", "parsley", "eggs", "fresh cucumber", "sesame seeds", "green onions", "monk fruit", "lemon juice", "olive oil", "tahini", "harissa", "black pepper", "butter", "onion", "fennel bulb", "chives", "shrimp", "dill"])),
+                             ("satay_steak_skewers", "Satay Steak Skewers", Set(["flank steak", "red and green thai chili", "kecap manis", "fish sauce", "monk fruit", "micro cilantro", "carrot", "apple cider vinegar", "sriacha", "lime juice", "olive oil", "cucumbers", "roasted peanuts", "crunchy peanut butter", "peanuts"])),
+                             ("parmesan_crackers_and_spinach_crackers_with_salmon_pate", "Parmesan Crackers and Spinach Crackers with Salmon Pate", Set(["fresh cucumber", "pecans", "ghee", "garlic", "chives", "flaxmeal", "chili flakes", "almond flour", "salmon fillets", "red onion", "cherry tomatoes", "coconut flour", "cumin", "spinach", "cream cheese", "avocado mayonnaise", "black pepper", "parmesan cheese", "salt", "lemon juice"])),
+                             ("pork_chops_with_grilled_castelfranco_radicchio_and_asparagus", "Pork Chops with Grilled Castelfranco Radicchio and Asparagus", Set(["pork chops", "salt", "asparagus", "eggs", "dijon mustard", "avocado oil", "lemon", "thyme", "monk fruit", "oregano", "avocado mayonnaise", "garlic", "black pepper", "rosemary", "butter", "basil", "castelfranco radicchio", "dill"])),
+                             ("seared_salmon_with_pickled_vegetable_and_watercress_salad", "Seared Salmon with Pickled Vegetable and Watercress Salad", Set(["red wine vinegar", "caster sugar", "salmon steaks", "radishes", "shallots", "red onion", "pink peppercorns", "toasted buckwheat", "lemon juice", "lime juice", "red cabbage", "watercress", "fennel seeds", "dutch carrot"])),
+                             ("braised_pork_belly_with_apple_salad", "Braised Pork Belly with Apple Salad", Set(["spring onions", "dark soy sauce", "light soy sauce", "pork belly", "monk fruit", "green cabbage", "star anise", "sesame seeds", "lemon juice", "olive oil", "black pepper", "ginger", "cinnamon sticks", "granny smith apples", "cilantro leaves"])),
+
+                             ("beachside_snapper", "Beachside Snapper", Set(["yellow mustard", "mayonnaise", "limes", "white onion", "red snapper", "fresh corn tortillas", "tomatoes", "red onion", "lime juice", "soy sauce", "mexican crema", "salsa", "garlic cloves", "green bell pepper", "olive oil", "black pepper", "salt", "yellow bell pepper", "worcestershire sauce", "anaheim chili", "butter", "red bell pepper"])),
+                             ("governor_shrimp_tacos", "Governor Shrimp Tacos", Set(["chile manzano", "worcestershire sauce", "oaxaca cheese", "garlic cloves", "red onion", "avocado", "lime juice", "kosher salt", "white onion", "chipotle adobo sauce", "poblano chili", "fresh corn tortillas", "butter", "black pepper", "pepitas", "tomato paste", "roma tomatoes", "shelled large shrimp"])),
+                             ("shrimp,_bacon_and_crispy_chickpea_tacos_with_salsa_de_guacamole", "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["fresh tortillas", "slivered almonds", "bacon", "sea salt", "chickpeas", "olive oil", "guajillo chile", "garlic", "butter", "black pepper", "onion", "shrimp", "avocado"])),
+                             ("burnt_masala_wings_with_classic_coleslaw", "Burnt Masala Wings with Classic Coleslaw", Set(["mayonnaise", "carrot", "red cabbage", "green cabbage", "apple cider vinegar", "lime juice", "cloves", "cinnamon sticks", "sriracha", "celery seeds", "chicken wings", "garlic cloves", "honey", "olive oil", "cilantro", "black pepper", "chiles de árbol", "tamarind concentrate", "green cardamom", "black cardamom", "lemon juice", "kosher salt", "serrano chili", "ginger", "black peppercorns", "butter"])),
+                             ("dahi_puri_with_black_chickpeas", "Dahi Puri with Black Chickpeas", Set(["roasted chicken", "scallion chutney", "yukon gold potato", "turmeric", "black chickpeas", "whole-milk yogurt", "chili powder", "red onion", "pani puri", "ginger", "mint", "thin sev", "date syrup", "cumin", "chaat masala", "tamarind concentrate"])),
+                             ("brisket_with_grilled_rhubarb,_onions,_and_fennel", "Brisket with Grilled Rhubarb, Onions, and Fennel", Set(["crushed red pepper flakes", "rhubarb", "thyme", "yellow onion", "garlic", "brown sugar", "beer", "lemon", "red onion", "oregano", "soy sauce", "white vinegar", "beef brisket", "parsley", "marjoram", "balsamic vinegar", "vegetable oil", "fennel bulbs", "cilantro", "black pepper", "worcestershire sauce", "celery", "kosher salt", "mint", "chili powder"])),
+                             ("roast_leg_of_lamb_with_crispy_moroccan_carrots_&_couscous", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", Set(["bay leaves", "fresh thyme", "carrot", "tahini", "garlic", "baby carrot", "oranges", "filo pastry", "tomatoes", "harissa", "onions", "rosemary", "leg of lamb", "vegetable bullion", "sesame seeds", "honey", "anchovy fillets", "vinegar", "olive oil", "couscous", "fresh mint", "celery", "yoghurt"])),
+                             ("baked_chicken_jollof_rice", "Baked Chicken Jollof Rice", Set(["coriander", "salt", "white pepper", "water", "bell pepper", "turmeric", "rice", "scotch bonnet pepper", "chicken", "thyme", "maggi cubes", "garlic", "ginger", "onion", "tomato", "carrot", "tomato puree"])),
+                             ("seafood_risotto", "Seafood Risotto", Set(["white wine", "water", "clams", "crab legs", "baby squid", "lemon juice", "parmesan cheese", "olive oil", "white onion", "garlic", "arborio risotto rice", "fish stock", "mussels", "flat-leaf parsley", "tomato paste", "prawns", "baby scallops", "cherry tomatoes"])),
+                             ("lamb_over_marinated_summer_squash_with_hazelnuts_and_ricotta", "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", Set(["red pepper flakes", "hazelnuts", "zucchini", "bay leaves", "carrot", "garlic", "white wine vinegar", "toasted bread", "lemon", "onions", "rosemary", "leg of lamb", "summer squash", "sea salt", "anchovy fillets", "vinegar", "olive oil", "black pepper", "fresh mint", "celery", "kosher salt", "fresh ricotta", "sugar"]))
+                             ]
+
+##############################
+# Data for test_check_drinks #
+##############################
+
+
+all_drinks  =  [("Amaretto Sour", ["almond liqueur", "bourbon", "cherries", "egg white", "lemon juice", "lemon twist", "simple syrup"]),
+                ("Aperol Spritz", ["aperol", "prosecco", "soda water"]),
+                ("Bannana Punch", ["banana", "ginger ale", "lemonade", "orange juice", "pineapple juice", "sugar", "water"]),
+                ("Beet Sumac Soda", ["beet", "club soda", "fresh lemon juice", "sugar", "sumac"]),
+                ("Better Than Celery Juice", ["apple cider vinegar", "black pepper", "celery stalks", "club soda", "granny smith apples", "kosher salt", "parsley"]),
+                ("Black & Blue Berries", ["blackberries", "blueberries", "honey", "lemon juice", "soda water"]),
+                ("Bloody Mary", ["celery", "celery salt", "lemon juice", "pepper", "tomato juice", "vodka", "worcestershire sauce"]),
+                ("Bloody Shame", ["V8 juice", "black pepper", "celery", "salt", "tabasco sauce"]),
+                ("Chai Blossom", ["chai tea bags", "club soda", "fresh lime juice", "lemon twists", "start anise pods", "sugar"]),
+                ("Chile-lime Pineapple Soda", ["chiles de árbol", "club soda", "fresh pineapple juice", "kosher salt", "lime juice", "lime wedges", "pink peppercorns", "sugar"]),
+                ("Citrus Fizz", ["organic marmalade cordial", "seedlip grove 42", "sparkling water"]),
+                ("Dry Martini", ["dry vermouth", "gin", "lemon twist", "olives"]),
+                ("Espresso Martini", ["coffee liqueur", "espresso", "sugar syrup", "vodka"]),
+                ("Fermented Grape Soda", ["red seedless grapes", "sugar", "washed organic ginger"]),
+                ("French 75", ["champagne", "gin", "lemon juice", "sugar syrup"]),
+                ("Gimlet", ["gin", "lime juice", "sugar syrup"]),
+                ("Gin Fizz", ["gin", "lemon juice", "soda water", "sugar syrup"]),
+                ("Huckleberry Shrub", ["club soda", "huckleberries", "sugar", "white wine vinegar"]),
+                ("Mai Tai", ["cherries", "lime juice", "lime wedge", "mint leaves", "orange curacao", "orgeat syrup", "rum", "sugar syrup"]),
+                ("Mango Mule", ["cucumber", "fresh lime juice", "ginger beer", "honey syrup", "ice", "mango puree"]),
+                ("Manhattan", ["bitters", "cherry", "rye", "sweet vermouth"]),
+                ("Maple-Ginger Cider Switchel", ["apple cider vinegar", "club soda", "fresh ginger", "fresh lime juice", "maple syrup", "mint sprigs"]),
+                ("Margarita", ["lime juice", "salt", "simple syrup", "tequila", "triple sec"]),
+                ("Mojito", ["lime", "mint leaves", "soda water", "sugar syrup", "white rum"]),
+                ("Moscow Mule", ["ginger beer", "lime", "lime juice", "vodka"]),
+                ("Negroni", ["bitters", "gin", "sweet vermouth"]),
+                ("Old Fashioned", ["bitters", "bourbon", "orange juice", "orange slices", "sugar"]),
+                ("PG13 Singapore Sling", ["fresh lime juice", "mango juice", "mint sprigs", "pineapple juice", "pomegranate juice", "tonic water"]),
+                ("Penicillin", ["ginger", "honey simple syrup", "lemon juice", "scotch"]),
+                ("Pina Colada", ["cherries", "coconut milk", "cream of coconut", "dark rum", "fresh pineapple", "lime juice", "white rum"]),
+                ("Raspberry Almond Soda", ["almonds", "club soda", "kosher salt", "limes", "ripe raspberries", "sugar"]),
+                ("Salted Meyer Lemon and Sage Presse", ["club soda meyer lemons", "kosher salt", "sage leaves", "simple syrup"]),
+                ("Salted Watermelon Juice", ["cubed watermelon", "kosher salt", "lime wedges"]),
+                ("Shirley Tonic", ["cinnamon sticks", "club soda", "ginger", "lemon twists", "pomegranate juice", "sugar", "whole cloves"]),
+                ("Shirley ginger", ["brooklyn crafted lemon lime ginger beer", "club soda", "grenadine", "lime juice"]),
+                ("Spiced Hibiscus Tea", ["cinnamon sticks", "dried hibiscus flowers", "ginger", "honey", "lemon juice", "lemon wheels", "whole allspice"]),
+                ("Turmeric Tonic", ["agave syrup", "cayenne pepper", "lemon", "peeled ginger", "peeled turmeric", "sparkling water"]),
+                ("Virgin Cucumber Gimlet", [";ime juice", "club soda", "muddled cucumber", "simple syrup"]),
+                ("Whiskey Sour", ["cherry", "lemon juice", "lemon slices", "superfine sugar", "whiskey"])
+                ]
+
+drink_names = ["Amaretto Sour Cocktail","Aperol Spritz Cocktail","Bannana Punch Mocktail","Beet Sumac Soda Mocktail",
+               "Better Than Celery Juice Mocktail","Black & Blue Berries Mocktail","Bloody Mary Cocktail",
+               "Bloody Shame Mocktail","Chai Blossom Mocktail","Chile-lime Pineapple Soda Mocktail",
+               "Citrus Fizz Mocktail","Dry Martini Cocktail","Espresso Martini Cocktail","Fermented Grape Soda Mocktail",
+               "French 75 Cocktail","Gimlet Cocktail","Gin Fizz Cocktail","Huckleberry Shrub Mocktail",
+               "Mai Tai Cocktail","Mango Mule Mocktail","Manhattan Cocktail","Maple-Ginger Cider Switchel Mocktail",
+               "Margarita Cocktail","Mojito Cocktail","Moscow Mule Cocktail","Negroni Cocktail",
+               "Old Fashioned Cocktail","PG13 Singapore Sling Mocktail","Penicillin Cocktail","Pina Colada Cocktail",
+               "Raspberry Almond Soda Mocktail","Salted Meyer Lemon and Sage Presse Mocktail",
+               "Salted Watermelon Juice Mocktail","Shirley Tonic Mocktail","Shirley ginger Mocktail",
+               "Spiced Hibiscus Tea Mocktail","Turmeric Tonic Mocktail","Virgin Cucumber Gimlet Mocktail",
+               "Whiskey Sour Cocktail"]
+
+
+#################################
+# Data for test_categorize_dish #
+#################################
+
+all_dishes = recipes_without_duplicates
+
+dishes_categorized  =  ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt: PALEO",
+                        "Winter Cobb Salad: VEGETARIAN",
+                        "White Cheddar Scalloped Potatoes: VEGETARIAN",
+                        "Walnut Ravioli with Artichokes and Tomatoes: VEGETARIAN",
+                        "Waakye: VEGAN",
+                        "Vegetarian Khoresh Bademjan: VEGAN",
+                        "Vegan Pizza with Caramelized Onions: VEGAN",
+                        "Vegan Mini Savory Mince Pies: VEGAN",
+                        "Vegan Carbonara: VEGAN",
+                        "Sweet and Spicy Crispy Green Beans: VEGAN",
+                        "Summer Minestrone Cups: VEGETARIAN",
+                        "Sticky Lemon Tofu: VEGAN",
+                        "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole: OMNIVORE",
+                        "Shakshuka: VEGAN",
+                        "Seared Salmon with Pickled Vegetable and Watercress Salad: KETO",
+                        "Seafood Risotto: OMNIVORE",
+                        "Satay Steak Skewers: KETO",
+                        "Roasted Corn and Zucchini Salad: VEGAN",
+                        "Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes: PALEO",
+                        "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing: VEGETARIAN",
+                        "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous: OMNIVORE",
+                        "Pumpkin Bread Crostini: PALEO",
+                        "Prawn and Herb Omelette: KETO",
+                        "Pork Chops with Grilled Castelfranco Radicchio and Asparagus: KETO",
+                        "Parmesan Crackers and Spinach Crackers with Salmon Pate: KETO",
+                        "Nut Wellington: VEGETARIAN",
+                        "Mushroom Lasagna: VEGETARIAN",
+                        "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta: OMNIVORE",
+                        "Kisir with Warm Pita: VEGAN",
+                        "Kingfish Lettuce Cups: KETO",
+                        "Grilled Tofu Tacos: VEGETARIAN",
+                        "Grilled Shrimp and Pesto over Zucchini Noodles: PALEO",
+                        "Grilled Pork Chops with Mango Pineapple Salsa: PALEO",
+                        "Grilled Flank Steak with Caesar Salad: PALEO",
+                        "Grilled Fish Tacos with Cauliflower Tortillas: PALEO",
+                        "Governor Shrimp Tacos: OMNIVORE",
+                        "Golden Potato Salad: VEGAN",
+                        "Georgian Eggplant Rolls with Walnuts: VEGAN",
+                        "Fried Zucchini with Balsamic and Chili Dressing: VEGETARIAN",
+                        "Fresh Garden Peas over Cauliflower Almond Puree: VEGETARIAN",
+                        "Flank Steak with Chimichurri and Asparagus: KETO",
+                        "Dahi Puri with Black Chickpeas: OMNIVORE",
+                        "Chicken with Tamarind and Apricot Sauce: PALEO",
+                        "Cherry Tomato, Watercress and Fava Bean Salad: VEGETARIAN",
+                        "Cheela with Spicy Mango Chutney: VEGAN",
+                        "Celeriac Schnitzel: VEGAN",
+                        "Cauliflower Pizza with Roasted Tomatoes and Chicken: KETO",
+                        "Carrot Puff Pastry Tart: VEGAN",
+                        "Cambodian-Style Vegetable Spring Rolls: VEGETARIAN",
+                        "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney: KETO",
+                        "Burnt Masala Wings with Classic Coleslaw: OMNIVORE",
+                        "Burmese Tofu with Garlic, Ginger and Chili Sauce: VEGAN",
+                        "Brisket with Grilled Rhubarb, Onions, and Fennel: OMNIVORE",
+                        "Braised Pork Belly with Apple Salad: KETO",
+                        "BLT Bites: PALEO",
+                        "Beachside Snapper: OMNIVORE",
+                        "Barley Risotto: VEGETARIAN",
+                        "Baked Kelewele: VEGAN",
+                        "Baked Chicken Jollof Rice: OMNIVORE",
+                        "Avocado Deviled Eggs: PALEO",
+                        "Asparagus Puffs: VEGETARIAN"]
+
+
+#########################################
+# Data for test_tag_special_ingredients #
+#########################################
+
+
+dupes =  ["Baked Kelewele", "Barley Risotto", "Burmese Tofu with Garlic, Ginger and Chili Sauce",
+          "Cambodian-Style Vegetable Spring Rolls", "Fried Zucchini with Balsamic and Chili Dressing",
+          "Kisir with Warm Pita", "Shakshuka", "Summer Minestrone Cups", "Vegetarian Khoresh Bademjan"]
+
+nondupes = ["Brisket with Grilled Rhubarb, Onions, and Fennel", "Burnt Masala Wings with Classic Coleslaw",
+            "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney",
+            "Cauliflower Pizza with Roasted Tomatoes and Chicken", "Dahi Puri with Black Chickpeas",
+            "Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups",
+            "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole"]
+
+group_1 = filter(item -> item[1] ∈ dupes, recipes_with_duplicates)
+group_2 = [(item[2], item[3]) for item in recipes_without_duplicates if item[2] ∈ nondupes]
+
+dishes_to_special_label = sort!(vcat(group_1, group_2))
+
+dishes_labeled =  [("Baked Kelewele", Set(["red onion"])),
+                   ("Barley Risotto", Set(["garlic", "red onion", "parmesan cheese"])),
+                   ("Brisket with Grilled Rhubarb, Onions, and Fennel", Set(["soy sauce", "garlic", "red onion", "yellow onion"])),
+                   ("Burmese Tofu with Garlic, Ginger and Chili Sauce", Set(["soy sauce", "garlic", "peanuts"])),
+                   ("Burnt Masala Wings with Classic Coleslaw", Set(["honey", "butter", "garlic cloves"])),
+                   ("Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", Set(["heavy cream", "garlic", "butter", "tomatoes"])),
+                   ("Cambodian-Style Vegetable Spring Rolls", Set(["soy sauce", "firm tofu", "garlic", "toasted peanuts"])),
+                   ("Cauliflower Pizza with Roasted Tomatoes and Chicken", Set(["parmesan", "mozzarella cheese", "tomato paste", "cherry tomatoes", "eggs"])),
+                   ("Dahi Puri with Black Chickpeas", Set(["red onion", "whole-milk yogurt"])),
+                   ("Flank Steak with Chimichurri and Asparagus", Set(["garlic"])),
+                   ("Fried Zucchini with Balsamic and Chili Dressing", Set(["honey", "garlic", "red onion"])),
+                   ("Kingfish Lettuce Cups", Set(["soy sauce", "oyster sauce", "garlic", "grilled king fish"])),
+                   ("Kisir with Warm Pita", Set(["bulgur", "tomato paste"])),
+                   ("Shakshuka", Set(["tomatoes", "tomato paste", "firm tofu", "yellow onion"])),
+                   ("Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["shrimp", "garlic", "butter", "slivered almonds", "bacon"])),
+                   ("Summer Minestrone Cups", Set(["garlic", "tomatoes", "parmesan cheese"])),
+                   ("Vegetarian Khoresh Bademjan", Set(["slivered almonds", "tomato paste"]))]
+
+
+
+#####################################
+# Data for test_compile_ingredients #
+#####################################
+
+
+ingredients_only = [[Set(["bulgur", "pomegranate molasses", "chopped parsley", "lemon juice", "tomato", "persian cucumber", "tomato paste", "spring onion", "water", "olive oil"]),
+                    Set(["vegan unsweetened yoghurt", "yellow onion", "firm tofu", "smoked paprika", "tomatoes", "tomato paste", "sugar", "cloves", "cumin", "za'atar", "olive oil", "harissa", "red bell pepper"]),
+                    Set(["yellow split peas", "tomato paste", "black pepper", "pomegranate concentrate", "yellow onions", "slivered almonds", "ground turmeric", "barberries", "basmati rice", "lemon juice", "hot water", "cayenne pepper", "chinese eggplants", "salt", "orange juice", "saffron powder", "vegan butter", "orange zest", "kosher salt"]),
+                    Set(["smoked paprika", "black peppercorn", "red onion", "grains of selim", "cayenne pepper", "calabash nutmeg", "coconut oil", "cloves", "fresh ginger", "salt", "ripe plantains"]),
+                    Set(["baking soda", "sorghum stems", "coconut oil", "black-eyed peas", "water", "salt", "white rice"]),
+                    Set(["pomegranate seeds", "oil", "coriander", "garlic", "khmeli suneli", "eggplants", "black pepper", "vinegar", "walnuts", "water", "salt"]),
+                    Set(["soy sauce", "oil", "chili flakes", "garlic", "brown sugar", "ginger", "peanuts", "rice vinegar", "spring onions", "water", "turmeric", "salt", "chickpea flour"]),
+                    Set(["soy sauce", "parsley", "lemon", "sunflower oil", "black pepper", "celeriac", "breadcrumbs", "water", "salt", "flour", "chickpea flour"]),
+                    Set(["soy sauce", "vegetable stock", "tofu", "cornstarch", "lemon juice", "lemon zest", "garlic", "ginger", "black pepper", "sugar", "water", "salt", "vegetable oil"]),
+                    Set(["soy sauce", "smoked tofu", "lemon juice", "nutritional yeast", "mixed herbs", "garlic", "black pepper", "silken tofu", "turmeric", "salt", "olive oil", "spaghetti"]),
+                    Set(["mushrooms", "rosemary", "garlic", "red pepper flakes", "yeast", "barley malt", "water", "olive oil", "garlic powder", "oregano", "honey", "nutritional yeast", "red onion", "tomatoes", "cashews", "sugar", "bell pepper", "flour", "salt", "fresh basil"]),
+                    Set(["clove powder", "oil", "cinnamon powder", "nigella seeds", "curry leaves", "coriander seeds", "garlic", "mangoes", "mashed potatoes", "cardamom powder", "vinegar", "water", "mustard seeds", "coriander powder", "cumin powder", "mango powder", "garam masala", "red chili powder", "hing", "garlic paste", "turmeric powder", "cilantro", "sugar", "onion", "serrano chili", "fresh ginger", "turmeric", "salt", "fresh red chili", "chickpea flour"]),
+                    Set(["soy sauce", "pomegranate molasses", "sesame oil", "green beans", "sunflower oil", "scallions", "garlic", "carrot", "ginger", "sesame seeds", "tomato paste", "bell pepper", "siracha"]),
+                    Set(["mushrooms", "cinnamon powder", "rosemary", "corn flour", "ginger", "brown sugar", "carrot", "black pepper", "raisins", "butternut squash", "vegetarian worcestershire sauce", "parev shortcrust pastry", "olive oil", "vegetable stock", "dried cherries", "lemon juice", "lemon zest", "figs", "dried cranberries", "apples", "pecans", "onion", "orange juice", "currants", "dried blueberries", "salt", "brandy", "orange zest", "allspice powder"]),
+                    Set(["green onions", "lemon juice", "lemon zest", "dill", "corn", "tomatoes", "black pepper", "zucchini", "olive oil"]),
+                    Set(["mustard seeds", "cumin seeds", "lemon juice", "garlic", "black pepper", "balsamic vinegar", "yukon gold potato", "chives", "turmeric", "salt", "olive oil"]),
+                    Set(["olive oil", "lemon", "lemon juice", "pareve puff pastry", "brown sugar", "red onion", "carrot", "garlic", "black pepper", "thyme", "vegan butter", "water", "salt", "ground almonds"])
+                    ],
+
+                    [Set(["nutmeg", "garlic", "black pepper", "onions", "butter", "parmesan cheese", "portobello mushrooms", "flour", "dried lasagna noodles", "olive oil", "milk", "kosher salt"]),
+                    Set(["sage", "puff pastry sheets", "hazelnuts", "almonds", "black pepper", "thyme", "marmite", "breadcrumbs", "walnuts", "dates", "eggs", "olive oil", "brazil nuts", "leeks", "chestnuts", "cashews", "apples", "pecans", "butter", "salt"]),
+                    Set(["shallots", "garlic", "cream", "thyme", "breadcrumbs", "sharp white cheddar", "yukon gold potato", "milk", "kosher salt"]),
+                    Set(["smoked tofu", "shiitake mushrooms", "red wine vinegar", "garlic", "tomatoes", "black pepper", "avocados", "blue cheese", "onion", "lacinato kale", "eggs", "olive oil"]),
+                    Set(["honey", "lemon", "dijon mustard", "feta cheese", "red wine vinegar", "red onion", "watercress", "green lentils", "currants", "capers", "pepitas", "fresh pumpkin", "olive oil"]),
+                    Set(["lime juice", "toasted peanuts", "firm tofu", "garlic", "corn flour", "bean sprouts", "carrot", "palm sugar", "shallots", "red chili", "vermicelli noodles", "wombok", "soy sauce", "sunflower oil", "spring roll wrappers", "vegetarian fish sauce"]),
+                    Set(["fresh peas", "rosemary", "garlic", "chickpeas", "carrot", "leek", "green lentils", "red chili", "olive oil", "croutons", "fresh corn", "lemon zest", "green beans", "parmesan rind", "basil", "tomatoes", "vegetable bullion", "parmesan cheese", "celery", "mint"]),
+                    Set(["honey", "lemon juice", "garlic", "red onion", "red thai chili", "pomegranate", "balsamic vinegar", "mint leaves", "zucchini", "olive oil"]),
+                    Set(["sage", "beets", "pearl barley", "brussel sprouts", "rosemary", "garlic", "carrot", "red onion", "black pepper", "thyme", "butternut squash", "vegetable bullion", "parmesan cheese", "olive oil", "white wine"]),
+                    Set(["fresh peas", "fresh cherry tomatoes", "garlic", "watercress", "balsamic vinegar", "fresh or frozen fava beans", "fresh cherry bocconcini", "salt", "olive oil"]),
+                    Set(["red onions", "lemon", "fresh peas", "garlic", "grated nutmeg", "cream", "cauliflower", "blanched almonds", "fresh pea tendrils", "olive oil", "vegetable oil"]),
+                    Set(["pine nuts", "oil marinated artichokes", "olives", "rosemary", "fresh tomatoes", "ricotta cheese", "black pepper", "fresh artichoke hearts", "walnuts", "pasta sheets", "lemon juice", "lemon zest", "basil", "red onion", "butter", "salt"]),
+                    Set(["egg", "asparagus", "lemon juice", "red onion", "ricotta cheese", "black pepper", "thyme", "salt", "parmesan cheese", "puff pastry", "chives"]),
+                    Set(["cotija cheese", "masa", "fresh cilantro leaves", "jalapeño chili", "chipotle chili", "firm tofu", "garlic", "carrot", "roasted corn", "tomatillos", "pepitas", "ancho chili", "crema", "red onions", "pasilla chili", "lemon", "hot water", "lemon juice", "tomatoes", "avocado", "cumin", "red cabbage", "limes", "black beans"])
+                    ],
+
+                    [Set(["baking soda", "coconut flour", "lemon juice", "lemon zest", "eggs", "coconut yogurt", "black pepper", "fresh thai chili", "coconut oil", "chives", "zucchini", "salt"]),
+                    Set(["lime juice", "fresh cilantro leaves", "eggs", "seranno chili", "avocado", "pepitas", "salt", "garlic powder"]),
+                    Set(["pine nuts", "white vinegar", "chipotle chili", "scallions", "garlic", "paleo parmesan cheese", "black pepper", "avocado oil", "treviso", "olive oil", "radishes", "flank steak", "dijon mustard", "castelfranco radicchio", "worcestershire sauce", "fresh parsley", "cherry tomatoes", "salt", "avocado mayonnaise"]),
+                    Set(["coconut flour", "garlic", "black pepper", "cloves", "eggs", "olive oil", "onions", "honey", "apple cider vinegar", "almond butter", "baking soda", "nutmeg", "pumpkin puree", "cinnamon", "shrimp", "basil", "coconut oil", "cherry tomatoes", "salt", "fresh red chili"]),
+                    Set(["mustard seed", "onion", "kale", "cherry tomatoes", "bacon", "paleo mayonnaise"]),
+                    Set(["purple sweet potato", "chiles de árbol", "garlic", "tomatoes", "safflower oil", "black pepper", "mexican oregano", "avocados", "shallots", "cumin", "olive oil", "lemons", "whole chicken", "limes", "kosher salt"]),
+                    Set(["garlic", "black pepper", "dried apricots", "roma tomatoes", "water", "olive oil", "honey", "cinnamon", "ground cumin", "cider vinegar", "chili powder", "safflower oil", "homemade tamarind concentrate", "white chicken", "allspice", "chipotles", "salt", "homemade apricot honey preserves", "kosher salt"]),
+                    Set(["green onions", "serrano chili", "shredded red cabbage", "smoked paprika", "mango", "eggs", "black pepper", "cilantro", "cauliflower", "avocado", "lime", "cumin", "salt", "tilapia"]),
+                    Set(["cilantro leaves", "lime", "pineapple", "chipotle chili", "garlic", "mangoes", "cauliflower", "avocado", "serrano chili", "pork chops", "lime zest", "lacinato kale", "onions"]),
+                    Set(["pine nuts", "shrimp", "green bell pepper", "lemon juice", "basil", "lemon zest", "garlic", "tomatoes", "cashews", "yellow bell pepper", "cumin", "zucchini", "salt", "olive oil", "red bell pepper"])
+                    ],
+
+                    [Set(["parmesan", "almond meal", "rosemary", "mozzarella cheese", "roasted chicken", "tomato paste", "cauliflower", "cherry tomatoes", "eggs", "fresh basil", "olive oil"]),
+                    Set(["white vinegar", "asparagus", "flank steak", "chipotle chili", "scallions", "garlic", "black pepper", "cauliflower", "sour cream", "fresh parsley", "salt", "olive oil"]),
+                    Set(["soy sauce", "watermelon radishes", "lime juice", "fish sauce", "mirin", "little gem lettuce heads", "peanut oil", "garlic", "sesame seeds", "oyster sauce", "spring onions", "avocado", "grilled king fish", "red cabbage"]),
+                    Set(["clove powder", "curry leaves", "coriander seeds", "ginger", "cardamom powder", "vinegar", "mustard seeds", "mango powder", "garam masala", "red chili powder", "chicken", "hing", "turmeric powder", "tomatoes", "ginger garlic paste", "fresh greek yogurt", "fresh ginger", "monk fruit", "turmeric", "cashew nuts", "salt", "fresh red chili", "cinnamon powder", "nigella seeds", "whole small crimini mushrooms", "brussel sprouts", "garlic", "mangoes", "heavy cream", "cloves", "coriander powder", "cumin powder", "cardamom", "green chili", "cinnamon", "garlic paste", "red chili flakes", "lemon juice", "cilantro", "butter", "dried fenugreek leaves", "boned chicken"]),
+                    Set(["green onions", "parsley", "sesame seeds", "black pepper", "chives", "eggs", "fennel bulb", "tahini", "olive oil", "harissa", "shrimp", "lemon juice", "dill", "butter", "onion", "fresh cucumber", "monk fruit", "salt"]),
+                    Set(["sriacha", "apple cider vinegar", "lime juice", "fish sauce", "red and green thai chili", "flank steak", "carrot", "peanuts", "cucumbers", "roasted peanuts", "crunchy peanut butter", "kecap manis", "monk fruit", "micro cilantro", "olive oil"]),
+                    Set(["spinach", "parmesan cheese", "coconut flour", "chili flakes", "garlic", "black pepper", "cream cheese", "ghee", "lemon juice", "flaxmeal", "red onion", "salt", "salmon fillets", "pecans", "almond flour", "cumin", "fresh cucumber", "cherry tomatoes", "chives", "avocado mayonnaise"]),
+                    Set(["rosemary", "garlic", "black pepper", "thyme", "avocado oil", "eggs", "oregano", "asparagus", "lemon", "dijon mustard", "basil", "castelfranco radicchio", "dill", "butter", "pork chops", "monk fruit", "salt", "avocado mayonnaise"]),
+                    Set(["lime juice", "caster sugar", "toasted buckwheat", "lemon juice", "red wine vinegar", "red onion", "dutch carrot", "salmon steaks", "watercress", "pink peppercorns", "shallots", "fennel seeds", "red cabbage", "radishes"]),
+                    Set(["cilantro leaves", "green cabbage", "lemon juice", "pork belly", "dark soy sauce", "granny smith apples", "ginger", "light soy sauce", "sesame seeds", "black pepper", "cinnamon sticks", "spring onions", "star anise", "monk fruit", "olive oil"])
+                    ],
+
+                    [Set(["lime juice", "salsa", "green bell pepper", "anaheim chili", "black pepper", "olive oil", "yellow mustard", "red bell pepper", "soy sauce", "mexican crema", "mayonnaise", "white onion", "garlic cloves", "fresh corn tortillas", "red onion", "tomatoes", "limes", "worcestershire sauce", "butter", "yellow bell pepper", "salt", "red snapper"]),
+                    Set(["lime juice", "poblano chili", "tomato paste", "black pepper", "chipotle adobo sauce", "chile manzano", "roma tomatoes", "pepitas", "oaxaca cheese", "white onion", "shelled large shrimp", "garlic cloves", "fresh corn tortillas", "red onion", "worcestershire sauce", "avocado", "butter", "kosher salt"]),
+                    Set(["fresh tortillas", "shrimp", "garlic", "chickpeas", "black pepper", "slivered almonds", "guajillo chile", "bacon", "sea salt", "butter", "onion", "avocado", "olive oil"]),
+                    Set(["lime juice", "green cabbage", "chiles de árbol", "green cardamom", "ginger", "carrot", "sriracha", "black pepper", "cinnamon sticks", "celery seeds", "cloves", "black cardamom", "olive oil", "chicken wings", "apple cider vinegar", "mayonnaise", "honey", "black peppercorns", "lemon juice", "garlic cloves", "tamarind concentrate", "cilantro", "butter", "serrano chili", "red cabbage", "kosher salt"]),
+                    Set(["whole-milk yogurt", "chaat masala", "ginger", "pani puri", "scallion chutney", "yukon gold potato", "black chickpeas", "thin sev", "date syrup", "red onion", "roasted chicken", "chili powder", "tamarind concentrate", "cumin", "turmeric", "mint"]),
+                    Set(["white vinegar", "parsley", "yellow onion", "rhubarb", "garlic", "brown sugar", "black pepper", "thyme", "crushed red pepper flakes", "fennel bulbs", "beer", "marjoram", "vegetable oil", "soy sauce", "oregano", "lemon", "red onion", "chili powder", "cilantro", "beef brisket", "balsamic vinegar", "worcestershire sauce", "celery", "mint", "kosher salt"]),
+                    Set(["oranges", "rosemary", "garlic", "anchovy fillets", "couscous", "carrot", "sesame seeds", "fresh thyme", "vinegar", "olive oil", "tahini", "harissa", "onions", "honey", "fresh mint", "leg of lamb", "tomatoes", "baby carrot", "vegetable bullion", "filo pastry", "celery", "bay leaves", "yoghurt"]),
+                    Set(["tomato puree", "garlic", "ginger", "tomato", "carrot", "thyme", "white pepper", "water", "maggi cubes", "chicken", "rice", "coriander", "scotch bonnet pepper", "bell pepper", "onion", "turmeric", "salt"]),
+                    Set(["garlic", "tomato paste", "baby scallops", "mussels", "water", "crab legs", "olive oil", "baby squid", "fish stock", "lemon juice", "white onion", "arborio risotto rice", "clams", "parmesan cheese", "flat-leaf parsley", "cherry tomatoes", "prawns", "white wine"]),
+                    Set(["toasted bread", "rosemary", "hazelnuts", "anchovy fillets", "garlic", "carrot", "summer squash", "black pepper", "red pepper flakes", "vinegar", "sea salt", "zucchini", "olive oil", "onions", "white wine vinegar", "fresh mint", "leg of lamb", "lemon", "fresh ricotta", "sugar", "celery", "bay leaves", "kosher salt"])
+                     ]]
+
+
+
+#####################################
+# Data for test_separate_appetizers #
+#####################################
+
+
+vegan = ["Kisir with Warm Pita", "Shakshuka", "Vegetarian Khoresh Bademjan", "Baked Kelewele", "Waakye", "Georgian Eggplant Rolls with Walnuts", "Burmese Tofu with Garlic, Ginger and Chili Sauce", "Celeriac Schnitzel", "Sticky Lemon Tofu", "Vegan Carbonara", "Vegan Pizza with Caramelized Onions", "Cheela with Spicy Mango Chutney", "Sweet and Spicy Crispy Green Beans", "Vegan Mini Savory Mince Pies", "Roasted Corn and Zucchini Salad", "Golden Potato Salad", "Carrot Puff Pastry Tart", "Kisir with Warm Pita", "Baked Kelewele", "Burmese Tofu with Garlic, Ginger and Chili Sauce", "Vegan Carbonara", "Sweet and Spicy Crispy Green Beans", "Golden Potato Salad"]
+vegan_appetizers = ["Georgian Eggplant Rolls with Walnuts", "Cheela with Spicy Mango Chutney", "Vegan Mini Savory Mince Pies", "Carrot Puff Pastry Tart", "Georgian Eggplant Rolls with Walnuts", "Carrot Puff Pastry Tart"]
+vegan_dishes = ["Golden Potato Salad", "Roasted Corn and Zucchini Salad", "Sticky Lemon Tofu", "Shakshuka", "Burmese Tofu with Garlic, Ginger and Chili Sauce", "Vegan Pizza with Caramelized Onions", "Celeriac Schnitzel", "Waakye", "Vegan Carbonara", "Sweet and Spicy Crispy Green Beans", "Vegetarian Khoresh Bademjan", "Baked Kelewele", "Kisir with Warm Pita"]
+vegan_appetizer_names = ["Georgian Eggplant Rolls with Walnuts","Cheela with Spicy Mango Chutney","Vegan Mini Savory Mince Pies","Carrot Puff Pastry Tart"]
+
+
+vegetarian = ["Mushroom Lasagna", "Nut Wellington", "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", "Cambodian-Style Vegetable Spring Rolls", "Summer Minestrone Cups", "Fried Zucchini with Balsamic and Chili Dressing", "Barley Risotto", "Cherry Tomato, Watercress and Fava Bean Salad", "Fresh Garden Peas over Cauliflower Almond Puree", "Walnut Ravioli with Artichokes and Tomatoes", "Asparagus Puffs", "Grilled Tofu Tacos", "Mushroom Lasagna", "Cambodian-Style Vegetable Spring Rolls", "Barley Risotto", "Walnut Ravioli with Artichokes and Tomatoes"]
+vegetarian_appetizers = ["Cambodian-Style Vegetable Spring Rolls", "Summer Minestrone Cups", "Asparagus Puffs", "Grilled Tofu Tacos", "Cambodian-Style Vegetable Spring Rolls", "Grilled Tofu Tacos"]
+vegetarian_dishes = ["Walnut Ravioli with Artichokes and Tomatoes", "Mushroom Lasagna", "Fried Zucchini with Balsamic and Chili Dressing", "Barley Risotto", "Nut Wellington", "Cherry Tomato, Watercress and Fava Bean Salad", "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", "Fresh Garden Peas over Cauliflower Almond Puree"]
+vegetarian_appetizer_names = ["Cambodian-Style Vegetable Spring Rolls","Summer Minestrone Cups","Asparagus Puffs","Grilled Tofu Tacos"]
+
+
+paleo = ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "Avocado Deviled Eggs", "Grilled Flank Steak with Caesar Salad", "Pumpkin Bread Crostini", "BLT Bites", "Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", "Chicken with Tamarind and Apricot Sauce", "Grilled Fish Tacos with Cauliflower Tortillas", "Grilled Pork Chops with Mango Pineapple Salsa", "Grilled Shrimp and Pesto over Zucchini Noodles", "Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "Pumpkin Bread Crostini", "Chicken with Tamarind and Apricot Sauce", "Grilled Shrimp and Pesto over Zucchini Noodles"]
+paleo_appetizers = ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "Avocado Deviled Eggs", "Pumpkin Bread Crostini", "BLT Bites", "Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "BLT Bites"]
+paleo_dishes = ["Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", "Grilled Flank Steak with Caesar Salad", "Grilled Fish Tacos with Cauliflower Tortillas", "Grilled Pork Chops with Mango Pineapple Salsa", "Grilled Shrimp and Pesto over Zucchini Noodles", "Chicken with Tamarind and Apricot Sauce"]
+paleo_appetizer_names = ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt","Avocado Deviled Eggs","Pumpkin Bread Crostini","BLT Bites"]
+
+
+keto = ["Cauliflower Pizza with Roasted Tomatoes and Chicken", "Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", "Prawn and Herb Omelette", "Satay Steak Skewers", "Parmesan Crackers and Spinach Crackers with Salmon Pate", "Pork Chops with Grilled Castelfranco Radicchio and Asparagus", "Seared Salmon with Pickled Vegetable and Watercress Salad", "Braised Pork Belly with Apple Salad", "Cauliflower Pizza with Roasted Tomatoes and Chicken", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", "Parmesan Crackers and Spinach Crackers with Salmon Pate", "Braised Pork Belly with Apple Salad"]
+keto_appetizers = ["Kingfish Lettuce Cups", "Prawn and Herb Omelette", "Satay Steak Skewers", "Parmesan Crackers and Spinach Crackers with Salmon Pate", "Kingfish Lettuce Cups", "Parmesan Crackers and Spinach Crackers with Salmon Pate"]
+keto_dishes = ["Cauliflower Pizza with Roasted Tomatoes and Chicken", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", "Braised Pork Belly with Apple Salad", "Seared Salmon with Pickled Vegetable and Watercress Salad", "Pork Chops with Grilled Castelfranco Radicchio and Asparagus", "Flank Steak with Chimichurri and Asparagus"]
+keto_appetizer_names = ["Kingfish Lettuce Cups","Prawn and Herb Omelette","Satay Steak Skewers","Parmesan Crackers and Spinach Crackers with Salmon Pate"]
+
+
+omnivore = ["Beachside Snapper", "Governor Shrimp Tacos", "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", "Burnt Masala Wings with Classic Coleslaw", "Dahi Puri with Black Chickpeas", "Brisket with Grilled Rhubarb, Onions, and Fennel", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", "Baked Chicken Jollof Rice", "Seafood Risotto", "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", "Beachside Snapper", "Burnt Masala Wings with Classic Coleslaw", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta"]
+omnivore_appetizers = ["Governor Shrimp Tacos", "Burnt Masala Wings with Classic Coleslaw", "Dahi Puri with Black Chickpeas", "Seafood Risotto", "Governor Shrimp Tacos", "Seafood Risotto"]
+omnivore_dishes = ["Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", "Brisket with Grilled Rhubarb, Onions, and Fennel", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", "Beachside Snapper", "Baked Chicken Jollof Rice"]
+omnivore_appetizer_names = ["Governor Shrimp Tacos","Burnt Masala Wings with Classic Coleslaw","Dahi Puri with Black Chickpeas","Seafood Risotto"]
+
+
+dishes_and_appetizers = ((vegan, vegan_appetizers),
+                         (vegetarian, vegetarian_appetizers),
+                         (paleo, paleo_appetizers),
+                         (keto, keto_appetizers),
+                         (omnivore, omnivore_appetizers)
+                        )
+
+dishes_cleaned = (vegan_dishes,
+                  vegetarian_dishes,
+                  paleo_dishes,
+                  keto_dishes,
+                  omnivore_dishes
+                  )
+
+
+#######################################
+# Data for test_singleton_ingredients #
+#######################################
+
+
+intersections = (VEGAN_INTERSECTIONS, VEGETARIAN_INTERSECTIONS, PALEO_INTERSECTIONS,
+                 KETO_INTERSECTIONS, OMNIVORE_INTERSECTIONS)
+
+dishes_and_overlap = [(item[1], item[2]) for item in zip(ingredients_only, intersections)]
+ingredients = (union(group...) for group in ingredients_only)
+singletons  = (symdiff(item[1], item[2]) for item in zip(ingredients, intersections))
+
+backup_singletons = [Set(["black-eyed peas", "coriander", "cashews", "yellow split peas", "pomegranate seeds", "cumin", "mangoes", "pomegranate concentrate", "red chili powder", "slivered almonds", "black peppercorn", "cornstarch", "smoked tofu", "curry leaves", "zucchini", "currants", "dried cranberries", "yukon gold potato", "tofu", "yeast", "fresh basil", "hot water", "ripe plantains", "calabash nutmeg", "green beans", "kosher salt", "grains of selim", "vegetarian worcestershire sauce", "cumin seeds", "figs", "ground turmeric", "white rice", "harissa", "garlic powder", "scallions", "barberries", "walnuts", "basmati rice", "saffron powder", "butternut squash", "thyme", "tomato", "chopped parsley", "hing", "coriander seeds", "turmeric powder", "eggplants", "sesame oil", "za'atar", "pareve puff pastry", "firm tofu", "yellow onions", "coriander powder", "parsley", "garlic paste", "rice vinegar", "sorghum stems", "spring onions", "raisins", "chinese eggplants", "garam masala", "ground almonds", "baking soda", "clove powder", "allspice powder", "parev shortcrust pastry", "dill", "nigella seeds", "dried blueberries", "cardamom powder", "cilantro", "serrano chili", "breadcrumbs", "mango powder", "dried cherries", "oregano", "fresh red chili", "pecans", "chives", "spaghetti", "mixed herbs", "brandy", "cumin powder", "silken tofu", "yellow onion", "balsamic vinegar", "persian cucumber", "red bell pepper", "peanuts", "siracha", "red pepper flakes", "spring onion", "vegan unsweetened yoghurt", "corn", "khmeli suneli", "barley malt", "green onions", "apples", "corn flour", "honey", "celeriac", "bulgur", "sesame seeds", "mashed potatoes", "chili flakes", "vegetable oil"]),
+                     Set(["vegetarian fish sauce", "cashews", "white wine", "portobello mushrooms", "marmite", "dates", "tomatillos", "cumin", "chestnuts", "beets", "masa", "mint", "smoked tofu", "fresh pea tendrils", "puff pastry sheets", "zucchini", "currants", "hazelnuts", "croutons", "pearl barley", "dijon mustard", "yukon gold potato", "fresh tomatoes", "vermicelli noodles", "fresh cherry tomatoes", "celery", "hot water", "green beans", "grated nutmeg", "roasted corn", "palm sugar", "ancho chili", "fresh corn", "spring roll wrappers", "cotija cheese", "parmesan rind", "pasta sheets", "brazil nuts", "cauliflower", "butternut squash", "mint leaves", "fresh cherry bocconcini", "crema", "blue cheese", "chickpeas", "pasilla chili", "black beans", "wombok", "capers", "pine nuts", "egg", "shiitake mushrooms", "red thai chili", "jalapeño chili", "toasted peanuts", "brussel sprouts", "lime juice", "leeks", "flour", "dried lasagna noodles", "onions", "limes", "chipotle chili", "lacinato kale", "fresh pumpkin", "almonds", "olives", "onion", "fresh artichoke hearts", "leek", "pecans", "chives", "blanched almonds", "nutmeg", "fresh or frozen fava beans", "soy sauce", "avocados", "bean sprouts", "asparagus", "feta cheese", "sharp white cheddar", "apples", "sunflower oil", "corn flour", "avocado", "puff pastry", "red cabbage", "pomegranate", "fresh cilantro leaves", "oil marinated artichokes", "vegetable oil"]),
+                     Set(["treviso", "cashews", "mexican oregano", "pumpkin puree", "purple sweet potato", "homemade apricot honey preserves", "apple cider vinegar", "homemade tamarind concentrate", "paleo parmesan cheese", "pineapple", "green bell pepper", "chipotles", "nutmeg", "ground cumin", "coconut yogurt", "kale", "mangoes", "red bell pepper", "dried apricots", "garlic powder", "pepitas", "white vinegar", "scallions", "avocados", "shredded red cabbage", "smoked paprika", "lime juice", "flank steak", "fresh parsley", "shallots", "chiles de árbol", "yellow bell pepper", "white chicken", "whole chicken", "chili powder", "bacon", "avocado mayonnaise", "cilantro", "limes", "lemons", "green onions", "avocado oil", "cloves", "lacinato kale", "lime zest", "paleo mayonnaise", "radishes", "mango", "dijon mustard", "mustard seed", "cider vinegar", "pork chops", "castelfranco radicchio", "water", "allspice", "seranno chili", "cilantro leaves", "onion", "tilapia", "fresh cilantro leaves", "worcestershire sauce", "almond butter", "fresh thai chili", "fresh red chili", "chives", "roma tomatoes"]),
+                     Set(["dried fenugreek leaves", "apple cider vinegar", "cinnamon sticks", "roasted chicken", "cumin", "mangoes", "heavy cream", "micro cilantro", "white vinegar", "red chili powder", "cinnamon powder", "mustard seeds", "red wine vinegar", "mirin", "cinnamon", "green chili", "avocado oil", "curry leaves", "star anise", "dijon mustard", "crunchy peanut butter", "grilled king fish", "chicken", "fresh basil", "cashew nuts", "pink peppercorns", "pork belly", "spinach", "watercress", "whole small crimini mushrooms", "coconut flour", "fresh ginger", "fennel bulb", "harissa", "tahini", "mozzarella cheese", "scallions", "sriacha", "fresh parsley", "thyme", "light soy sauce", "cream cheese", "hing", "coriander seeds", "sour cream", "turmeric powder", "castelfranco radicchio", "parmesan", "toasted buckwheat", "coriander powder", "dark soy sauce", "granny smith apples", "parsley", "shrimp", "garlic paste", "roasted peanuts", "turmeric", "carrot", "garam masala", "clove powder", "cucumbers", "tomato paste", "almond meal", "dutch carrot", "brussel sprouts", "red and green thai chili", "shallots", "nigella seeds", "cardamom powder", "watermelon radishes", "flaxmeal", "cilantro", "fennel seeds", "chipotle chili", "ghee", "parmesan cheese", "radishes", "pork chops", "cilantro leaves", "fresh greek yogurt", "cardamom", "mango powder", "onion", "oregano", "fresh red chili", "pecans", "salmon fillets", "basil", "green cabbage", "cumin powder", "almond flour", "lemon", "boned chicken", "oyster sauce", "soy sauce", "little gem lettuce heads", "peanut oil", "peanuts", "caster sugar", "salmon steaks", "ginger garlic paste", "green onions", "vinegar", "cloves", "kecap manis", "avocado", "chili flakes", "red chili flakes", "tomatoes"]),
+                     Set(["coriander", "white wine", "fish stock", "apple cider vinegar", "salsa", "rhubarb", "beef brisket", "cinnamon sticks", "cumin", "roasted chicken", "chicken wings", "white vinegar", "sriracha", "slivered almonds", "fresh thyme", "scotch bonnet pepper", "zucchini", "hazelnuts", "pani puri", "yukon gold potato", "toasted bread", "chicken", "yoghurt", "maggi cubes", "couscous", "roma tomatoes", "celery seeds", "chaat masala", "white pepper", "black cardamom", "harissa", "red snapper", "green cardamom", "crushed red pepper flakes", "tahini", "mexican crema", "chiles de árbol", "tomato", "baby squid", "mussels", "chipotle adobo sauce", "shelled large shrimp", "tomato puree", "chickpeas", "fresh tortillas", "flat-leaf parsley", "anaheim chili", "parsley", "shrimp", "chile manzano", "vegetable bullion", "prawns", "cherry tomatoes", "marjoram", "beer", "green bell pepper", "date syrup", "guajillo chile", "baby scallops", "yellow mustard", "black chickpeas", "bell pepper", "filo pastry", "thin sev", "bacon", "white wine vinegar", "limes", "rice", "serrano chili", "brown sugar", "parmesan cheese", "poblano chili", "fennel bulbs", "clams", "baby carrot", "arborio risotto rice", "oregano", "oaxaca cheese", "green cabbage", "yellow onion", "balsamic vinegar", "whole-milk yogurt", "sugar", "red bell pepper", "pepitas", "red pepper flakes", "oranges", "yellow bell pepper", "summer squash", "cloves", "red cabbage", "black peppercorns", "fresh ricotta", "crab legs", "scallion chutney", "sesame seeds", "vegetable oil"])]
+
+
+
+"""Functions for compiling dishes and ingredients for a catering company."""
+
+
+"""Remove duplicates from `dish_ingredients`.
+:param dish_name: String - containing the dish name.
+:param dish_ingredients: Vector - dish ingredients.
+:return: tuple - containing (dish_name, ingredient set).
+This function should return a `Tuple` with the name of the dish as the first item,
+followed by the de-duped `Set` of ingredients as the second item.
+"""
+function clean_ingredients(dish_name, dish_ingredients)
+    (dish_name, Set(dish_ingredients))
+end
+
+"""Append "Cocktail" (alcohol)  or "Mocktail" (no alcohol) to `drink_name`, based on `drink_ingredients`.
+:param drink_name: String - name of the drink.
+:param drink_ingredients: Vector - ingredients in the drink.
+:return: String - drink_name appended with "Mocktail" or "Cocktail".
+The function should return the name of the drink followed by "Mocktail" (non-alcoholic) and drink
+name followed by "Cocktail" (includes alcohol).
+"""
+function check_drinks(drink_name, drink_ingredients)
+    drink_name * (isdisjoint(drink_ingredients, ALCOHOLS) ? " Mocktail" : " Cocktail")
+end
+
+"""Categorize `dish_name` based on `dish_ingredients`.
+:param dish_name: String - dish to be categorized.
+:param dish_ingredients: Set - ingredients for the dish.
+:return: String - the dish name appended with ": <CATEGORY>".
+This function should return a string with the `dish name: <CATEGORY>` (which meal category the dish belongs to).
+`<CATEGORY>` can be any one of  (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
+All dishes will "fit" into one of the categories imported from `sets_categories_data.py`
+"""
+function categorize_dish(dish_name, dish_ingredients)
+    for category in ("VEGAN"=>VEGAN, "VEGETARIAN"=>VEGETARIAN, "PALEO"=>PALEO, "KETO"=>KETO, "OMNIVORE"=>OMNIVORE)
+        dish_ingredients ⊆ category.second && return dish_name * ": " * category.first
+    end
+end
+
+"""Compare `dish` ingredients to `SPECIAL_INGREDIENTS`.
+:param dish: Tuple - of (dish name, list of dish ingredients).
+:return: Tuple - containing (dish name, dish special ingredients).
+Return the dish name followed by the `Set` of ingredients that require a special note on the dish description.
+For the purposes of this exercise, all allergens or special ingredients that need to be tracked are in the
+SPECIAL_INGREDIENTS constant imported from `sets_categories_data.py`.
+"""
+function tag_special_ingredients((dish_name, dish_ingredients))
+    (dish_name, SPECIAL_INGREDIENTS ∩ dish_ingredients)
+end
+
+"""Create a master list of ingredients.
+:param dishes: Vector - of dish ingredient sets.
+:return: Set - of ingredients compiled from `dishes`.
+This function should return a `Set` of all ingredients from all listed dishes.
+"""
+function compile_ingredients(dishes)
+    union(dishes...)
+end
+
+"""Determine which `dishes` are designated `appetizers` and remove them.
+:param dishes: Vector - of dish names.
+:param appetizers: Vector - of appetizer names.
+:return: Vector - of dish names that do not appear on appetizer list.
+The function should return the vector of dish names with appetizer names removed.
+Either vector could contain duplicates and may require de-duping.
+"""
+function separate_appetizers(dishes, appetizers)
+    setdiff(dishes, appetizers)
+end
+
+"""Determine which `dishes` have a singleton ingredient (an ingredient that only appears once across dishes).
+:param dishes: Vector - of ingredient sets.
+:param intersection: constant - can be one of `<CATEGORY>_INTERSECTIONS` constants imported from `sets_categories_data.py`.
+:return: Set - containing singleton ingredients.
+Each dish is represented by a `Set` of its ingredients.
+Each `<CATEGORY>_INTERSECTIONS` is an `intersection` of all dishes in the category. `<CATEGORY>` can be any one of:
+    (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
+The function should return a `Set` of ingredients that only appear in a single dish.
+"""
+function singleton_ingredients(dishes, intersection)
+    setdiff(union(dishes...), intersection)
+end

--- a/exercises/concept/cater-waiter/cater-waiter.jl
+++ b/exercises/concept/cater-waiter/cater-waiter.jl
@@ -1,0 +1,29 @@
+include("sets_categories_data.jl")
+
+function clean_ingredients(dish_name, dish_ingredients)
+
+end
+
+function check_drinks(drink_name, drink_ingredients)
+
+end
+
+function categorize_dish(dish_name, dish_ingredients)
+
+end
+
+function tag_special_ingredients(dish)
+
+end
+
+function compile_ingredients(dishes)
+
+end
+
+function separate_appetizers(dishes, appetizers)
+
+end
+
+function singleton_ingredients(dishes, intersection)
+
+end

--- a/exercises/concept/cater-waiter/runtests.jl
+++ b/exercises/concept/cater-waiter/runtests.jl
@@ -1,0 +1,63 @@
+using Test 
+
+include("cater-waiter.jl")
+
+@testset verbose=true "tests" begin
+    @testset "clean ingredients" begin
+        test_data = zip(recipes_with_duplicates[1:3:end], recipes_without_duplicates[1:3:end])
+
+        for (item, result) in test_data
+            @test clean_ingredients(item[1], item[2]) == (result[2], result[3])
+        end
+     end
+
+    @testset "check_drinks" begin
+        test_data = zip(all_drinks[1:2:end], drink_names[1:2:end])
+
+        for (item, result) in test_data
+            @test check_drinks(item[1], item[2]) == result
+        end
+    end
+
+    @testset "categorize dish" begin
+        test_data = zip(sort(recipes_without_duplicates, rev=true)[1:3:end], dishes_categorized[1:3:end])
+
+        for (item, result) in test_data
+            @test categorize_dish(item[2], item[3]) == result
+        end
+    end
+
+    @testset "tag special ingredients" begin
+        test_data = zip(dishes_to_special_label[1:3:end], dishes_labeled[1:3:end])
+
+        for (item, result)  in test_data
+            @test tag_special_ingredients(item) == result
+        end
+    end
+
+    @testset "compile ingredients" begin
+        test_data = zip(ingredients_only, [VEGAN, VEGETARIAN, PALEO, KETO, OMNIVORE])
+
+        for (item, result) in test_data
+            @test compile_ingredients(item) == result
+        end
+    end
+
+    @testset "separate appetizers" begin
+        test_data = zip(dishes_and_appetizers, dishes_cleaned)
+
+        for (item, result) in test_data
+            separateappetizers = separate_appetizers(item[1], item[2])
+            @test isa(separateappetizers, Vector)
+            @test sort(separateappetizers) == sort(result)
+        end
+    end
+
+    @testset "singleton ingredients" begin
+        test_data = zip(dishes_and_overlap, singletons)
+
+        for (item, result) in test_data
+            @test singleton_ingredients(item[1], item[2]) == result
+        end
+    end
+end

--- a/exercises/concept/cater-waiter/sets_categories_data.jl
+++ b/exercises/concept/cater-waiter/sets_categories_data.jl
@@ -1,0 +1,678 @@
+VEGAN = Set([
+            "chives", "nutritional yeast", "tomato", "orange zest", "pareve puff pastry", "cashews", "tofu",
+            "rice vinegar", "black pepper", "cardamom powder", "mustard seeds", "parev shortcrust pastry",
+            "scallions", "water", "chinese eggplants", "lemon juice", "smoked paprika", "cloves", "basmati rice",
+            "cayenne pepper", "green onions", "sunflower oil", "mixed herbs", "garlic paste", "parsley",
+            "fresh red chili", "flour", "garlic", "oregano", "green beans", "harissa", "brandy", "fresh basil",
+            "coriander",  "vinegar", "thyme", "coriander seeds", "clove powder", "pomegranate seeds",
+            "sugar", "yukon gold potato", "sesame oil", "cinnamon powder", "butternut squash", "allspice powder",
+            "red pepper flakes", "soy sauce", "sesame seeds", "cornstarch", "mango powder", "vegetable stock",
+            "raisins", "barley malt", "olive oil", "ground almonds", "white rice", "garlic powder", "walnuts",
+            "saffron powder", "red chili powder", "turmeric powder", "spring onions", "yeast", "khmeli suneli",
+            "peanuts", "bulgur", "cilantro", "onion", "calabash nutmeg", "black-eyed peas", "grains of selim",
+            "zucchini", "currants", "spaghetti", "figs", "red bell pepper", "lemon zest", "ground turmeric",
+            "chili flakes", "chickpea flour", "hing", "slivered almonds", "vegetable oil", "serrano chili",
+            "salt", "yellow onions", "salt", "coriander powder", "orange zest", "garam masala", "yellow onion",
+            "smoked tofu", "bell pepper", "apples", "brown sugar", "coconut oil", "orange juice",
+            "sorghum stems", "dried blueberries", "tomato paste", "curry leaves", "vegetarian worcestershire sauce",
+            "hot water", "fresh ginger", "firm tofu", "eggplants", "bell pepper", "siracha", "carrot", "nigella seeds",
+            "vegan butter", "za'atar", "baking soda", "brown sugar", "dried cranberries", "kosher salt", "mangoes",
+            "vegan unsweetened yoghurt", "black peppercorn", "vinegar", "dill", "barberries", "honey", "tomatoes",
+            "yellow split peas", "persian cucumber", "turmeric", "lemon", "cumin", "oil", "mushrooms", "spring onion",
+            "pomegranate concentrate", "cumin seeds", "balsamic vinegar", "ripe plantains", "celeriac", "breadcrumbs",
+            "ginger", "dried cherries", "red onion", "rosemary", "chopped parsley", "corn", "cumin powder", "pecans",
+            "silken tofu", "pomegranate molasses", "carrot", "corn flour", "mashed potatoes"
+            ])
+
+
+VEGETARIAN = Set([
+                "almonds", "chives", "limes", "puff pastry", "onion", "cashews", "red cabbage", "red wine vinegar",
+                "brussel sprouts", "fresh corn", "black pepper", "lemon juice", "roasted corn", "eggs",
+                "fresh cilantro leaves", "shiitake mushrooms", "sunflower oil", "sage", "dijon mustard",
+                "blanched almonds", "dates", "flour", "fresh pea tendrils", "garlic", "egg", "green beans",
+                "yukon gold potato", "vermicelli noodles", "onions", "avocado", "dried lasagna noodles",
+                "thyme", "cauliflower", "basil", "watercress", "black beans", "butternut squash", "red thai chili",
+                "masa", "red chili", "red onions", "jalapeño chili", "grated nutmeg", "feta cheese", "hazelnuts",
+                "soy sauce", "shallots", "chipotle chili", "vegetable bullion", "fresh cherry tomatoes", "olive oil",
+                "milk", "fresh cherry bocconcini", "crema", "marmite", "walnuts", "nutmeg", "ricotta cheese",
+                "chestnuts", "mint leaves", "lime juice", "white wine", "apples", "pearl barley", "cotija cheese",
+                "zucchini", "currants", "leek", "pomegranate", "lemon zest", "avocados", "parmesan cheese", "mint",
+                "leeks", "fresh artichoke hearts", "vegetable oil", "brazil nuts", "red chili", "sharp white cheddar",
+                "salt", "pepitas", "green lentils", "beets", "celery", "smoked tofu", "fresh tomatoes",
+                "puff pastry sheets", "palm sugar", "vegetarian fish sauce", "oil marinated artichokes", "hot water",
+                "chickpeas", "firm tofu", "wombok", "carrot", "asparagus", "bean sprouts", "kosher salt",
+                "pasilla chili", "tomatillos", "parmesan rind", "pasta sheets", "cream", "butter", "croutons",
+                "lacinato kale", "fresh or frozen fava beans", "fresh pumpkin", "honey", "tomatoes", "olives",
+                "capers", "pine nuts", "lemon", "cumin", "ancho chili", "fresh peas", "spring roll wrappers",
+                "balsamic vinegar", "portobello mushrooms", "breadcrumbs", "blue cheese", "red onion",
+                "rosemary", "pecans", "carrot", "corn flour", "toasted peanuts"
+                ])
+
+PALEO = Set([
+            "cinnamon", "chiles de árbol", "chives", "limes", "allspice", "zucchini", "seranno chili", "lemon zest",
+            "apple cider vinegar", "avocados", "cashews", "mango", "cilantro leaves", "pepitas", "white chicken",
+            "chipotles", "black pepper", "scallions", "pumpkin puree", "water", "serrano chili", "lemon juice",
+            "smoked paprika", "homemade apricot honey preserves", "eggs", "salt", "flank steak", "fresh cilantro leaves",
+            "cider vinegar", "cloves", "purple sweet potato", "coconut yogurt", "green onions", "tilapia",
+            "yellow bell pepper", "coconut oil", "whole chicken", "coconut oil", "safflower oil", "roma tomatoes",
+            "fresh red chili", "fresh thai chili", "shrimp", "garlic", "onions", "lime", "avocado", "fresh parsley",
+            "cauliflower", "shredded red cabbage", "basil", "baking soda", "serrano chili",
+            "cherry tomatoes", "kale", "bacon", "kosher salt", "mangoes", "lacinato kale", "shallots", "pineapple",
+            "chipotle chili", "white vinegar", "honey", "tomatoes", "homemade tamarind concentrate",
+            "mexican oregano", "olive oil", "pine nuts", "garlic powder", "coconut flour", "green bell pepper",
+            "dried apricots", "cumin", "nutmeg", "kosher salt", "onions", "mustard seed", "lemons", "lime zest",
+            "ground cumin", "almond butter", "chili powder", "lime juice", "paleo mayonnaise", "pork chops",
+            "cilantro", "onion", "red bell pepper", "paleo parmesan cheese", "radishes", "avocado oil",
+            "dijon mustard", "avocado mayonnaise", "castelfranco radicchio", "worcestershire sauce", "treviso"
+            ])
+
+KETO = Set([
+            "cinnamon", "avocado oil", "chives", "sriacha", "almond flour", "crunchy peanut butter",
+            "cucumbers", "cream cheese", "red cabbage", "red wine vinegar", "brussel sprouts", "black pepper",
+            "cardamom powder", "mustard seeds", "scallions", "kecap manis", "lemon juice", "eggs", "tahini",
+            "cloves", "green onions", "dijon mustard", "garlic paste", "watermelon radishes", "parmesan",
+            "parsley", "star anise", "fresh cucumber", "fresh red chili", "shrimp", "garlic", "oregano",
+            "fennel bulb", "harissa", "dutch carrot", "fresh basil", "avocado", "clove powder", "coriander seeds",
+            "thyme", "fresh parsley", "chicken", "cauliflower", "basil", "watercress", "cinnamon powder",
+            "cherry tomatoes", "soy sauce", "sesame seeds", "micro cilantro", "mozzarella cheese", "shallots",
+            "mango powder", "chipotle chili", "olive oil", "spinach", "pink peppercorns", "coconut flour",
+            "salmon steaks", "dark soy sauce", "red chili powder", "turmeric powder", "spring onions",
+            "lime juice", "ginger garlic paste", "pork chops", "peanuts", "dried fenugreek leaves", "cilantro",
+            "onion", "salmon fillets", "toasted buckwheat", "whole small crimini mushrooms", "caster sugar",
+            "granny smith apples", "green cabbage", "apple cider vinegar", "chili flakes", "parmesan cheese",
+            "hing", "castelfranco radicchio", "cilantro leaves", "fresh greek yogurt", "roasted chicken", "ghee",
+            "flaxmeal", "flank steak", "salt", "coriander powder", "boned chicken", "red chili flakes",
+            "garam masala", "almond meal", "peanut oil", "tomato paste", "oyster sauce",
+            "curry leaves", "fresh ginger", "cardamom", "radishes", "little gem lettuce heads",
+            "grilled king fish", "carrot", "cinnamon sticks", "heavy cream", "asparagus", "nigella seeds",
+            "light soy sauce", "pork belly", "green chili", "mangoes", "red and green thai chili", "butter",
+            "vinegar", "dill", "fish sauce", "white vinegar", "tomatoes", "mirin",
+            "avocado mayonnaise", "turmeric", "lemon", "cumin", "fennel seeds", "lemon juice",  "salt",
+            "roasted peanuts", "ginger", "red onion", "rosemary", "cumin powder", "cashew nuts", "pecans",
+            "green chili","whole small crimini mushrooms", "monk fruit", "sour cream"
+            ])
+
+OMNIVORE = Set([
+                "clams", "prawns", "white wine vinegar", "date syrup", "limes", "tomato", "coriander",
+                "black chickpeas", "yellow bell pepper", "black cardamom", "baby squid", "pepitas",
+                "red cabbage", "baby scallops", "green cardamom", "black pepper", "chaat masala", "water",
+                "lemon juice", "tahini", "cloves", "white pepper", "fennel bulbs", "tomato puree",
+                "maggi cubes", "couscous", "yellow mustard", "parsley", "sriracha", "roma tomatoes",
+                "shrimp", "garlic", "oregano", "chicken wings", "yukon gold potato", "harissa", "onions",
+                "avocado", "thyme", "chicken", "sugar", "flat-leaf parsley", "celery seeds", "cherry tomatoes",
+                "mayonnaise", "scallion chutney", "red pepper flakes", "hazelnuts", "soy sauce", "sesame seeds",
+                "red snapper", "white onion", "vegetable bullion", "marjoram", "pani puri", "olive oil", "rice",
+                "serrano chili", "tamarind concentrate", "lime juice", "white wine", "beef brisket", "cilantro",
+                "onion", "crushed red pepper flakes", "chiles de árbol", "fresh mint", "zucchini", "red bell pepper",
+                "yoghurt", "apple cider vinegar", "parmesan cheese", "slivered almonds", "whole-milk yogurt",
+                "anchovy fillets", "fresh ricotta", "mint", "chile manzano", "roasted chicken", "sea salt",
+                "fresh thyme", "vegetable oil", "salt", "mexican crema", "celery", "yellow onion",
+                "worcestershire sauce", "fresh tortillas", "tomato paste", "oranges", "chickpeas",
+                "scotch bonnet pepper", "shelled large shrimp", "mussels", "summer squash", "salsa",
+                "garlic cloves", "fish stock", "bell pepper", "green bell pepper", "carrot", "cinnamon sticks",
+                "thin sev", "brown sugar", "baby carrot", "bacon", "kosher salt", "bay leaves", "anaheim chili",
+                "oaxaca cheese", "butter", "vinegar", "crab legs", "white vinegar", "honey", "tomatoes",
+                "green cabbage", "toasted bread", "turmeric", "lemon", "cumin", "black peppercorns", "poblano chili",
+                "arborio risotto rice", "fresh corn tortillas", "balsamic vinegar", "rhubarb", "ginger",
+                "guajillo chile", "filo pastry", "leg of lamb", "red onion", "chipotle adobo sauce", "rosemary",
+                "chili powder", "beer", "carrot"
+                ])
+
+SPECIAL_INGREDIENTS = Set([
+                            "cream","bacon", "garlic", "baby scallops", "mussels", "baby squid", "cashews", "salmon fillets",
+                            "filo pastry", "almonds", "milk", "blue cheese", "clams", "shrimp", "tomato puree", "chocolate",
+                            "honey", "anchovy fillets", "bulgur", "prawns", "parmesan cheese", "fish", "shelled large shrimp",
+                            "gluten", "crab legs", "feta cheese", "whole-milk yogurt", "crema", "firm tofu", "fish stock",
+                            "fresh ricotta", "tomato paste", "fresh cherry tomatoes", "pork chops", "eggs", "greek yogurt",
+                            "hazelnuts", "pecans", "brie cheese", "oaxaca cheese", "yellow onion", "whey", "silken tofu",
+                            "toasted bread", "parmesan", "beef", "tofu", "flour", "tomatoes", "red onion", "slivered almonds",
+                            "strawberries", "onions", "pine nuts", "cherry tomatoes", "soy sauce", "oyster sauce",
+                            "mozzarella cheese", "roma tomatoes", "heavy cream", "paneer", "pork tenderloin", "garlic cloves",
+                            "swiss cheese", "grilled king fish", "ground almonds", "tilapia", "sprint onion", "couscous",
+                            "walnuts", "semolina", "yogurt", "cotija cheese", "oysters", "spaghetti", "cheddar cheese",
+                            "butter", "lobster", "smoked tofu", "peanuts", "ground pork", "fresh cherry bocconcini",
+                            "pork belly", "toasted peanuts", "roasted peanuts"
+                            ])
+
+ALCOHOLS = Set([
+                "whiskey", "whisky", "white rum", "dark rum", "bourbon", "rye", "scotch", "vodka",
+                "tequila", "gin", "dry vermouth", "sweet vermouth", "prosecco","aperol", "brandy", "mezcal",
+                "triple sec", "coffee liqueur", "almond liqueur", "champagne", "orange curacao", "rum"
+                ])
+
+
+VEGAN_INTERSECTIONS = Set([
+                            "brown sugar", "carrot", "sugar", "vegetable stock", "fresh ginger", "nutritional yeast",
+                            "cayenne pepper", "olive oil", "lemon", "ginger", "red onion", "pomegranate molasses",
+                            "onion", "water", "chickpea flour", "orange zest", "coconut oil", "smoked paprika",
+                            "lemon zest", "sunflower oil", "orange juice", "black pepper", "cinnamon powder",
+                            "mushrooms", "cloves", "salt", "oil", "vegan butter", "turmeric", "tomato paste",
+                            "mustard seeds", "bell pepper", "rosemary", "vinegar", "tomatoes", "flour", "soy sauce",
+                            "lemon juice", "garlic"
+                            ])
+
+VEGETARIAN_INTERSECTIONS = Set([
+                                "carrot", "milk", "basil", "green lentils", "vegetable bullion", "red onions",
+                                "balsamic vinegar", "lemon", "olive oil", "butter", "honey", "red chili",
+                                "red onion", "breadcrumbs", "lemon zest", "pepitas", "black pepper", "fresh peas",
+                                "salt", "firm tofu", "ricotta cheese", "kosher salt", "watercress", "cream",
+                                "parmesan cheese", "shallots", "rosemary", "sage", "tomatoes", "walnuts",
+                                "lemon juice", "thyme", "garlic", "eggs", "red wine vinegar"
+                                ])
+
+PALEO_INTERSECTIONS = Set([
+                            "basil", "olive oil", "honey", "pine nuts", "baking soda", "shrimp", "cherry tomatoes",
+                            "coconut oil", "cinnamon", "lemon zest", "cumin", "black pepper", "lime", "salt",
+                            "zucchini", "kosher salt", "chipotle chili", "eggs", "coconut flour", "avocado",
+                            "cauliflower", "serrano chili", "safflower oil", "tomatoes", "lemon juice", "onions",
+                            "garlic"
+                            ])
+
+KETO_INTERSECTIONS = Set([
+                            "fresh cucumber", "red cabbage", "olive oil", "ginger", "butter", "dill", "red onion",
+                            "monk fruit", "cherry tomatoes", "spring onions", "lime juice", "fish sauce",
+                            "sesame seeds", "black pepper", "salt", "chives", "asparagus", "eggs",
+                            "avocado mayonnaise", "rosemary", "cauliflower", "flank steak", "lemon juice", "garlic"
+                            ])
+
+OMNIVORE_INTERSECTIONS = Set([
+                                "mint", "carrot", "fresh mint", "olive oil", "lemon", "ginger", "butter", "honey",
+                                "leg of lamb", "red onion", "bay leaves", "tamarind concentrate",
+                                "worcestershire sauce", "onion", "lime juice", "water", "anchovy fillets", "celery",
+                                "black pepper", "cilantro", "chili powder", "salt", "mayonnaise", "garlic cloves",
+                                "kosher salt", "white onion", "turmeric", "rosemary", "vinegar", "tomatoes",
+                                "sea salt", "soy sauce", "lemon juice", "onions", "thyme", "garlic", "avocado",
+                                "fresh corn tortillas", "tomato paste"
+                                ])
+
+
+EXAMPLE_INTERSECTION = Set([
+                            "fresh red chili", "sugar", "nutritional yeast", "fresh ginger", "red chili powder", "garlic",
+                            "olive oil", "mashed potatoes", "garam masala", "clove powder", "cumin powder", "onion",
+                            "chickpea flour", "water", "turmeric powder", "hing", "black pepper", "cinnamon powder",
+                            "cilantro", "salt", "oil", "cardamom powder", "turmeric", "garlic paste", "mustard seeds",
+                            "vinegar", "mangoes", "nigella seeds", "serrano chili", "flour", "soy sauce", "coriander seeds",
+                            "coriander powder", "lemon juice", "mango powder", "curry leaves"
+                            ])
+
+example_dishes = (
+                  Set(["salt", "breadcrumbs", "water", "flour", "celeriac", "chickpea flour", "soy sauce", "parsley",
+                       "sunflower oil", "lemon", "black pepper"]),
+
+                  Set(["cornstarch", "salt", "vegetable oil", "sugar", "vegetable stock", "water", "tofu", "soy sauce",
+                       "lemon zest", "lemon juice", "black pepper", "ginger", "garlic"]),
+
+                  Set(["salt", "mixed herbs", "silken tofu", "smoked tofu", "nutritional yeast", "turmeric", "soy sauce",
+                       "garlic", "lemon juice", "olive oil", "black pepper", "spaghetti"]),
+
+                  Set(["salt", "mushrooms", "sugar", "barley malt", "nutritional yeast", "fresh basil", "olive oil",
+                       "honey", "yeast", "red onion", "bell pepper", "cashews", "oregano", "rosemary", "garlic powder",
+                       "tomatoes", "water", "flour", "red pepper flakes", "garlic"]),
+
+                  Set(["mango powder", "oil", "salt", "cardamom powder", "fresh red chili", "sugar", "fresh ginger",
+                       "turmeric", "red chili powder", "curry leaves", "garlic paste", "mustard seeds", "vinegar",
+                       "mashed potatoes", "garam masala", "mangoes", "nigella seeds", "clove powder", "serrano chili",
+                       "cumin powder", "onion", "water", "chickpea flour", "coriander seeds", "turmeric powder", "hing",
+                       "coriander powder", "cinnamon powder", "cilantro", "garlic"]),
+
+                  Set(["mango powder", "oil", "salt", "cardamom powder", "fresh red chili", "sugar", "fresh ginger",
+                       "turmeric", "red chili powder", "curry leaves", "garlic paste", "mustard seeds", "vinegar",
+                       "mashed potatoes", "garam masala", "mangoes", "nigella seeds", "clove powder", "serrano chili",
+                       "cumin powder", "onion", "water", "chickpea flour", "coriander seeds", "turmeric powder", "hing",
+                       "coriander powder", "cinnamon powder", "cilantro", "garlic"])
+                  )
+
+
+#####################################
+# Data from original sets_test_data #
+#####################################
+
+recipes_with_duplicates  =  [("Kisir with Warm Pita", ["bulgur", "pomegranate molasses", "chopped parsley", "lemon juice", "tomato", "persian cucumber", "tomato paste", "spring onion", "water", "olive oil", "bulgur", "bulgur", "pomegranate molasses", "pomegranate molasses", "pomegranate molasses", "chopped parsley", "lemon juice", "tomato", "tomato", "persian cucumber", "tomato paste", "tomato paste", "tomato paste"]),
+                             ("Shakshuka", ["vegan unsweetened yoghurt", "yellow onion", "firm tofu", "smoked paprika", "tomatoes", "tomato paste", "sugar", "cloves", "cumin", "za'atar", "olive oil", "harissa", "red bell pepper"]),
+                             ("Vegetarian Khoresh Bademjan", ["yellow split peas", "tomato paste", "black pepper", "pomegranate concentrate", "yellow onions", "slivered almonds", "ground turmeric", "barberries", "basmati rice", "lemon juice", "hot water", "cayenne pepper", "chinese eggplants", "salt", "orange juice", "saffron powder", "vegan butter", "orange zest", "kosher salt", "yellow split peas", "yellow split peas", "tomato paste", "tomato paste", "tomato paste", "black pepper"]),
+                             ("Baked Kelewele", ["smoked paprika", "black peppercorn", "red onion", "grains of selim", "cayenne pepper", "calabash nutmeg", "coconut oil", "cloves", "fresh ginger", "salt", "ripe plantains", "smoked paprika", "black peppercorn", "black peppercorn", "red onion", "grains of selim", "grains of selim", "grains of selim"]),
+                             ("Waakye", ["baking soda", "sorghum stems", "coconut oil", "black-eyed peas", "water", "salt", "white rice", "baking soda", "baking soda", "sorghum stems", "sorghum stems", "sorghum stems", "coconut oil"]),
+                             ("Georgian Eggplant Rolls with Walnuts", ["pomegranate seeds", "oil", "coriander", "garlic", "khmeli suneli", "eggplants", "black pepper", "vinegar", "walnuts", "water", "salt"]),
+                             ("Burmese Tofu with Garlic, Ginger and Chili Sauce", ["soy sauce", "oil", "chili flakes", "garlic", "brown sugar", "ginger", "peanuts", "rice vinegar", "spring onions", "water", "turmeric", "salt", "chickpea flour", "soy sauce", "soy sauce", "oil", "oil", "oil", "chili flakes", "garlic", "brown sugar", "brown sugar", "ginger", "peanuts", "peanuts", "peanuts"]),
+                             ("Celeriac Schnitzel", ["soy sauce", "parsley", "lemon", "sunflower oil", "black pepper", "celeriac", "breadcrumbs", "water", "salt", "flour", "chickpea flour"]),
+                             ("Sticky Lemon Tofu", ["soy sauce", "vegetable stock", "tofu", "cornstarch", "lemon juice", "lemon zest", "garlic", "ginger", "black pepper", "sugar", "water", "salt", "vegetable oil", "soy sauce", "soy sauce", "vegetable stock", "vegetable stock", "vegetable stock", "tofu"]),
+                             ("Vegan Carbonara", ["soy sauce", "smoked tofu", "lemon juice", "nutritional yeast", "mixed herbs", "garlic", "black pepper", "silken tofu", "turmeric", "salt", "olive oil", "spaghetti", "soy sauce", "smoked tofu", "smoked tofu", "lemon juice", "nutritional yeast", "nutritional yeast", "nutritional yeast"]),
+                             ("Vegan Pizza with Caramelized Onions", ["mushrooms", "rosemary", "garlic", "red pepper flakes", "yeast", "barley malt", "water", "olive oil", "garlic powder", "oregano", "honey", "nutritional yeast", "red onion", "tomatoes", "cashews", "sugar", "bell pepper", "flour", "salt", "fresh basil", "mushrooms", "mushrooms", "rosemary", "rosemary", "rosemary", "garlic"]),
+                             ("Cheela with Spicy Mango Chutney", ["clove powder", "oil", "cinnamon powder", "nigella seeds", "curry leaves", "coriander seeds", "garlic", "mangoes", "mashed potatoes", "cardamom powder", "vinegar", "water", "mustard seeds", "coriander powder", "cumin powder", "mango powder", "garam masala", "red chili powder", "hing", "garlic paste", "turmeric powder", "cilantro", "sugar", "onion", "serrano chili", "fresh ginger", "turmeric", "salt", "fresh red chili", "chickpea flour"]),
+                             ("Sweet and Spicy Crispy Green Beans", ["soy sauce", "pomegranate molasses", "sesame oil", "green beans", "sunflower oil", "scallions", "garlic", "carrot", "ginger", "sesame seeds", "tomato paste", "bell pepper", "siracha", "soy sauce", "soy sauce", "pomegranate molasses", "pomegranate molasses", "pomegranate molasses", "sesame oil", "green beans", "sunflower oil", "sunflower oil", "scallions", "garlic", "garlic", "garlic"]),
+                             ("Vegan Mini Savory Mince Pies", ["mushrooms", "cinnamon powder", "rosemary", "corn flour", "ginger", "brown sugar", "carrot", "black pepper", "raisins", "butternut squash", "vegetarian worcestershire sauce", "parev shortcrust pastry", "olive oil", "vegetable stock", "dried cherries", "lemon juice", "lemon zest", "figs", "dried cranberries", "apples", "pecans", "onion", "orange juice", "currants", "dried blueberries", "salt", "brandy", "orange zest", "allspice powder"]),
+                             ("Roasted Corn and Zucchini Salad", ["green onions", "lemon juice", "lemon zest", "dill", "corn", "tomatoes", "black pepper", "zucchini", "olive oil", "green onions", "green onions", "lemon juice", "lemon juice", "lemon juice", "lemon zest"]),
+                             ("Golden Potato Salad", ["mustard seeds", "cumin seeds", "lemon juice", "garlic", "black pepper", "balsamic vinegar", "yukon gold potato", "chives", "turmeric", "salt", "olive oil", "mustard seeds", "cumin seeds", "cumin seeds", "lemon juice", "garlic", "garlic", "garlic"]),
+                             ("Carrot Puff Pastry Tart", ["olive oil", "lemon", "lemon juice", "pareve puff pastry", "brown sugar", "red onion", "carrot", "garlic", "black pepper", "thyme", "vegan butter", "water", "salt", "ground almonds", "olive oil", "olive oil", "lemon", "lemon", "lemon", "lemon juice"]),
+
+                             ("Mushroom Lasagna", ["nutmeg", "garlic", "black pepper", "onions", "butter", "parmesan cheese", "portobello mushrooms", "flour", "dried lasagna noodles", "olive oil", "milk", "kosher salt"]),
+                             ("Nut Wellington", ["sage", "puff pastry sheets", "hazelnuts", "almonds", "black pepper", "thyme", "marmite", "breadcrumbs", "walnuts", "dates", "eggs", "olive oil", "brazil nuts", "leeks", "chestnuts", "cashews", "apples", "pecans", "butter", "salt", "sage", "sage", "puff pastry sheets", "puff pastry sheets", "puff pastry sheets", "hazelnuts", "almonds", "black pepper", "black pepper", "thyme", "marmite", "marmite", "marmite"]),
+                             ("White Cheddar Scalloped Potatoes", ["shallots", "garlic", "cream", "thyme", "breadcrumbs", "sharp white cheddar", "yukon gold potato", "milk", "kosher salt"]),
+                             ("Winter Cobb Salad", ["smoked tofu", "shiitake mushrooms", "red wine vinegar", "garlic", "tomatoes", "black pepper", "avocados", "blue cheese", "onion", "lacinato kale", "eggs", "olive oil", "smoked tofu", "smoked tofu", "shiitake mushrooms", "shiitake mushrooms", "shiitake mushrooms", "red wine vinegar"]),
+                             ("Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", ["honey", "lemon", "dijon mustard", "feta cheese", "red wine vinegar", "red onion", "watercress", "green lentils", "currants", "capers", "pepitas", "fresh pumpkin", "olive oil", "honey", "lemon", "lemon", "dijon mustard", "feta cheese", "feta cheese", "feta cheese"]),
+                             ("Cambodian-Style Vegetable Spring Rolls", ["lime juice", "toasted peanuts", "firm tofu", "garlic", "corn flour", "bean sprouts", "carrot", "palm sugar", "shallots", "red chili", "vermicelli noodles", "wombok", "soy sauce", "sunflower oil", "spring roll wrappers", "vegetarian fish sauce", "lime juice", "lime juice", "toasted peanuts", "toasted peanuts", "toasted peanuts", "firm tofu"]),
+                             ("Summer Minestrone Cups", ["fresh peas", "rosemary", "garlic", "chickpeas", "carrot", "leek", "green lentils", "red chili", "olive oil", "croutons", "fresh corn", "lemon zest", "green beans", "parmesan rind", "basil", "tomatoes", "vegetable bullion", "parmesan cheese", "celery", "mint"]),
+                             ("Fried Zucchini with Balsamic and Chili Dressing", ["honey", "lemon juice", "garlic", "red onion", "red thai chili", "pomegranate", "balsamic vinegar", "mint leaves", "zucchini", "olive oil", "honey", "honey", "lemon juice", "lemon juice", "lemon juice", "garlic", "red onion", "red thai chili", "red thai chili", "pomegranate", "balsamic vinegar", "balsamic vinegar", "balsamic vinegar"]),
+                             ("Barley Risotto", ["sage", "beets", "pearl barley", "brussel sprouts", "rosemary", "garlic", "carrot", "red onion", "black pepper", "thyme", "butternut squash", "vegetable bullion", "parmesan cheese", "olive oil", "white wine"]),
+                             ("Cherry Tomato, Watercress and Fava Bean Salad", ["fresh peas", "fresh cherry tomatoes", "garlic", "watercress", "balsamic vinegar", "fresh or frozen fava beans", "fresh cherry bocconcini", "salt", "olive oil", "fresh peas", "fresh peas", "fresh cherry tomatoes", "fresh cherry tomatoes", "fresh cherry tomatoes", "garlic"]),
+                             ("Fresh Garden Peas over Cauliflower Almond Puree", ["red onions", "lemon", "fresh peas", "garlic", "grated nutmeg", "cream", "cauliflower", "blanched almonds", "fresh pea tendrils", "olive oil", "vegetable oil", "red onions", "lemon", "lemon", "fresh peas", "garlic", "garlic", "garlic"]),
+                             ("Walnut Ravioli with Artichokes and Tomatoes", ["pine nuts", "oil marinated artichokes", "olives", "rosemary", "fresh tomatoes", "ricotta cheese", "black pepper", "fresh artichoke hearts", "walnuts", "pasta sheets", "lemon juice", "lemon zest", "basil", "red onion", "butter", "salt", "pine nuts", "pine nuts", "oil marinated artichokes", "oil marinated artichokes", "oil marinated artichokes", "olives"]),
+                             ("Asparagus Puffs", ["eggs", "asparagus", "lemon juice", "red onion", "ricotta cheese", "black pepper", "thyme", "salt", "parmesan cheese", "puff pastry", "chives"]),
+                             ("Grilled Tofu Tacos", ["cotija cheese", "masa", "fresh cilantro leaves", "jalapeño chili", "chipotle chili", "firm tofu", "garlic", "carrot", "roasted corn", "tomatillos", "pepitas", "ancho chili", "crema", "red onions", "pasilla chili", "lemon", "hot water", "lemon juice", "tomatoes", "avocado", "cumin", "red cabbage", "limes", "black beans", "cotija cheese", "cotija cheese", "masa", "masa", "masa", "fresh cilantro leaves", "jalapeño chili", "chipotle chili", "chipotle chili", "firm tofu", "garlic", "garlic", "garlic"]),
+
+                             ("Zucchini Fritters with Lemon-Thyme Coconut Yogurt", ["baking soda", "coconut flour", "lemon juice", "lemon zest", "eggs", "coconut yogurt", "black pepper", "fresh thai chili", "coconut oil", "chives", "zucchini", "salt"]),
+                             ("Avocado Deviled Eggs", ["lime juice", "fresh cilantro leaves", "eggs", "seranno chili", "avocado", "pepitas", "salt", "garlic powder", "lime juice", "lime juice", "fresh cilantro leaves", "fresh cilantro leaves", "fresh cilantro leaves", "eggs"]),
+                             ("Grilled Flank Steak with Caesar Salad", ["pine nuts", "white vinegar", "chipotle chili", "scallions", "garlic", "paleo parmesan cheese", "black pepper", "avocado oil", "treviso", "olive oil", "radishes", "flank steak", "dijon mustard", "castelfranco radicchio", "worcestershire sauce", "fresh parsley", "cherry tomatoes", "salt", "avocado mayonnaise", "pine nuts", "white vinegar", "white vinegar", "chipotle chili", "scallions", "scallions", "scallions"]),
+                             ("Pumpkin Bread Crostini", ["coconut flour", "garlic", "black pepper", "cloves", "eggs", "olive oil", "onions", "honey", "apple cider vinegar", "almond butter", "baking soda", "nutmeg", "pumpkin puree", "cinnamon", "shrimp", "basil", "coconut oil", "cherry tomatoes", "salt", "fresh red chili", "coconut flour", "coconut flour", "garlic", "garlic", "garlic", "black pepper"]),
+                             ("BLT Bites", ["mustard seed", "onion", "kale", "cherry tomatoes", "bacon", "paleo mayonnaise"]),
+                             ("Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", ["purple sweet potato", "chiles de árbol", "garlic", "tomatoes", "safflower oil", "black pepper", "mexican oregano", "avocados", "shallots", "cumin", "olive oil", "lemons", "whole chicken", "limes", "kosher salt", "purple sweet potato", "purple sweet potato", "chiles de árbol", "chiles de árbol", "chiles de árbol", "garlic", "tomatoes", "safflower oil", "safflower oil", "black pepper", "mexican oregano", "mexican oregano", "mexican oregano"]),
+                             ("Chicken with Tamarind and Apricot Sauce", ["garlic", "black pepper", "dried apricots", "roma tomatoes", "water", "olive oil", "honey", "cinnamon", "ground cumin", "cider vinegar", "chili powder", "safflower oil", "homemade tamarind concentrate", "white chicken", "allspice", "chipotles", "salt", "homemade apricot honey preserves", "kosher salt"]),
+                             ("Grilled Fish Tacos with Cauliflower Tortillas", ["green onions", "serrano chili", "shredded red cabbage", "smoked paprika", "mango", "eggs", "black pepper", "cilantro", "cauliflower", "avocado", "lime", "cumin", "salt", "tilapia", "green onions", "green onions", "serrano chili", "serrano chili", "serrano chili", "shredded red cabbage"]),
+                             ("Grilled Pork Chops with Mango Pineapple Salsa", ["cilantro leaves", "lime", "pineapple", "chipotle chili", "garlic", "mangoes", "cauliflower", "avocado", "serrano chili", "pork chops", "lime zest", "lacinato kale", "onions", "cilantro leaves", "lime", "lime", "pineapple", "chipotle chili", "chipotle chili", "chipotle chili"]),
+                             ("Grilled Shrimp and Pesto over Zucchini Noodles", ["pine nuts", "shrimp", "green bell pepper", "lemon juice", "basil", "lemon zest", "garlic", "tomatoes", "cashews", "yellow bell pepper", "cumin", "zucchini", "salt", "olive oil", "red bell pepper", "pine nuts", "pine nuts", "shrimp", "shrimp", "shrimp", "green bell pepper"]),
+
+                             ("Cauliflower Pizza with Roasted Tomatoes and Chicken", ["parmesan", "almond meal", "rosemary", "mozzarella cheese", "roasted chicken", "tomato paste", "cauliflower", "cherry tomatoes", "eggs", "fresh basil", "olive oil"]),
+                             ("Flank Steak with Chimichurri and Asparagus", ["white vinegar", "asparagus", "flank steak", "chipotle chili", "scallions", "garlic", "black pepper", "cauliflower", "sour cream", "fresh parsley", "salt", "olive oil", "white vinegar", "white vinegar", "asparagus", "asparagus", "asparagus", "flank steak", "chipotle chili", "scallions", "scallions", "garlic", "black pepper", "black pepper", "black pepper"]),
+                             ("Kingfish Lettuce Cups", ["soy sauce", "watermelon radishes", "lime juice", "fish sauce", "mirin", "little gem lettuce heads", "peanut oil", "garlic", "sesame seeds", "oyster sauce", "spring onions", "avocado", "grilled king fish", "red cabbage"]),
+                             ("Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", ["clove powder", "curry leaves", "coriander seeds", "ginger", "cardamom powder", "vinegar", "mustard seeds", "mango powder", "garam masala", "red chili powder", "chicken", "hing", "turmeric powder", "tomatoes", "ginger garlic paste", "fresh greek yogurt", "fresh ginger", "monk fruit", "turmeric", "cashew nuts", "salt", "fresh red chili", "cinnamon powder", "nigella seeds", "whole small crimini mushrooms", "brussel sprouts", "garlic", "mangoes", "heavy cream", "cloves", "coriander powder", "cumin powder", "cardamom", "green chili", "cinnamon", "garlic paste", "red chili flakes", "lemon juice", "cilantro", "butter", "dried fenugreek leaves", "boned chicken", "clove powder", "clove powder", "curry leaves", "curry leaves", "curry leaves", "coriander seeds"]),
+                             ("Prawn and Herb Omelette", ["green onions", "parsley", "sesame seeds", "black pepper", "chives", "eggs", "fennel bulb", "tahini", "olive oil", "harissa", "shrimp", "lemon juice", "dill", "butter", "onion", "fresh cucumber", "monk fruit", "salt", "green onions", "parsley", "parsley", "sesame seeds", "black pepper", "black pepper", "black pepper"]),
+                             ("Satay Steak Skewers", ["sriacha", "apple cider vinegar", "lime juice", "fish sauce", "red and green thai chili", "flank steak", "carrot", "peanuts", "cucumbers", "roasted peanuts", "crunchy peanut butter", "kecap manis", "monk fruit", "micro cilantro", "olive oil", "sriacha", "sriacha", "apple cider vinegar", "apple cider vinegar", "apple cider vinegar", "lime juice"]),
+                             ("Parmesan Crackers and Spinach Crackers with Salmon Pate", ["spinach", "parmesan cheese", "coconut flour", "chili flakes", "garlic", "black pepper", "cream cheese", "ghee", "lemon juice", "flaxmeal", "red onion", "salt", "salmon fillets", "pecans", "almond flour", "cumin", "fresh cucumber", "cherry tomatoes", "chives", "avocado mayonnaise"]),
+                             ("Pork Chops with Grilled Castelfranco Radicchio and Asparagus", ["rosemary", "garlic", "black pepper", "thyme", "avocado oil", "eggs", "oregano", "asparagus", "lemon", "dijon mustard", "basil", "castelfranco radicchio", "dill", "butter", "pork chops", "monk fruit", "salt", "avocado mayonnaise", "rosemary", "rosemary", "garlic", "garlic", "garlic", "black pepper", "thyme", "avocado oil", "avocado oil", "eggs", "oregano", "oregano", "oregano"]),
+                             ("Seared Salmon with Pickled Vegetable and Watercress Salad", ["lime juice", "caster sugar", "toasted buckwheat", "lemon juice", "red wine vinegar", "red onion", "dutch carrot", "salmon steaks", "watercress", "pink peppercorns", "shallots", "fennel seeds", "red cabbage", "radishes"]),
+                             ("Braised Pork Belly with Apple Salad", ["cilantro leaves", "green cabbage", "lemon juice", "pork belly", "dark soy sauce", "granny smith apples", "ginger", "light soy sauce", "sesame seeds", "black pepper", "cinnamon sticks", "spring onions", "star anise", "monk fruit", "olive oil", "cilantro leaves", "cilantro leaves", "green cabbage", "green cabbage", "green cabbage", "lemon juice"]),
+
+                             ("Beachside Snapper", ["lime juice", "salsa", "green bell pepper", "anaheim chili", "black pepper", "olive oil", "yellow mustard", "red bell pepper", "soy sauce", "mexican crema", "mayonnaise", "white onion", "garlic cloves", "fresh corn tortillas", "red onion", "tomatoes", "limes", "worcestershire sauce", "butter", "yellow bell pepper", "salt", "red snapper", "lime juice", "salsa", "salsa", "green bell pepper", "anaheim chili", "anaheim chili", "anaheim chili"]),
+                             ("Governor Shrimp Tacos", ["lime juice", "poblano chili", "tomato paste", "black pepper", "chipotle adobo sauce", "chile manzano", "roma tomatoes", "pepitas", "oaxaca cheese", "white onion", "shelled large shrimp", "garlic cloves", "fresh corn tortillas", "red onion", "worcestershire sauce", "avocado", "butter", "kosher salt", "lime juice", "lime juice", "poblano chili", "poblano chili", "poblano chili", "tomato paste"]),
+                             ("Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", ["fresh tortillas", "shrimp", "garlic", "chickpeas", "black pepper", "slivered almonds", "guajillo chile", "bacon", "sea salt", "butter", "onion", "avocado", "olive oil"]),
+                             ("Burnt Masala Wings with Classic Coleslaw", ["lime juice", "green cabbage", "chiles de árbol", "green cardamom", "ginger", "carrot", "sriracha", "black pepper", "cinnamon sticks", "celery seeds", "cloves", "black cardamom", "olive oil", "chicken wings", "apple cider vinegar", "mayonnaise", "honey", "black peppercorns", "lemon juice", "garlic cloves", "tamarind concentrate", "cilantro", "butter", "serrano chili", "red cabbage", "kosher salt", "lime juice", "lime juice", "green cabbage", "green cabbage", "green cabbage", "chiles de árbol", "green cardamom", "ginger", "ginger", "carrot", "sriracha", "sriracha", "sriracha"]),
+                             ("Dahi Puri with Black Chickpeas", ["whole-milk yogurt", "chaat masala", "ginger", "pani puri", "scallion chutney", "yukon gold potato", "black chickpeas", "thin sev", "date syrup", "red onion", "roasted chicken", "chili powder", "tamarind concentrate", "cumin", "turmeric", "mint"]),
+                             ("Brisket with Grilled Rhubarb, Onions, and Fennel", ["white vinegar", "parsley", "yellow onion", "rhubarb", "garlic", "brown sugar", "black pepper", "thyme", "crushed red pepper flakes", "fennel bulbs", "beer", "marjoram", "vegetable oil", "soy sauce", "oregano", "lemon", "red onion", "chili powder", "cilantro", "beef brisket", "balsamic vinegar", "worcestershire sauce", "celery", "mint", "kosher salt", "white vinegar", "white vinegar", "parsley", "parsley", "parsley", "yellow onion"]),
+                             ("Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", ["oranges", "rosemary", "garlic", "anchovy fillets", "couscous", "carrot", "sesame seeds", "fresh thyme", "vinegar", "olive oil", "tahini", "harissa", "onions", "honey", "fresh mint", "leg of lamb", "tomatoes", "baby carrot", "vegetable bullion", "filo pastry", "celery", "bay leaves", "yoghurt", "oranges", "rosemary", "rosemary", "garlic", "anchovy fillets", "anchovy fillets", "anchovy fillets"]),
+                             ("Baked Chicken Jollof Rice", ["tomato puree", "garlic", "ginger", "tomato", "carrot", "thyme", "white pepper", "water", "maggi cubes", "chicken", "rice", "coriander", "scotch bonnet pepper", "bell pepper", "onion", "turmeric", "salt", "tomato puree", "tomato puree", "garlic", "garlic", "garlic", "ginger"]),
+                             ("Seafood Risotto", ["garlic", "tomato paste", "baby scallops", "mussels", "water", "crab legs", "olive oil", "baby squid", "fish stock", "lemon juice", "white onion", "arborio risotto rice", "clams", "parmesan cheese", "flat-leaf parsley", "cherry tomatoes", "prawns", "white wine"]),
+                             ("Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", ["toasted bread", "rosemary", "hazelnuts", "anchovy fillets", "garlic", "carrot", "summer squash", "black pepper", "red pepper flakes", "vinegar", "sea salt", "zucchini", "olive oil", "onions", "white wine vinegar", "fresh mint", "leg of lamb", "lemon", "fresh ricotta", "sugar", "celery", "bay leaves", "kosher salt", "toasted bread", "toasted bread", "rosemary", "rosemary", "rosemary", "hazelnuts", "anchovy fillets", "garlic", "garlic", "carrot", "summer squash", "summer squash", "summer squash"])
+                             ]
+
+recipes_without_duplicates  =  [("kisir_with_warm_pita", "Kisir with Warm Pita", Set(["water", "chopped parsley", "pomegranate molasses", "spring onion", "lemon juice", "olive oil", "bulgur", "tomato paste", "tomato", "persian cucumber"])),
+                             ("shakshuka", "Shakshuka", Set(["smoked paprika", "tomatoes", "cumin", "firm tofu", "olive oil", "harissa", "yellow onion", "sugar", "za'atar", "tomato paste", "cloves", "red bell pepper", "vegan unsweetened yoghurt"])),
+                             ("vegetarian_khoresh_bademjan", "Vegetarian Khoresh Bademjan", Set(["pomegranate concentrate", "saffron powder", "cayenne pepper", "barberries", "salt", "yellow onions", "yellow split peas", "slivered almonds", "ground turmeric", "orange zest", "lemon juice", "kosher salt", "hot water", "basmati rice", "black pepper", "orange juice", "tomato paste", "vegan butter", "chinese eggplants"])),
+                             ("baked_kelewele", "Baked Kelewele", Set(["salt", "coconut oil", "smoked paprika", "cayenne pepper", "red onion", "fresh ginger", "calabash nutmeg", "grains of selim", "black peppercorn", "cloves", "ripe plantains"])),
+                             ("waakye", "Waakye", Set(["salt", "coconut oil", "water", "white rice", "sorghum stems", "black-eyed peas", "baking soda"])),
+                             ("georgian_eggplant_rolls_with_walnuts", "Georgian Eggplant Rolls with Walnuts", Set(["salt", "coriander", "pomegranate seeds", "oil", "water", "vinegar", "garlic", "eggplants", "black pepper", "khmeli suneli", "walnuts"])),
+                             ("burmese_tofu_with_garlic,_ginger_and_chili_sauce", "Burmese Tofu with Garlic, Ginger and Chili Sauce", Set(["salt", "rice vinegar", "oil", "water", "turmeric", "chili flakes", "spring onions", "brown sugar", "garlic", "chickpea flour", "ginger", "soy sauce", "peanuts"])),
+                             ("celeriac_schnitzel", "Celeriac Schnitzel", Set(["salt", "parsley", "water", "sunflower oil", "flour", "breadcrumbs", "lemon", "celeriac", "chickpea flour", "soy sauce", "black pepper"])),
+                             ("sticky_lemon_tofu", "Sticky Lemon Tofu", Set(["salt", "water", "tofu", "cornstarch", "vegetable stock", "vegetable oil", "lemon juice", "garlic", "black pepper", "ginger", "soy sauce", "sugar", "lemon zest"])),
+                             ("vegan_carbonara", "Vegan Carbonara", Set(["salt", "turmeric", "spaghetti", "lemon juice", "olive oil", "garlic", "black pepper", "nutritional yeast", "soy sauce", "smoked tofu", "silken tofu", "mixed herbs"])),
+                             ("vegan_pizza_with_caramelized_onions", "Vegan Pizza with Caramelized Onions", Set(["red pepper flakes", "garlic", "cashews", "fresh basil", "flour", "tomatoes", "red onion", "oregano", "nutritional yeast", "rosemary", "water", "bell pepper", "honey", "barley malt", "olive oil", "salt", "garlic powder", "mushrooms", "yeast", "sugar"])),
+                             ("cheela_with_spicy_mango_chutney", "Cheela with Spicy Mango Chutney", Set(["hing", "curry leaves", "mangoes", "garlic", "nigella seeds", "garlic paste", "coriander seeds", "oil", "turmeric", "red chili powder", "coriander powder", "cardamom powder", "turmeric powder", "clove powder", "water", "cumin powder", "fresh ginger", "vinegar", "cinnamon powder", "cilantro", "chickpea flour", "onion", "salt", "mango powder", "fresh red chili", "mashed potatoes", "mustard seeds", "serrano chili", "garam masala", "sugar"])),
+                             ("sweet_and_spicy_crispy_green_beans", "Sweet and Spicy Crispy Green Beans", Set(["sesame oil", "siracha", "sunflower oil", "pomegranate molasses", "sesame seeds", "green beans", "carrot", "scallions", "garlic", "ginger", "soy sauce", "tomato paste", "bell pepper"])),
+                             ("vegan_mini_savory_mince_pies", "Vegan Mini Savory Mince Pies", Set(["apples", "brandy", "pecans", "raisins", "brown sugar", "lemon zest", "dried blueberries", "vegetarian worcestershire sauce", "orange zest", "butternut squash", "corn flour", "rosemary", "vegetable stock", "carrot", "figs", "cinnamon powder", "olive oil", "orange juice", "black pepper", "onion", "dried cherries", "salt", "dried cranberries", "parev shortcrust pastry", "mushrooms", "allspice powder", "lemon juice", "ginger", "currants"])),
+                             ("roasted_corn_and_zucchini_salad", "Roasted Corn and Zucchini Salad", Set(["zucchini", "tomatoes", "green onions", "corn", "lemon juice", "olive oil", "black pepper", "lemon zest", "dill"])),
+                             ("golden_potato_salad", "Golden Potato Salad", Set(["salt", "yukon gold potato", "turmeric", "balsamic vinegar", "cumin seeds", "lemon juice", "olive oil", "garlic", "mustard seeds", "black pepper", "chives"])),
+                             ("carrot_puff_pastry_tart", "Carrot Puff Pastry Tart", Set(["salt", "water", "lemon", "thyme", "red onion", "carrot", "lemon juice", "pareve puff pastry", "ground almonds", "brown sugar", "olive oil", "garlic", "black pepper", "vegan butter"])),
+
+                             ("mushroom_lasagna", "Mushroom Lasagna", Set(["dried lasagna noodles", "portobello mushrooms", "nutmeg", "flour", "kosher salt", "milk", "olive oil", "garlic", "onions", "butter", "black pepper", "parmesan cheese"])),
+                             ("nut_wellington", "Nut Wellington", Set(["apples", "eggs", "hazelnuts", "pecans", "thyme", "dates", "cashews", "breadcrumbs", "almonds", "marmite", "sage", "leeks", "olive oil", "black pepper", "walnuts", "salt", "chestnuts", "brazil nuts", "butter", "puff pastry sheets"])),
+                             ("white_cheddar_scalloped_potatoes", "White Cheddar Scalloped Potatoes", Set(["yukon gold potato", "shallots", "cream", "thyme", "breadcrumbs", "sharp white cheddar", "kosher salt", "milk", "garlic"])),
+                             ("winter_cobb_salad", "Winter Cobb Salad", Set(["lacinato kale", "eggs", "red wine vinegar", "shiitake mushrooms", "tomatoes", "avocados", "olive oil", "blue cheese", "garlic", "black pepper", "onion", "smoked tofu"])),
+                             ("roast_pumpkin_and_lentil_salad_with_roasted_lemon_dressing", "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", Set(["red wine vinegar", "dijon mustard", "lemon", "honey", "red onion", "feta cheese", "olive oil", "capers", "pepitas", "fresh pumpkin", "watercress", "green lentils", "currants"])),
+                             ("cambodian-style_vegetable_spring_rolls", "Cambodian-Style Vegetable Spring Rolls", Set(["sunflower oil", "vegetarian fish sauce", "shallots", "vermicelli noodles", "wombok", "firm tofu", "lime juice", "corn flour", "palm sugar", "bean sprouts", "spring roll wrappers", "garlic", "red chili", "soy sauce", "toasted peanuts", "carrot"])),
+                             ("summer_minestrone_cups", "Summer Minestrone Cups", Set(["leek", "garlic", "lemon zest", "tomatoes", "red chili", "chickpeas", "rosemary", "carrot", "vegetable bullion", "fresh corn", "fresh peas", "green beans", "olive oil", "parmesan cheese", "croutons", "celery", "mint", "basil", "green lentils", "parmesan rind"])),
+                             ("fried_zucchini_with_balsamic_and_chili_dressing", "Fried Zucchini with Balsamic and Chili Dressing", Set(["zucchini", "balsamic vinegar", "honey", "red onion", "lemon juice", "olive oil", "mint leaves", "garlic", "red thai chili", "pomegranate"])),
+                             ("barley_risotto", "Barley Risotto", Set(["beets", "white wine", "thyme", "red onion", "carrot", "butternut squash", "olive oil", "sage", "garlic", "brussel sprouts", "rosemary", "black pepper", "parmesan cheese", "pearl barley", "vegetable bullion"])),
+                             ("cherry_tomato,_watercress_and_fava_bean_salad", "Cherry Tomato, Watercress and Fava Bean Salad", Set(["salt", "fresh or frozen fava beans", "fresh peas", "balsamic vinegar", "olive oil", "garlic", "watercress", "fresh cherry bocconcini", "fresh cherry tomatoes"])),
+                             ("fresh_garden_peas_over_cauliflower_almond_puree", "Fresh Garden Peas over Cauliflower Almond Puree", Set(["grated nutmeg", "red onions", "lemon", "fresh peas", "cream", "vegetable oil", "olive oil", "garlic", "blanched almonds", "cauliflower", "fresh pea tendrils"])),
+                             ("walnut_ravioli_with_artichokes_and_tomatoes", "Walnut Ravioli with Artichokes and Tomatoes", Set(["salt", "fresh tomatoes", "ricotta cheese", "lemon zest", "olives", "red onion", "lemon juice", "black pepper", "rosemary", "butter", "basil", "fresh artichoke hearts", "pasta sheets", "pine nuts", "walnuts", "oil marinated artichokes"])),
+                             ("asparagus_puffs", "Asparagus Puffs", Set(["salt", "asparagus", "ricotta cheese", "thyme", "puff pastry", "red onion", "eggs", "lemon juice", "black pepper", "parmesan cheese", "chives"])),
+                             ("grilled_tofu_tacos", "Grilled Tofu Tacos", Set(["carrot", "red cabbage", "ancho chili", "limes", "hot water", "garlic", "roasted corn", "masa", "pasilla chili", "lemon", "tomatoes", "cumin", "fresh cilantro leaves", "chipotle chili", "red onions", "pepitas", "tomatillos", "black beans", "cotija cheese", "crema", "firm tofu", "lemon juice", "jalapeño chili", "avocado"])),
+
+                             ("zucchini_fritters_with_lemon-thyme_coconut_yogurt", "Zucchini Fritters with Lemon-Thyme Coconut Yogurt", Set(["salt", "coconut oil", "eggs", "fresh thai chili", "coconut yogurt", "zucchini", "lemon juice", "black pepper", "coconut flour", "chives", "lemon zest", "baking soda"])),
+                             ("avocado_deviled_eggs", "Avocado Deviled Eggs", Set(["salt", "eggs", "garlic powder", "seranno chili", "avocado", "lime juice", "pepitas", "fresh cilantro leaves"])),
+                             ("grilled_flank_steak_with_caesar_salad", "Grilled Flank Steak with Caesar Salad", Set(["flank steak", "avocado oil", "treviso", "scallions", "garlic", "cherry tomatoes", "pine nuts", "white vinegar", "chipotle chili", "dijon mustard", "olive oil", "avocado mayonnaise", "black pepper", "paleo parmesan cheese", "castelfranco radicchio", "fresh parsley", "salt", "worcestershire sauce", "radishes"])),
+                             ("pumpkin_bread_crostini", "Pumpkin Bread Crostini", Set(["eggs", "nutmeg", "cinnamon", "garlic", "pumpkin puree", "apple cider vinegar", "cherry tomatoes", "onions", "coconut flour", "cloves", "shrimp", "coconut oil", "honey", "olive oil", "black pepper", "almond butter", "salt", "fresh red chili", "basil", "baking soda"])),
+                             ("blt_bites", "BLT Bites", Set(["paleo mayonnaise", "bacon", "kale", "cherry tomatoes", "mustard seed", "onion"])),
+                             ("roasted_chicken_with_roasted_tomatoes,_avocado,_and_sweet_potatoes", "Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", Set(["safflower oil", "shallots", "whole chicken", "lemons", "tomatoes", "purple sweet potato", "avocados", "limes", "kosher salt", "olive oil", "mexican oregano", "garlic", "black pepper", "cumin", "chiles de árbol"])),
+                             ("chicken_with_tamarind_and_apricot_sauce", "Chicken with Tamarind and Apricot Sauce", Set(["cinnamon", "garlic", "cider vinegar", "chipotles", "homemade tamarind concentrate", "roma tomatoes", "white chicken", "ground cumin", "water", "safflower oil", "allspice", "dried apricots", "honey", "olive oil", "black pepper", "salt", "homemade apricot honey preserves", "kosher salt", "chili powder"])),
+                             ("grilled_fish_tacos_with_cauliflower_tortillas", "Grilled Fish Tacos with Cauliflower Tortillas", Set(["salt", "eggs", "smoked paprika", "shredded red cabbage", "mango", "green onions", "lime", "cumin", "tilapia", "cilantro", "black pepper", "serrano chili", "cauliflower", "avocado"])),
+                             ("grilled_pork_chops_with_mango_pineapple_salsa", "Grilled Pork Chops with Mango Pineapple Salsa", Set(["pork chops", "lacinato kale", "chipotle chili", "serrano chili", "lime zest", "pineapple", "lime", "garlic", "onions", "mangoes", "cauliflower", "avocado", "cilantro leaves"])),
+                             ("grilled_shrimp_and_pesto_over_zucchini_noodles", "Grilled Shrimp and Pesto over Zucchini Noodles", Set(["salt", "green bell pepper", "cashews", "zucchini", "tomatoes", "red bell pepper", "cumin", "lemon juice", "yellow bell pepper", "olive oil", "garlic", "pine nuts", "basil", "lemon zest", "shrimp"])),
+
+                             ("cauliflower_pizza_with_roasted_tomatoes_and_chicken", "Cauliflower Pizza with Roasted Tomatoes and Chicken", Set(["roasted chicken", "eggs", "fresh basil", "olive oil", "almond meal", "cherry tomatoes", "rosemary", "cauliflower", "mozzarella cheese", "tomato paste", "parmesan"])),
+                             ("flank_steak_with_chimichurri_and_asparagus", "Flank Steak with Chimichurri and Asparagus", Set(["fresh parsley", "salt", "asparagus", "chipotle chili", "flank steak", "scallions", "olive oil", "garlic", "black pepper", "cauliflower", "white vinegar", "sour cream"])),
+                             ("kingfish_lettuce_cups", "Kingfish Lettuce Cups", Set(["oyster sauce", "fish sauce", "spring onions", "sesame seeds", "grilled king fish", "little gem lettuce heads", "mirin", "red cabbage", "lime juice", "peanut oil", "garlic", "watermelon radishes", "soy sauce", "avocado"])),
+                             ("butter_chicken_with_grilled_mushrooms,_brussel_sprouts_and_mango_chutney", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", Set(["hing", "curry leaves", "cashew nuts", "green chili", "cinnamon", "mangoes", "garlic", "nigella seeds", "garlic paste", "coriander seeds", "turmeric", "ginger garlic paste", "tomatoes", "red chili powder", "coriander powder", "cardamom powder", "turmeric powder", "clove powder", "cloves", "heavy cream", "cardamom", "fresh greek yogurt", "monk fruit", "fresh ginger", "cumin powder", "vinegar", "cinnamon powder", "cilantro", "brussel sprouts", "whole small crimini mushrooms", "salt", "boned chicken", "red chili flakes", "mango powder", "fresh red chili", "lemon juice", "garam masala", "butter", "ginger", "mustard seeds", "chicken", "dried fenugreek leaves"])),
+                             ("prawn_and_herb_omelette", "Prawn and Herb Omelette", Set(["salt", "parsley", "eggs", "fresh cucumber", "sesame seeds", "green onions", "monk fruit", "lemon juice", "olive oil", "tahini", "harissa", "black pepper", "butter", "onion", "fennel bulb", "chives", "shrimp", "dill"])),
+                             ("satay_steak_skewers", "Satay Steak Skewers", Set(["flank steak", "red and green thai chili", "kecap manis", "fish sauce", "monk fruit", "micro cilantro", "carrot", "apple cider vinegar", "sriacha", "lime juice", "olive oil", "cucumbers", "roasted peanuts", "crunchy peanut butter", "peanuts"])),
+                             ("parmesan_crackers_and_spinach_crackers_with_salmon_pate", "Parmesan Crackers and Spinach Crackers with Salmon Pate", Set(["fresh cucumber", "pecans", "ghee", "garlic", "chives", "flaxmeal", "chili flakes", "almond flour", "salmon fillets", "red onion", "cherry tomatoes", "coconut flour", "cumin", "spinach", "cream cheese", "avocado mayonnaise", "black pepper", "parmesan cheese", "salt", "lemon juice"])),
+                             ("pork_chops_with_grilled_castelfranco_radicchio_and_asparagus", "Pork Chops with Grilled Castelfranco Radicchio and Asparagus", Set(["pork chops", "salt", "asparagus", "eggs", "dijon mustard", "avocado oil", "lemon", "thyme", "monk fruit", "oregano", "avocado mayonnaise", "garlic", "black pepper", "rosemary", "butter", "basil", "castelfranco radicchio", "dill"])),
+                             ("seared_salmon_with_pickled_vegetable_and_watercress_salad", "Seared Salmon with Pickled Vegetable and Watercress Salad", Set(["red wine vinegar", "caster sugar", "salmon steaks", "radishes", "shallots", "red onion", "pink peppercorns", "toasted buckwheat", "lemon juice", "lime juice", "red cabbage", "watercress", "fennel seeds", "dutch carrot"])),
+                             ("braised_pork_belly_with_apple_salad", "Braised Pork Belly with Apple Salad", Set(["spring onions", "dark soy sauce", "light soy sauce", "pork belly", "monk fruit", "green cabbage", "star anise", "sesame seeds", "lemon juice", "olive oil", "black pepper", "ginger", "cinnamon sticks", "granny smith apples", "cilantro leaves"])),
+
+                             ("beachside_snapper", "Beachside Snapper", Set(["yellow mustard", "mayonnaise", "limes", "white onion", "red snapper", "fresh corn tortillas", "tomatoes", "red onion", "lime juice", "soy sauce", "mexican crema", "salsa", "garlic cloves", "green bell pepper", "olive oil", "black pepper", "salt", "yellow bell pepper", "worcestershire sauce", "anaheim chili", "butter", "red bell pepper"])),
+                             ("governor_shrimp_tacos", "Governor Shrimp Tacos", Set(["chile manzano", "worcestershire sauce", "oaxaca cheese", "garlic cloves", "red onion", "avocado", "lime juice", "kosher salt", "white onion", "chipotle adobo sauce", "poblano chili", "fresh corn tortillas", "butter", "black pepper", "pepitas", "tomato paste", "roma tomatoes", "shelled large shrimp"])),
+                             ("shrimp,_bacon_and_crispy_chickpea_tacos_with_salsa_de_guacamole", "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["fresh tortillas", "slivered almonds", "bacon", "sea salt", "chickpeas", "olive oil", "guajillo chile", "garlic", "butter", "black pepper", "onion", "shrimp", "avocado"])),
+                             ("burnt_masala_wings_with_classic_coleslaw", "Burnt Masala Wings with Classic Coleslaw", Set(["mayonnaise", "carrot", "red cabbage", "green cabbage", "apple cider vinegar", "lime juice", "cloves", "cinnamon sticks", "sriracha", "celery seeds", "chicken wings", "garlic cloves", "honey", "olive oil", "cilantro", "black pepper", "chiles de árbol", "tamarind concentrate", "green cardamom", "black cardamom", "lemon juice", "kosher salt", "serrano chili", "ginger", "black peppercorns", "butter"])),
+                             ("dahi_puri_with_black_chickpeas", "Dahi Puri with Black Chickpeas", Set(["roasted chicken", "scallion chutney", "yukon gold potato", "turmeric", "black chickpeas", "whole-milk yogurt", "chili powder", "red onion", "pani puri", "ginger", "mint", "thin sev", "date syrup", "cumin", "chaat masala", "tamarind concentrate"])),
+                             ("brisket_with_grilled_rhubarb,_onions,_and_fennel", "Brisket with Grilled Rhubarb, Onions, and Fennel", Set(["crushed red pepper flakes", "rhubarb", "thyme", "yellow onion", "garlic", "brown sugar", "beer", "lemon", "red onion", "oregano", "soy sauce", "white vinegar", "beef brisket", "parsley", "marjoram", "balsamic vinegar", "vegetable oil", "fennel bulbs", "cilantro", "black pepper", "worcestershire sauce", "celery", "kosher salt", "mint", "chili powder"])),
+                             ("roast_leg_of_lamb_with_crispy_moroccan_carrots_&_couscous", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", Set(["bay leaves", "fresh thyme", "carrot", "tahini", "garlic", "baby carrot", "oranges", "filo pastry", "tomatoes", "harissa", "onions", "rosemary", "leg of lamb", "vegetable bullion", "sesame seeds", "honey", "anchovy fillets", "vinegar", "olive oil", "couscous", "fresh mint", "celery", "yoghurt"])),
+                             ("baked_chicken_jollof_rice", "Baked Chicken Jollof Rice", Set(["coriander", "salt", "white pepper", "water", "bell pepper", "turmeric", "rice", "scotch bonnet pepper", "chicken", "thyme", "maggi cubes", "garlic", "ginger", "onion", "tomato", "carrot", "tomato puree"])),
+                             ("seafood_risotto", "Seafood Risotto", Set(["white wine", "water", "clams", "crab legs", "baby squid", "lemon juice", "parmesan cheese", "olive oil", "white onion", "garlic", "arborio risotto rice", "fish stock", "mussels", "flat-leaf parsley", "tomato paste", "prawns", "baby scallops", "cherry tomatoes"])),
+                             ("lamb_over_marinated_summer_squash_with_hazelnuts_and_ricotta", "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", Set(["red pepper flakes", "hazelnuts", "zucchini", "bay leaves", "carrot", "garlic", "white wine vinegar", "toasted bread", "lemon", "onions", "rosemary", "leg of lamb", "summer squash", "sea salt", "anchovy fillets", "vinegar", "olive oil", "black pepper", "fresh mint", "celery", "kosher salt", "fresh ricotta", "sugar"]))
+                             ]
+
+##############################
+# Data for test_check_drinks #
+##############################
+
+
+all_drinks  =  [("Amaretto Sour", ["almond liqueur", "bourbon", "cherries", "egg white", "lemon juice", "lemon twist", "simple syrup"]),
+                ("Aperol Spritz", ["aperol", "prosecco", "soda water"]),
+                ("Bannana Punch", ["banana", "ginger ale", "lemonade", "orange juice", "pineapple juice", "sugar", "water"]),
+                ("Beet Sumac Soda", ["beet", "club soda", "fresh lemon juice", "sugar", "sumac"]),
+                ("Better Than Celery Juice", ["apple cider vinegar", "black pepper", "celery stalks", "club soda", "granny smith apples", "kosher salt", "parsley"]),
+                ("Black & Blue Berries", ["blackberries", "blueberries", "honey", "lemon juice", "soda water"]),
+                ("Bloody Mary", ["celery", "celery salt", "lemon juice", "pepper", "tomato juice", "vodka", "worcestershire sauce"]),
+                ("Bloody Shame", ["V8 juice", "black pepper", "celery", "salt", "tabasco sauce"]),
+                ("Chai Blossom", ["chai tea bags", "club soda", "fresh lime juice", "lemon twists", "start anise pods", "sugar"]),
+                ("Chile-lime Pineapple Soda", ["chiles de árbol", "club soda", "fresh pineapple juice", "kosher salt", "lime juice", "lime wedges", "pink peppercorns", "sugar"]),
+                ("Citrus Fizz", ["organic marmalade cordial", "seedlip grove 42", "sparkling water"]),
+                ("Dry Martini", ["dry vermouth", "gin", "lemon twist", "olives"]),
+                ("Espresso Martini", ["coffee liqueur", "espresso", "sugar syrup", "vodka"]),
+                ("Fermented Grape Soda", ["red seedless grapes", "sugar", "washed organic ginger"]),
+                ("French 75", ["champagne", "gin", "lemon juice", "sugar syrup"]),
+                ("Gimlet", ["gin", "lime juice", "sugar syrup"]),
+                ("Gin Fizz", ["gin", "lemon juice", "soda water", "sugar syrup"]),
+                ("Huckleberry Shrub", ["club soda", "huckleberries", "sugar", "white wine vinegar"]),
+                ("Mai Tai", ["cherries", "lime juice", "lime wedge", "mint leaves", "orange curacao", "orgeat syrup", "rum", "sugar syrup"]),
+                ("Mango Mule", ["cucumber", "fresh lime juice", "ginger beer", "honey syrup", "ice", "mango puree"]),
+                ("Manhattan", ["bitters", "cherry", "rye", "sweet vermouth"]),
+                ("Maple-Ginger Cider Switchel", ["apple cider vinegar", "club soda", "fresh ginger", "fresh lime juice", "maple syrup", "mint sprigs"]),
+                ("Margarita", ["lime juice", "salt", "simple syrup", "tequila", "triple sec"]),
+                ("Mojito", ["lime", "mint leaves", "soda water", "sugar syrup", "white rum"]),
+                ("Moscow Mule", ["ginger beer", "lime", "lime juice", "vodka"]),
+                ("Negroni", ["bitters", "gin", "sweet vermouth"]),
+                ("Old Fashioned", ["bitters", "bourbon", "orange juice", "orange slices", "sugar"]),
+                ("PG13 Singapore Sling", ["fresh lime juice", "mango juice", "mint sprigs", "pineapple juice", "pomegranate juice", "tonic water"]),
+                ("Penicillin", ["ginger", "honey simple syrup", "lemon juice", "scotch"]),
+                ("Pina Colada", ["cherries", "coconut milk", "cream of coconut", "dark rum", "fresh pineapple", "lime juice", "white rum"]),
+                ("Raspberry Almond Soda", ["almonds", "club soda", "kosher salt", "limes", "ripe raspberries", "sugar"]),
+                ("Salted Meyer Lemon and Sage Presse", ["club soda meyer lemons", "kosher salt", "sage leaves", "simple syrup"]),
+                ("Salted Watermelon Juice", ["cubed watermelon", "kosher salt", "lime wedges"]),
+                ("Shirley Tonic", ["cinnamon sticks", "club soda", "ginger", "lemon twists", "pomegranate juice", "sugar", "whole cloves"]),
+                ("Shirley ginger", ["brooklyn crafted lemon lime ginger beer", "club soda", "grenadine", "lime juice"]),
+                ("Spiced Hibiscus Tea", ["cinnamon sticks", "dried hibiscus flowers", "ginger", "honey", "lemon juice", "lemon wheels", "whole allspice"]),
+                ("Turmeric Tonic", ["agave syrup", "cayenne pepper", "lemon", "peeled ginger", "peeled turmeric", "sparkling water"]),
+                ("Virgin Cucumber Gimlet", [";ime juice", "club soda", "muddled cucumber", "simple syrup"]),
+                ("Whiskey Sour", ["cherry", "lemon juice", "lemon slices", "superfine sugar", "whiskey"])
+                ]
+
+drink_names = ["Amaretto Sour Cocktail","Aperol Spritz Cocktail","Bannana Punch Mocktail","Beet Sumac Soda Mocktail",
+               "Better Than Celery Juice Mocktail","Black & Blue Berries Mocktail","Bloody Mary Cocktail",
+               "Bloody Shame Mocktail","Chai Blossom Mocktail","Chile-lime Pineapple Soda Mocktail",
+               "Citrus Fizz Mocktail","Dry Martini Cocktail","Espresso Martini Cocktail","Fermented Grape Soda Mocktail",
+               "French 75 Cocktail","Gimlet Cocktail","Gin Fizz Cocktail","Huckleberry Shrub Mocktail",
+               "Mai Tai Cocktail","Mango Mule Mocktail","Manhattan Cocktail","Maple-Ginger Cider Switchel Mocktail",
+               "Margarita Cocktail","Mojito Cocktail","Moscow Mule Cocktail","Negroni Cocktail",
+               "Old Fashioned Cocktail","PG13 Singapore Sling Mocktail","Penicillin Cocktail","Pina Colada Cocktail",
+               "Raspberry Almond Soda Mocktail","Salted Meyer Lemon and Sage Presse Mocktail",
+               "Salted Watermelon Juice Mocktail","Shirley Tonic Mocktail","Shirley ginger Mocktail",
+               "Spiced Hibiscus Tea Mocktail","Turmeric Tonic Mocktail","Virgin Cucumber Gimlet Mocktail",
+               "Whiskey Sour Cocktail"]
+
+
+#################################
+# Data for test_categorize_dish #
+#################################
+
+all_dishes = recipes_without_duplicates
+
+dishes_categorized  =  ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt: PALEO",
+                        "Winter Cobb Salad: VEGETARIAN",
+                        "White Cheddar Scalloped Potatoes: VEGETARIAN",
+                        "Walnut Ravioli with Artichokes and Tomatoes: VEGETARIAN",
+                        "Waakye: VEGAN",
+                        "Vegetarian Khoresh Bademjan: VEGAN",
+                        "Vegan Pizza with Caramelized Onions: VEGAN",
+                        "Vegan Mini Savory Mince Pies: VEGAN",
+                        "Vegan Carbonara: VEGAN",
+                        "Sweet and Spicy Crispy Green Beans: VEGAN",
+                        "Summer Minestrone Cups: VEGETARIAN",
+                        "Sticky Lemon Tofu: VEGAN",
+                        "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole: OMNIVORE",
+                        "Shakshuka: VEGAN",
+                        "Seared Salmon with Pickled Vegetable and Watercress Salad: KETO",
+                        "Seafood Risotto: OMNIVORE",
+                        "Satay Steak Skewers: KETO",
+                        "Roasted Corn and Zucchini Salad: VEGAN",
+                        "Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes: PALEO",
+                        "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing: VEGETARIAN",
+                        "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous: OMNIVORE",
+                        "Pumpkin Bread Crostini: PALEO",
+                        "Prawn and Herb Omelette: KETO",
+                        "Pork Chops with Grilled Castelfranco Radicchio and Asparagus: KETO",
+                        "Parmesan Crackers and Spinach Crackers with Salmon Pate: KETO",
+                        "Nut Wellington: VEGETARIAN",
+                        "Mushroom Lasagna: VEGETARIAN",
+                        "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta: OMNIVORE",
+                        "Kisir with Warm Pita: VEGAN",
+                        "Kingfish Lettuce Cups: KETO",
+                        "Grilled Tofu Tacos: VEGETARIAN",
+                        "Grilled Shrimp and Pesto over Zucchini Noodles: PALEO",
+                        "Grilled Pork Chops with Mango Pineapple Salsa: PALEO",
+                        "Grilled Flank Steak with Caesar Salad: PALEO",
+                        "Grilled Fish Tacos with Cauliflower Tortillas: PALEO",
+                        "Governor Shrimp Tacos: OMNIVORE",
+                        "Golden Potato Salad: VEGAN",
+                        "Georgian Eggplant Rolls with Walnuts: VEGAN",
+                        "Fried Zucchini with Balsamic and Chili Dressing: VEGETARIAN",
+                        "Fresh Garden Peas over Cauliflower Almond Puree: VEGETARIAN",
+                        "Flank Steak with Chimichurri and Asparagus: KETO",
+                        "Dahi Puri with Black Chickpeas: OMNIVORE",
+                        "Chicken with Tamarind and Apricot Sauce: PALEO",
+                        "Cherry Tomato, Watercress and Fava Bean Salad: VEGETARIAN",
+                        "Cheela with Spicy Mango Chutney: VEGAN",
+                        "Celeriac Schnitzel: VEGAN",
+                        "Cauliflower Pizza with Roasted Tomatoes and Chicken: KETO",
+                        "Carrot Puff Pastry Tart: VEGAN",
+                        "Cambodian-Style Vegetable Spring Rolls: VEGETARIAN",
+                        "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney: KETO",
+                        "Burnt Masala Wings with Classic Coleslaw: OMNIVORE",
+                        "Burmese Tofu with Garlic, Ginger and Chili Sauce: VEGAN",
+                        "Brisket with Grilled Rhubarb, Onions, and Fennel: OMNIVORE",
+                        "Braised Pork Belly with Apple Salad: KETO",
+                        "BLT Bites: PALEO",
+                        "Beachside Snapper: OMNIVORE",
+                        "Barley Risotto: VEGETARIAN",
+                        "Baked Kelewele: VEGAN",
+                        "Baked Chicken Jollof Rice: OMNIVORE",
+                        "Avocado Deviled Eggs: PALEO",
+                        "Asparagus Puffs: VEGETARIAN"]
+
+
+#########################################
+# Data for test_tag_special_ingredients #
+#########################################
+
+
+dupes =  ["Baked Kelewele", "Barley Risotto", "Burmese Tofu with Garlic, Ginger and Chili Sauce",
+          "Cambodian-Style Vegetable Spring Rolls", "Fried Zucchini with Balsamic and Chili Dressing",
+          "Kisir with Warm Pita", "Shakshuka", "Summer Minestrone Cups", "Vegetarian Khoresh Bademjan"]
+
+nondupes = ["Brisket with Grilled Rhubarb, Onions, and Fennel", "Burnt Masala Wings with Classic Coleslaw",
+            "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney",
+            "Cauliflower Pizza with Roasted Tomatoes and Chicken", "Dahi Puri with Black Chickpeas",
+            "Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups",
+            "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole"]
+
+group_1 = filter(item -> item[1] ∈ dupes, recipes_with_duplicates)
+group_2 = [(item[2], item[3]) for item in recipes_without_duplicates if item[2] ∈ nondupes]
+
+dishes_to_special_label = sort!(vcat(group_1, group_2))
+
+dishes_labeled =  [("Baked Kelewele", Set(["red onion"])),
+                   ("Barley Risotto", Set(["garlic", "red onion", "parmesan cheese"])),
+                   ("Brisket with Grilled Rhubarb, Onions, and Fennel", Set(["soy sauce", "garlic", "red onion", "yellow onion"])),
+                   ("Burmese Tofu with Garlic, Ginger and Chili Sauce", Set(["soy sauce", "garlic", "peanuts"])),
+                   ("Burnt Masala Wings with Classic Coleslaw", Set(["honey", "butter", "garlic cloves"])),
+                   ("Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", Set(["heavy cream", "garlic", "butter", "tomatoes"])),
+                   ("Cambodian-Style Vegetable Spring Rolls", Set(["soy sauce", "firm tofu", "garlic", "toasted peanuts"])),
+                   ("Cauliflower Pizza with Roasted Tomatoes and Chicken", Set(["parmesan", "mozzarella cheese", "tomato paste", "cherry tomatoes", "eggs"])),
+                   ("Dahi Puri with Black Chickpeas", Set(["red onion", "whole-milk yogurt"])),
+                   ("Flank Steak with Chimichurri and Asparagus", Set(["garlic"])),
+                   ("Fried Zucchini with Balsamic and Chili Dressing", Set(["honey", "garlic", "red onion"])),
+                   ("Kingfish Lettuce Cups", Set(["soy sauce", "oyster sauce", "garlic", "grilled king fish"])),
+                   ("Kisir with Warm Pita", Set(["bulgur", "tomato paste"])),
+                   ("Shakshuka", Set(["tomatoes", "tomato paste", "firm tofu", "yellow onion"])),
+                   ("Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["shrimp", "garlic", "butter", "slivered almonds", "bacon"])),
+                   ("Summer Minestrone Cups", Set(["garlic", "tomatoes", "parmesan cheese"])),
+                   ("Vegetarian Khoresh Bademjan", Set(["slivered almonds", "tomato paste"]))]
+
+
+
+#####################################
+# Data for test_compile_ingredients #
+#####################################
+
+
+ingredients_only = [[Set(["bulgur", "pomegranate molasses", "chopped parsley", "lemon juice", "tomato", "persian cucumber", "tomato paste", "spring onion", "water", "olive oil"]),
+                    Set(["vegan unsweetened yoghurt", "yellow onion", "firm tofu", "smoked paprika", "tomatoes", "tomato paste", "sugar", "cloves", "cumin", "za'atar", "olive oil", "harissa", "red bell pepper"]),
+                    Set(["yellow split peas", "tomato paste", "black pepper", "pomegranate concentrate", "yellow onions", "slivered almonds", "ground turmeric", "barberries", "basmati rice", "lemon juice", "hot water", "cayenne pepper", "chinese eggplants", "salt", "orange juice", "saffron powder", "vegan butter", "orange zest", "kosher salt"]),
+                    Set(["smoked paprika", "black peppercorn", "red onion", "grains of selim", "cayenne pepper", "calabash nutmeg", "coconut oil", "cloves", "fresh ginger", "salt", "ripe plantains"]),
+                    Set(["baking soda", "sorghum stems", "coconut oil", "black-eyed peas", "water", "salt", "white rice"]),
+                    Set(["pomegranate seeds", "oil", "coriander", "garlic", "khmeli suneli", "eggplants", "black pepper", "vinegar", "walnuts", "water", "salt"]),
+                    Set(["soy sauce", "oil", "chili flakes", "garlic", "brown sugar", "ginger", "peanuts", "rice vinegar", "spring onions", "water", "turmeric", "salt", "chickpea flour"]),
+                    Set(["soy sauce", "parsley", "lemon", "sunflower oil", "black pepper", "celeriac", "breadcrumbs", "water", "salt", "flour", "chickpea flour"]),
+                    Set(["soy sauce", "vegetable stock", "tofu", "cornstarch", "lemon juice", "lemon zest", "garlic", "ginger", "black pepper", "sugar", "water", "salt", "vegetable oil"]),
+                    Set(["soy sauce", "smoked tofu", "lemon juice", "nutritional yeast", "mixed herbs", "garlic", "black pepper", "silken tofu", "turmeric", "salt", "olive oil", "spaghetti"]),
+                    Set(["mushrooms", "rosemary", "garlic", "red pepper flakes", "yeast", "barley malt", "water", "olive oil", "garlic powder", "oregano", "honey", "nutritional yeast", "red onion", "tomatoes", "cashews", "sugar", "bell pepper", "flour", "salt", "fresh basil"]),
+                    Set(["clove powder", "oil", "cinnamon powder", "nigella seeds", "curry leaves", "coriander seeds", "garlic", "mangoes", "mashed potatoes", "cardamom powder", "vinegar", "water", "mustard seeds", "coriander powder", "cumin powder", "mango powder", "garam masala", "red chili powder", "hing", "garlic paste", "turmeric powder", "cilantro", "sugar", "onion", "serrano chili", "fresh ginger", "turmeric", "salt", "fresh red chili", "chickpea flour"]),
+                    Set(["soy sauce", "pomegranate molasses", "sesame oil", "green beans", "sunflower oil", "scallions", "garlic", "carrot", "ginger", "sesame seeds", "tomato paste", "bell pepper", "siracha"]),
+                    Set(["mushrooms", "cinnamon powder", "rosemary", "corn flour", "ginger", "brown sugar", "carrot", "black pepper", "raisins", "butternut squash", "vegetarian worcestershire sauce", "parev shortcrust pastry", "olive oil", "vegetable stock", "dried cherries", "lemon juice", "lemon zest", "figs", "dried cranberries", "apples", "pecans", "onion", "orange juice", "currants", "dried blueberries", "salt", "brandy", "orange zest", "allspice powder"]),
+                    Set(["green onions", "lemon juice", "lemon zest", "dill", "corn", "tomatoes", "black pepper", "zucchini", "olive oil"]),
+                    Set(["mustard seeds", "cumin seeds", "lemon juice", "garlic", "black pepper", "balsamic vinegar", "yukon gold potato", "chives", "turmeric", "salt", "olive oil"]),
+                    Set(["olive oil", "lemon", "lemon juice", "pareve puff pastry", "brown sugar", "red onion", "carrot", "garlic", "black pepper", "thyme", "vegan butter", "water", "salt", "ground almonds"])
+                    ],
+
+                    [Set(["nutmeg", "garlic", "black pepper", "onions", "butter", "parmesan cheese", "portobello mushrooms", "flour", "dried lasagna noodles", "olive oil", "milk", "kosher salt"]),
+                    Set(["sage", "puff pastry sheets", "hazelnuts", "almonds", "black pepper", "thyme", "marmite", "breadcrumbs", "walnuts", "dates", "eggs", "olive oil", "brazil nuts", "leeks", "chestnuts", "cashews", "apples", "pecans", "butter", "salt"]),
+                    Set(["shallots", "garlic", "cream", "thyme", "breadcrumbs", "sharp white cheddar", "yukon gold potato", "milk", "kosher salt"]),
+                    Set(["smoked tofu", "shiitake mushrooms", "red wine vinegar", "garlic", "tomatoes", "black pepper", "avocados", "blue cheese", "onion", "lacinato kale", "eggs", "olive oil"]),
+                    Set(["honey", "lemon", "dijon mustard", "feta cheese", "red wine vinegar", "red onion", "watercress", "green lentils", "currants", "capers", "pepitas", "fresh pumpkin", "olive oil"]),
+                    Set(["lime juice", "toasted peanuts", "firm tofu", "garlic", "corn flour", "bean sprouts", "carrot", "palm sugar", "shallots", "red chili", "vermicelli noodles", "wombok", "soy sauce", "sunflower oil", "spring roll wrappers", "vegetarian fish sauce"]),
+                    Set(["fresh peas", "rosemary", "garlic", "chickpeas", "carrot", "leek", "green lentils", "red chili", "olive oil", "croutons", "fresh corn", "lemon zest", "green beans", "parmesan rind", "basil", "tomatoes", "vegetable bullion", "parmesan cheese", "celery", "mint"]),
+                    Set(["honey", "lemon juice", "garlic", "red onion", "red thai chili", "pomegranate", "balsamic vinegar", "mint leaves", "zucchini", "olive oil"]),
+                    Set(["sage", "beets", "pearl barley", "brussel sprouts", "rosemary", "garlic", "carrot", "red onion", "black pepper", "thyme", "butternut squash", "vegetable bullion", "parmesan cheese", "olive oil", "white wine"]),
+                    Set(["fresh peas", "fresh cherry tomatoes", "garlic", "watercress", "balsamic vinegar", "fresh or frozen fava beans", "fresh cherry bocconcini", "salt", "olive oil"]),
+                    Set(["red onions", "lemon", "fresh peas", "garlic", "grated nutmeg", "cream", "cauliflower", "blanched almonds", "fresh pea tendrils", "olive oil", "vegetable oil"]),
+                    Set(["pine nuts", "oil marinated artichokes", "olives", "rosemary", "fresh tomatoes", "ricotta cheese", "black pepper", "fresh artichoke hearts", "walnuts", "pasta sheets", "lemon juice", "lemon zest", "basil", "red onion", "butter", "salt"]),
+                    Set(["egg", "asparagus", "lemon juice", "red onion", "ricotta cheese", "black pepper", "thyme", "salt", "parmesan cheese", "puff pastry", "chives"]),
+                    Set(["cotija cheese", "masa", "fresh cilantro leaves", "jalapeño chili", "chipotle chili", "firm tofu", "garlic", "carrot", "roasted corn", "tomatillos", "pepitas", "ancho chili", "crema", "red onions", "pasilla chili", "lemon", "hot water", "lemon juice", "tomatoes", "avocado", "cumin", "red cabbage", "limes", "black beans"])
+                    ],
+
+                    [Set(["baking soda", "coconut flour", "lemon juice", "lemon zest", "eggs", "coconut yogurt", "black pepper", "fresh thai chili", "coconut oil", "chives", "zucchini", "salt"]),
+                    Set(["lime juice", "fresh cilantro leaves", "eggs", "seranno chili", "avocado", "pepitas", "salt", "garlic powder"]),
+                    Set(["pine nuts", "white vinegar", "chipotle chili", "scallions", "garlic", "paleo parmesan cheese", "black pepper", "avocado oil", "treviso", "olive oil", "radishes", "flank steak", "dijon mustard", "castelfranco radicchio", "worcestershire sauce", "fresh parsley", "cherry tomatoes", "salt", "avocado mayonnaise"]),
+                    Set(["coconut flour", "garlic", "black pepper", "cloves", "eggs", "olive oil", "onions", "honey", "apple cider vinegar", "almond butter", "baking soda", "nutmeg", "pumpkin puree", "cinnamon", "shrimp", "basil", "coconut oil", "cherry tomatoes", "salt", "fresh red chili"]),
+                    Set(["mustard seed", "onion", "kale", "cherry tomatoes", "bacon", "paleo mayonnaise"]),
+                    Set(["purple sweet potato", "chiles de árbol", "garlic", "tomatoes", "safflower oil", "black pepper", "mexican oregano", "avocados", "shallots", "cumin", "olive oil", "lemons", "whole chicken", "limes", "kosher salt"]),
+                    Set(["garlic", "black pepper", "dried apricots", "roma tomatoes", "water", "olive oil", "honey", "cinnamon", "ground cumin", "cider vinegar", "chili powder", "safflower oil", "homemade tamarind concentrate", "white chicken", "allspice", "chipotles", "salt", "homemade apricot honey preserves", "kosher salt"]),
+                    Set(["green onions", "serrano chili", "shredded red cabbage", "smoked paprika", "mango", "eggs", "black pepper", "cilantro", "cauliflower", "avocado", "lime", "cumin", "salt", "tilapia"]),
+                    Set(["cilantro leaves", "lime", "pineapple", "chipotle chili", "garlic", "mangoes", "cauliflower", "avocado", "serrano chili", "pork chops", "lime zest", "lacinato kale", "onions"]),
+                    Set(["pine nuts", "shrimp", "green bell pepper", "lemon juice", "basil", "lemon zest", "garlic", "tomatoes", "cashews", "yellow bell pepper", "cumin", "zucchini", "salt", "olive oil", "red bell pepper"])
+                    ],
+
+                    [Set(["parmesan", "almond meal", "rosemary", "mozzarella cheese", "roasted chicken", "tomato paste", "cauliflower", "cherry tomatoes", "eggs", "fresh basil", "olive oil"]),
+                    Set(["white vinegar", "asparagus", "flank steak", "chipotle chili", "scallions", "garlic", "black pepper", "cauliflower", "sour cream", "fresh parsley", "salt", "olive oil"]),
+                    Set(["soy sauce", "watermelon radishes", "lime juice", "fish sauce", "mirin", "little gem lettuce heads", "peanut oil", "garlic", "sesame seeds", "oyster sauce", "spring onions", "avocado", "grilled king fish", "red cabbage"]),
+                    Set(["clove powder", "curry leaves", "coriander seeds", "ginger", "cardamom powder", "vinegar", "mustard seeds", "mango powder", "garam masala", "red chili powder", "chicken", "hing", "turmeric powder", "tomatoes", "ginger garlic paste", "fresh greek yogurt", "fresh ginger", "monk fruit", "turmeric", "cashew nuts", "salt", "fresh red chili", "cinnamon powder", "nigella seeds", "whole small crimini mushrooms", "brussel sprouts", "garlic", "mangoes", "heavy cream", "cloves", "coriander powder", "cumin powder", "cardamom", "green chili", "cinnamon", "garlic paste", "red chili flakes", "lemon juice", "cilantro", "butter", "dried fenugreek leaves", "boned chicken"]),
+                    Set(["green onions", "parsley", "sesame seeds", "black pepper", "chives", "eggs", "fennel bulb", "tahini", "olive oil", "harissa", "shrimp", "lemon juice", "dill", "butter", "onion", "fresh cucumber", "monk fruit", "salt"]),
+                    Set(["sriacha", "apple cider vinegar", "lime juice", "fish sauce", "red and green thai chili", "flank steak", "carrot", "peanuts", "cucumbers", "roasted peanuts", "crunchy peanut butter", "kecap manis", "monk fruit", "micro cilantro", "olive oil"]),
+                    Set(["spinach", "parmesan cheese", "coconut flour", "chili flakes", "garlic", "black pepper", "cream cheese", "ghee", "lemon juice", "flaxmeal", "red onion", "salt", "salmon fillets", "pecans", "almond flour", "cumin", "fresh cucumber", "cherry tomatoes", "chives", "avocado mayonnaise"]),
+                    Set(["rosemary", "garlic", "black pepper", "thyme", "avocado oil", "eggs", "oregano", "asparagus", "lemon", "dijon mustard", "basil", "castelfranco radicchio", "dill", "butter", "pork chops", "monk fruit", "salt", "avocado mayonnaise"]),
+                    Set(["lime juice", "caster sugar", "toasted buckwheat", "lemon juice", "red wine vinegar", "red onion", "dutch carrot", "salmon steaks", "watercress", "pink peppercorns", "shallots", "fennel seeds", "red cabbage", "radishes"]),
+                    Set(["cilantro leaves", "green cabbage", "lemon juice", "pork belly", "dark soy sauce", "granny smith apples", "ginger", "light soy sauce", "sesame seeds", "black pepper", "cinnamon sticks", "spring onions", "star anise", "monk fruit", "olive oil"])
+                    ],
+
+                    [Set(["lime juice", "salsa", "green bell pepper", "anaheim chili", "black pepper", "olive oil", "yellow mustard", "red bell pepper", "soy sauce", "mexican crema", "mayonnaise", "white onion", "garlic cloves", "fresh corn tortillas", "red onion", "tomatoes", "limes", "worcestershire sauce", "butter", "yellow bell pepper", "salt", "red snapper"]),
+                    Set(["lime juice", "poblano chili", "tomato paste", "black pepper", "chipotle adobo sauce", "chile manzano", "roma tomatoes", "pepitas", "oaxaca cheese", "white onion", "shelled large shrimp", "garlic cloves", "fresh corn tortillas", "red onion", "worcestershire sauce", "avocado", "butter", "kosher salt"]),
+                    Set(["fresh tortillas", "shrimp", "garlic", "chickpeas", "black pepper", "slivered almonds", "guajillo chile", "bacon", "sea salt", "butter", "onion", "avocado", "olive oil"]),
+                    Set(["lime juice", "green cabbage", "chiles de árbol", "green cardamom", "ginger", "carrot", "sriracha", "black pepper", "cinnamon sticks", "celery seeds", "cloves", "black cardamom", "olive oil", "chicken wings", "apple cider vinegar", "mayonnaise", "honey", "black peppercorns", "lemon juice", "garlic cloves", "tamarind concentrate", "cilantro", "butter", "serrano chili", "red cabbage", "kosher salt"]),
+                    Set(["whole-milk yogurt", "chaat masala", "ginger", "pani puri", "scallion chutney", "yukon gold potato", "black chickpeas", "thin sev", "date syrup", "red onion", "roasted chicken", "chili powder", "tamarind concentrate", "cumin", "turmeric", "mint"]),
+                    Set(["white vinegar", "parsley", "yellow onion", "rhubarb", "garlic", "brown sugar", "black pepper", "thyme", "crushed red pepper flakes", "fennel bulbs", "beer", "marjoram", "vegetable oil", "soy sauce", "oregano", "lemon", "red onion", "chili powder", "cilantro", "beef brisket", "balsamic vinegar", "worcestershire sauce", "celery", "mint", "kosher salt"]),
+                    Set(["oranges", "rosemary", "garlic", "anchovy fillets", "couscous", "carrot", "sesame seeds", "fresh thyme", "vinegar", "olive oil", "tahini", "harissa", "onions", "honey", "fresh mint", "leg of lamb", "tomatoes", "baby carrot", "vegetable bullion", "filo pastry", "celery", "bay leaves", "yoghurt"]),
+                    Set(["tomato puree", "garlic", "ginger", "tomato", "carrot", "thyme", "white pepper", "water", "maggi cubes", "chicken", "rice", "coriander", "scotch bonnet pepper", "bell pepper", "onion", "turmeric", "salt"]),
+                    Set(["garlic", "tomato paste", "baby scallops", "mussels", "water", "crab legs", "olive oil", "baby squid", "fish stock", "lemon juice", "white onion", "arborio risotto rice", "clams", "parmesan cheese", "flat-leaf parsley", "cherry tomatoes", "prawns", "white wine"]),
+                    Set(["toasted bread", "rosemary", "hazelnuts", "anchovy fillets", "garlic", "carrot", "summer squash", "black pepper", "red pepper flakes", "vinegar", "sea salt", "zucchini", "olive oil", "onions", "white wine vinegar", "fresh mint", "leg of lamb", "lemon", "fresh ricotta", "sugar", "celery", "bay leaves", "kosher salt"])
+                     ]]
+
+
+
+#####################################
+# Data for test_separate_appetizers #
+#####################################
+
+
+vegan = ["Kisir with Warm Pita", "Shakshuka", "Vegetarian Khoresh Bademjan", "Baked Kelewele", "Waakye", "Georgian Eggplant Rolls with Walnuts", "Burmese Tofu with Garlic, Ginger and Chili Sauce", "Celeriac Schnitzel", "Sticky Lemon Tofu", "Vegan Carbonara", "Vegan Pizza with Caramelized Onions", "Cheela with Spicy Mango Chutney", "Sweet and Spicy Crispy Green Beans", "Vegan Mini Savory Mince Pies", "Roasted Corn and Zucchini Salad", "Golden Potato Salad", "Carrot Puff Pastry Tart", "Kisir with Warm Pita", "Baked Kelewele", "Burmese Tofu with Garlic, Ginger and Chili Sauce", "Vegan Carbonara", "Sweet and Spicy Crispy Green Beans", "Golden Potato Salad"]
+vegan_appetizers = ["Georgian Eggplant Rolls with Walnuts", "Cheela with Spicy Mango Chutney", "Vegan Mini Savory Mince Pies", "Carrot Puff Pastry Tart", "Georgian Eggplant Rolls with Walnuts", "Carrot Puff Pastry Tart"]
+vegan_dishes = ["Golden Potato Salad", "Roasted Corn and Zucchini Salad", "Sticky Lemon Tofu", "Shakshuka", "Burmese Tofu with Garlic, Ginger and Chili Sauce", "Vegan Pizza with Caramelized Onions", "Celeriac Schnitzel", "Waakye", "Vegan Carbonara", "Sweet and Spicy Crispy Green Beans", "Vegetarian Khoresh Bademjan", "Baked Kelewele", "Kisir with Warm Pita"]
+vegan_appetizer_names = ["Georgian Eggplant Rolls with Walnuts","Cheela with Spicy Mango Chutney","Vegan Mini Savory Mince Pies","Carrot Puff Pastry Tart"]
+
+
+vegetarian = ["Mushroom Lasagna", "Nut Wellington", "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", "Cambodian-Style Vegetable Spring Rolls", "Summer Minestrone Cups", "Fried Zucchini with Balsamic and Chili Dressing", "Barley Risotto", "Cherry Tomato, Watercress and Fava Bean Salad", "Fresh Garden Peas over Cauliflower Almond Puree", "Walnut Ravioli with Artichokes and Tomatoes", "Asparagus Puffs", "Grilled Tofu Tacos", "Mushroom Lasagna", "Cambodian-Style Vegetable Spring Rolls", "Barley Risotto", "Walnut Ravioli with Artichokes and Tomatoes"]
+vegetarian_appetizers = ["Cambodian-Style Vegetable Spring Rolls", "Summer Minestrone Cups", "Asparagus Puffs", "Grilled Tofu Tacos", "Cambodian-Style Vegetable Spring Rolls", "Grilled Tofu Tacos"]
+vegetarian_dishes = ["Walnut Ravioli with Artichokes and Tomatoes", "Mushroom Lasagna", "Fried Zucchini with Balsamic and Chili Dressing", "Barley Risotto", "Nut Wellington", "Cherry Tomato, Watercress and Fava Bean Salad", "Roast Pumpkin and Lentil Salad with Roasted Lemon Dressing", "Fresh Garden Peas over Cauliflower Almond Puree"]
+vegetarian_appetizer_names = ["Cambodian-Style Vegetable Spring Rolls","Summer Minestrone Cups","Asparagus Puffs","Grilled Tofu Tacos"]
+
+
+paleo = ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "Avocado Deviled Eggs", "Grilled Flank Steak with Caesar Salad", "Pumpkin Bread Crostini", "BLT Bites", "Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", "Chicken with Tamarind and Apricot Sauce", "Grilled Fish Tacos with Cauliflower Tortillas", "Grilled Pork Chops with Mango Pineapple Salsa", "Grilled Shrimp and Pesto over Zucchini Noodles", "Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "Pumpkin Bread Crostini", "Chicken with Tamarind and Apricot Sauce", "Grilled Shrimp and Pesto over Zucchini Noodles"]
+paleo_appetizers = ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "Avocado Deviled Eggs", "Pumpkin Bread Crostini", "BLT Bites", "Zucchini Fritters with Lemon-Thyme Coconut Yogurt", "BLT Bites"]
+paleo_dishes = ["Roasted Chicken with Roasted Tomatoes, Avocado, and Sweet Potatoes", "Grilled Flank Steak with Caesar Salad", "Grilled Fish Tacos with Cauliflower Tortillas", "Grilled Pork Chops with Mango Pineapple Salsa", "Grilled Shrimp and Pesto over Zucchini Noodles", "Chicken with Tamarind and Apricot Sauce"]
+paleo_appetizer_names = ["Zucchini Fritters with Lemon-Thyme Coconut Yogurt","Avocado Deviled Eggs","Pumpkin Bread Crostini","BLT Bites"]
+
+
+keto = ["Cauliflower Pizza with Roasted Tomatoes and Chicken", "Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", "Prawn and Herb Omelette", "Satay Steak Skewers", "Parmesan Crackers and Spinach Crackers with Salmon Pate", "Pork Chops with Grilled Castelfranco Radicchio and Asparagus", "Seared Salmon with Pickled Vegetable and Watercress Salad", "Braised Pork Belly with Apple Salad", "Cauliflower Pizza with Roasted Tomatoes and Chicken", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", "Parmesan Crackers and Spinach Crackers with Salmon Pate", "Braised Pork Belly with Apple Salad"]
+keto_appetizers = ["Kingfish Lettuce Cups", "Prawn and Herb Omelette", "Satay Steak Skewers", "Parmesan Crackers and Spinach Crackers with Salmon Pate", "Kingfish Lettuce Cups", "Parmesan Crackers and Spinach Crackers with Salmon Pate"]
+keto_dishes = ["Cauliflower Pizza with Roasted Tomatoes and Chicken", "Butter Chicken with Grilled Mushrooms, Brussel Sprouts and Mango Chutney", "Braised Pork Belly with Apple Salad", "Seared Salmon with Pickled Vegetable and Watercress Salad", "Pork Chops with Grilled Castelfranco Radicchio and Asparagus", "Flank Steak with Chimichurri and Asparagus"]
+keto_appetizer_names = ["Kingfish Lettuce Cups","Prawn and Herb Omelette","Satay Steak Skewers","Parmesan Crackers and Spinach Crackers with Salmon Pate"]
+
+
+omnivore = ["Beachside Snapper", "Governor Shrimp Tacos", "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", "Burnt Masala Wings with Classic Coleslaw", "Dahi Puri with Black Chickpeas", "Brisket with Grilled Rhubarb, Onions, and Fennel", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", "Baked Chicken Jollof Rice", "Seafood Risotto", "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", "Beachside Snapper", "Burnt Masala Wings with Classic Coleslaw", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", "Lamb over Marinated Summer Squash with Hazelnuts and Ricotta"]
+omnivore_appetizers = ["Governor Shrimp Tacos", "Burnt Masala Wings with Classic Coleslaw", "Dahi Puri with Black Chickpeas", "Seafood Risotto", "Governor Shrimp Tacos", "Seafood Risotto"]
+omnivore_dishes = ["Lamb over Marinated Summer Squash with Hazelnuts and Ricotta", "Shrimp, Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", "Brisket with Grilled Rhubarb, Onions, and Fennel", "Roast Leg of Lamb with Crispy Moroccan Carrots & Couscous", "Beachside Snapper", "Baked Chicken Jollof Rice"]
+omnivore_appetizer_names = ["Governor Shrimp Tacos","Burnt Masala Wings with Classic Coleslaw","Dahi Puri with Black Chickpeas","Seafood Risotto"]
+
+
+dishes_and_appetizers = ((vegan, vegan_appetizers),
+                         (vegetarian, vegetarian_appetizers),
+                         (paleo, paleo_appetizers),
+                         (keto, keto_appetizers),
+                         (omnivore, omnivore_appetizers)
+                        )
+
+dishes_cleaned = (vegan_dishes,
+                  vegetarian_dishes,
+                  paleo_dishes,
+                  keto_dishes,
+                  omnivore_dishes
+                  )
+
+
+#######################################
+# Data for test_singleton_ingredients #
+#######################################
+
+
+intersections = (VEGAN_INTERSECTIONS, VEGETARIAN_INTERSECTIONS, PALEO_INTERSECTIONS,
+                 KETO_INTERSECTIONS, OMNIVORE_INTERSECTIONS)
+
+dishes_and_overlap = [(item[1], item[2]) for item in zip(ingredients_only, intersections)]
+ingredients = (union(group...) for group in ingredients_only)
+singletons  = (symdiff(item[1], item[2]) for item in zip(ingredients, intersections))
+
+backup_singletons = [Set(["black-eyed peas", "coriander", "cashews", "yellow split peas", "pomegranate seeds", "cumin", "mangoes", "pomegranate concentrate", "red chili powder", "slivered almonds", "black peppercorn", "cornstarch", "smoked tofu", "curry leaves", "zucchini", "currants", "dried cranberries", "yukon gold potato", "tofu", "yeast", "fresh basil", "hot water", "ripe plantains", "calabash nutmeg", "green beans", "kosher salt", "grains of selim", "vegetarian worcestershire sauce", "cumin seeds", "figs", "ground turmeric", "white rice", "harissa", "garlic powder", "scallions", "barberries", "walnuts", "basmati rice", "saffron powder", "butternut squash", "thyme", "tomato", "chopped parsley", "hing", "coriander seeds", "turmeric powder", "eggplants", "sesame oil", "za'atar", "pareve puff pastry", "firm tofu", "yellow onions", "coriander powder", "parsley", "garlic paste", "rice vinegar", "sorghum stems", "spring onions", "raisins", "chinese eggplants", "garam masala", "ground almonds", "baking soda", "clove powder", "allspice powder", "parev shortcrust pastry", "dill", "nigella seeds", "dried blueberries", "cardamom powder", "cilantro", "serrano chili", "breadcrumbs", "mango powder", "dried cherries", "oregano", "fresh red chili", "pecans", "chives", "spaghetti", "mixed herbs", "brandy", "cumin powder", "silken tofu", "yellow onion", "balsamic vinegar", "persian cucumber", "red bell pepper", "peanuts", "siracha", "red pepper flakes", "spring onion", "vegan unsweetened yoghurt", "corn", "khmeli suneli", "barley malt", "green onions", "apples", "corn flour", "honey", "celeriac", "bulgur", "sesame seeds", "mashed potatoes", "chili flakes", "vegetable oil"]),
+                     Set(["vegetarian fish sauce", "cashews", "white wine", "portobello mushrooms", "marmite", "dates", "tomatillos", "cumin", "chestnuts", "beets", "masa", "mint", "smoked tofu", "fresh pea tendrils", "puff pastry sheets", "zucchini", "currants", "hazelnuts", "croutons", "pearl barley", "dijon mustard", "yukon gold potato", "fresh tomatoes", "vermicelli noodles", "fresh cherry tomatoes", "celery", "hot water", "green beans", "grated nutmeg", "roasted corn", "palm sugar", "ancho chili", "fresh corn", "spring roll wrappers", "cotija cheese", "parmesan rind", "pasta sheets", "brazil nuts", "cauliflower", "butternut squash", "mint leaves", "fresh cherry bocconcini", "crema", "blue cheese", "chickpeas", "pasilla chili", "black beans", "wombok", "capers", "pine nuts", "egg", "shiitake mushrooms", "red thai chili", "jalapeño chili", "toasted peanuts", "brussel sprouts", "lime juice", "leeks", "flour", "dried lasagna noodles", "onions", "limes", "chipotle chili", "lacinato kale", "fresh pumpkin", "almonds", "olives", "onion", "fresh artichoke hearts", "leek", "pecans", "chives", "blanched almonds", "nutmeg", "fresh or frozen fava beans", "soy sauce", "avocados", "bean sprouts", "asparagus", "feta cheese", "sharp white cheddar", "apples", "sunflower oil", "corn flour", "avocado", "puff pastry", "red cabbage", "pomegranate", "fresh cilantro leaves", "oil marinated artichokes", "vegetable oil"]),
+                     Set(["treviso", "cashews", "mexican oregano", "pumpkin puree", "purple sweet potato", "homemade apricot honey preserves", "apple cider vinegar", "homemade tamarind concentrate", "paleo parmesan cheese", "pineapple", "green bell pepper", "chipotles", "nutmeg", "ground cumin", "coconut yogurt", "kale", "mangoes", "red bell pepper", "dried apricots", "garlic powder", "pepitas", "white vinegar", "scallions", "avocados", "shredded red cabbage", "smoked paprika", "lime juice", "flank steak", "fresh parsley", "shallots", "chiles de árbol", "yellow bell pepper", "white chicken", "whole chicken", "chili powder", "bacon", "avocado mayonnaise", "cilantro", "limes", "lemons", "green onions", "avocado oil", "cloves", "lacinato kale", "lime zest", "paleo mayonnaise", "radishes", "mango", "dijon mustard", "mustard seed", "cider vinegar", "pork chops", "castelfranco radicchio", "water", "allspice", "seranno chili", "cilantro leaves", "onion", "tilapia", "fresh cilantro leaves", "worcestershire sauce", "almond butter", "fresh thai chili", "fresh red chili", "chives", "roma tomatoes"]),
+                     Set(["dried fenugreek leaves", "apple cider vinegar", "cinnamon sticks", "roasted chicken", "cumin", "mangoes", "heavy cream", "micro cilantro", "white vinegar", "red chili powder", "cinnamon powder", "mustard seeds", "red wine vinegar", "mirin", "cinnamon", "green chili", "avocado oil", "curry leaves", "star anise", "dijon mustard", "crunchy peanut butter", "grilled king fish", "chicken", "fresh basil", "cashew nuts", "pink peppercorns", "pork belly", "spinach", "watercress", "whole small crimini mushrooms", "coconut flour", "fresh ginger", "fennel bulb", "harissa", "tahini", "mozzarella cheese", "scallions", "sriacha", "fresh parsley", "thyme", "light soy sauce", "cream cheese", "hing", "coriander seeds", "sour cream", "turmeric powder", "castelfranco radicchio", "parmesan", "toasted buckwheat", "coriander powder", "dark soy sauce", "granny smith apples", "parsley", "shrimp", "garlic paste", "roasted peanuts", "turmeric", "carrot", "garam masala", "clove powder", "cucumbers", "tomato paste", "almond meal", "dutch carrot", "brussel sprouts", "red and green thai chili", "shallots", "nigella seeds", "cardamom powder", "watermelon radishes", "flaxmeal", "cilantro", "fennel seeds", "chipotle chili", "ghee", "parmesan cheese", "radishes", "pork chops", "cilantro leaves", "fresh greek yogurt", "cardamom", "mango powder", "onion", "oregano", "fresh red chili", "pecans", "salmon fillets", "basil", "green cabbage", "cumin powder", "almond flour", "lemon", "boned chicken", "oyster sauce", "soy sauce", "little gem lettuce heads", "peanut oil", "peanuts", "caster sugar", "salmon steaks", "ginger garlic paste", "green onions", "vinegar", "cloves", "kecap manis", "avocado", "chili flakes", "red chili flakes", "tomatoes"]),
+                     Set(["coriander", "white wine", "fish stock", "apple cider vinegar", "salsa", "rhubarb", "beef brisket", "cinnamon sticks", "cumin", "roasted chicken", "chicken wings", "white vinegar", "sriracha", "slivered almonds", "fresh thyme", "scotch bonnet pepper", "zucchini", "hazelnuts", "pani puri", "yukon gold potato", "toasted bread", "chicken", "yoghurt", "maggi cubes", "couscous", "roma tomatoes", "celery seeds", "chaat masala", "white pepper", "black cardamom", "harissa", "red snapper", "green cardamom", "crushed red pepper flakes", "tahini", "mexican crema", "chiles de árbol", "tomato", "baby squid", "mussels", "chipotle adobo sauce", "shelled large shrimp", "tomato puree", "chickpeas", "fresh tortillas", "flat-leaf parsley", "anaheim chili", "parsley", "shrimp", "chile manzano", "vegetable bullion", "prawns", "cherry tomatoes", "marjoram", "beer", "green bell pepper", "date syrup", "guajillo chile", "baby scallops", "yellow mustard", "black chickpeas", "bell pepper", "filo pastry", "thin sev", "bacon", "white wine vinegar", "limes", "rice", "serrano chili", "brown sugar", "parmesan cheese", "poblano chili", "fennel bulbs", "clams", "baby carrot", "arborio risotto rice", "oregano", "oaxaca cheese", "green cabbage", "yellow onion", "balsamic vinegar", "whole-milk yogurt", "sugar", "red bell pepper", "pepitas", "red pepper flakes", "oranges", "yellow bell pepper", "summer squash", "cloves", "red cabbage", "black peppercorns", "fresh ricotta", "crab legs", "scallion chutney", "sesame seeds", "vegetable oil"])]
+                     


### PR DESCRIPTION
A second attempt at adding cater-waiter. Previous is [PR #818](https://github.com/exercism/julia/pull/818/files)

I haven't included `sets_test_data.jl` since I believe it was superfluous with the current setup putting everything in `exemplar.jl`, but we'll see if the checks pass.