### PR TITLE
Cater waiter reformat

### DIFF
--- a/exercises/concept/cater-waiter/.docs/instructions.md
+++ b/exercises/concept/cater-waiter/.docs/instructions.md
@@ -27,11 +27,11 @@ For the purposes of this exercise, cocktails will only include alcohols from the
 
 ```julia-repl
 julia> include("sets_categories_data.jl");
+
 julia> check_drinks("Honeydew Cucumber", ["honeydew", "coconut water", "mint leaves", "lime juice", "salt", "english cucumber"])
-...
 "Honeydew Cucumber Mocktail"
+
 julia> check_drinks("Shirley Tonic", ["cinnamon stick", "scotch", "whole cloves", "ginger", "pomegranate juice", "sugar", "club soda"])
-...
 "Shirley Tonic Cocktail"
 ```
 

--- a/exercises/concept/cater-waiter/.docs/instructions.md
+++ b/exercises/concept/cater-waiter/.docs/instructions.md
@@ -19,14 +19,14 @@ julia> clean_ingredients("Punjabi-Style Chole", ["onions", "tomatoes", "ginger p
 ## 2. Cocktails and Mocktails
 
 The event is going to include both cocktails and "mocktails" - mixed drinks _without_ the alcohol.
- You need to ensure that "mocktail" drinks are truly non-alcoholic and the cocktails do indeed _include_ alcohol.
+You need to ensure that "mocktail" drinks are truly non-alcoholic and the cocktails do indeed _include_ alcohol.
 
 Implement the `check_drinks(<drink_name>, <drink_ingredients>)` function that takes the name of a drink and a `vector` of ingredients.
- The function should return the name of the drink followed by "Mocktail" if the drink has no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
-  For the purposes of this exercise, cocktails will only include alcohols from the ALCOHOLS constant in `sets_categories_data.jl`:
+The function should return the name of the drink followed by "Mocktail" if the drink has no alcoholic ingredients, and drink name followed by "Cocktail" if the drink includes alcohol.
+For the purposes of this exercise, cocktails will only include alcohols from the ALCOHOLS constant in `sets_categories_data.jl`:
 
 ```julia-repl
-julia> include("sets_categories_data.jl") 
+julia> include("sets_categories_data.jl");
 julia> check_drinks("Honeydew Cucumber", ["honeydew", "coconut water", "mint leaves", "lime juice", "salt", "english cucumber"])
 ...
 "Honeydew Cucumber Mocktail"
@@ -44,12 +44,12 @@ The function should return a string with the `dish name: <CATEGORY>` (_which mea
 All dishes will "fit" into one of the categories found in `sets_categories_data.jl` (VEGAN, VEGETARIAN, PALEO, KETO, or OMNIVORE).
 
 ```julia-repl
-julia> include("sets_categories_data.jl")
+julia> include("sets_categories_data.jl");
+
 julia> categorize_dish("Sticky Lemon Tofu", Set(["tofu", "soy sauce", "salt", "black pepper", "cornstarch", "vegetable oil", "garlic", "ginger", "water", "vegetable stock", "lemon juice", "lemon zest", "sugar"]))
-...
 "Sticky Lemon Tofu: VEGAN"
->>> categorize_dish("Shrimp Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["shrimp", "bacon", "avocado", "chickpeas", "fresh tortillas", "sea salt", "guajillo chile", "slivered almonds", "olive oil", "butter", "black pepper", "garlic", "onion"]))
-...
+
+julia> categorize_dish("Shrimp Bacon and Crispy Chickpea Tacos with Salsa de Guacamole", Set(["shrimp", "bacon", "avocado", "chickpeas", "fresh tortillas", "sea salt", "guajillo chile", "slivered almonds", "olive oil", "butter", "black pepper", "garlic", "onion"]))
 "Shrimp Bacon and Crispy Chickpea Tacos with Salsa de Guacamole: OMNIVORE"
 ```
 
@@ -63,14 +63,14 @@ Return the dish name followed by the `set` of ingredients that require a special
 Dish ingredients inside a `vector` may or may not have duplicates.
  For the purposes of this exercise, all allergens or special ingredients that need to be labeled are in the SPECIAL_INGREDIENTS constant found in `sets_categories_data.py`.
 
-```julia-reple
-julia> include("sets_categories_data.jl")
+```julia-repl
+julia> include("sets_categories_data.jl");
+
 julia> tag_special_ingredients(("Ginger Glazed Tofu Cutlets", ["tofu", "soy sauce", "ginger", "corn starch", "garlic", "brown sugar", "sesame seeds", "lemon juice"]))
-...
 ("Ginger Glazed Tofu Cutlets", Set(["garlic","soy sauce","tofu"]))
->>> tag_special_ingredients(("Arugula and Roasted Pork Salad", ["pork tenderloin", "arugula", "pears", "blue cheese", "pine nuts", "balsamic vinegar", "onions", "black pepper"
+
+julia> tag_special_ingredients(("Arugula and Roasted Pork Salad", ["pork tenderloin", "arugula", "pears", "blue cheese", "pine nuts", "balsamic vinegar", "onions", "black pepper"
 ]))
-...
 ("Arugula and Roasted Pork Salad", Set(["pork tenderloin", "blue cheese", "pine nuts", "onions"]))
 ```
 
@@ -82,12 +82,11 @@ Implement the `compile_ingredients(<dishes>)` function that takes a `vector` of 
 Each individual dish is represented by its `set` of ingredients.
 
 ```julia-repl
-dishes = [Set(["tofu", "soy sauce", "ginger", "corn starch", "garlic", "brown sugar", "sesame seeds", "lemon juice"]),
-          Set(["pork tenderloin", "arugula", "pears", "blue cheese", "pine nuts",
-             "balsamic vinegar", "onions", "black pepper"]),
-          Set(["honeydew", "coconut water", "mint leaves", "lime juice", "salt", "english cucumber"])]
+julia> dishes = [Set(["tofu", "soy sauce", "ginger", "corn starch", "garlic", "brown sugar", "sesame seeds", "lemon juice"]),
+                 Set(["pork tenderloin", "arugula", "pears", "blue cheese", "pine nuts","balsamic vinegar", "onions", "black pepper"]),
+                 Set(["honeydew", "coconut water", "mint leaves", "lime juice", "salt", "english cucumber"])];
+
 julia> compile_ingredients(dishes)
-...
 Set(["arugula", "brown sugar", "honeydew", "coconut water", "english cucumber", "balsamic vinegar", "mint leaves", "pears", "pork tenderloin", "ginger", "blue cheese", "soy sauce", "sesame seeds", "black pepper", "garlic", "lime juice", "corn starch", "pine nuts", "lemon juice", "onions", "salt", "tofu"])
 ```
 
@@ -101,18 +100,16 @@ The function should return a `vector` with the list of dish names with appetizer
 Either the `<dishes>` or `<appetizers>` `vector` could contain duplicates and may require de-duping.
 
 ```julia-repl
-dishes =    ["Avocado Deviled Eggs","Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups",
-             "Grilled Flank Steak with Caesar Salad","Vegetarian Khoresh Bademjan","Avocado Deviled Eggs",
-             "Barley Risotto","Kingfish Lettuce Cups"]
+julia> dishes =    ["Avocado Deviled Eggs","Flank Steak with Chimichurri and Asparagus", "Kingfish Lettuce Cups",
+                    "Grilled Flank Steak with Caesar Salad","Vegetarian Khoresh Bademjan","Avocado Deviled Eggs",
+                    "Barley Risotto","Kingfish Lettuce Cups"];
           
-appetizers = ["Kingfish Lettuce Cups","Avocado Deviled Eggs","Satay Steak Skewers",
-              "Dahi Puri with Black Chickpeas","Avocado Deviled Eggs","Asparagus Puffs",
-              "Asparagus Puffs"]
+julia> appetizers = ["Kingfish Lettuce Cups","Avocado Deviled Eggs","Satay Steak Skewers",
+                     "Dahi Puri with Black Chickpeas","Avocado Deviled Eggs","Asparagus Puffs",
+                     "Asparagus Puffs"];
               
 julia> separate_appetizers(dishes, appetizers)
-...
-["Vegetarian Khoresh Bademjan", "Barley Risotto", "Flank Steak with Chimichurri and Asparagus", 
- "Grilled Flank Steak with Caesar Salad"]
+["Vegetarian Khoresh Bademjan", "Barley Risotto", "Flank Steak with Chimichurri and Asparagus", "Grilled Flank Steak with Caesar Salad"]
 ```
 
 ## 7. Find Ingredients Used in Only One Recipe
@@ -126,8 +123,8 @@ Each `<CATEGORY>_INTERSECTIONS` is a `set` of ingredients that appear in more th
 Using set operations, your function should return a `set` of "singleton" ingredients (_ingredients appearing in only one dish in the category_).
 
 ```julia-repl
-julia> include("sets_categories_data.jl")
+julia> include("sets_categories_data.jl");
+
 julia> singleton_ingredients(example_dishes, EXAMPLE_INTERSECTION)
-...
 Set(["garlic powder", "sunflower oil", "mixed herbs", "cornstarch", "celeriac", "honey", "mushrooms", "bell pepper", "rosemary", "parsley", "lemon", "yeast", "vegetable oil", "vegetable stock", "silken tofu", "tofu", "cashews", "lemon zest", "smoked tofu", "spaghetti", "ginger", "breadcrumbs", "tomatoes", "barley malt", "red pepper flakes", "oregano", "red onion", "fresh basil"])
 ```

--- a/exercises/concept/cater-waiter/.docs/introduction.md
+++ b/exercises/concept/cater-waiter/.docs/introduction.md
@@ -10,37 +10,22 @@ Create them with the `Set()` constructor, using any iterator as the parameter.
 
 ```julia-repl
 julia> s1 = Set(1:4)
-Set{Int64} with 4 elements:
-  4
-  2
-  3
-  1
+Set([4, 2, 3, 1])
 ```
 
 Add new elements with `push!()` (the same as with arrays), and remove them with `delete!()`.
 
 ```julia-repl
 julia> push!(s1, 5)
-Set{Int64} with 5 elements:
-  5
-  4
-  2
-  3
-  1
+Set([5, 4, 2, 3, 1])
+
 # Duplicates are ignored
 julia> push!(s1, 3)
-Set{Int64} with 5 elements:
-  5
-  4
-  2
-  3
-  1
+Set([5, 4, 2, 3, 1])
+
 julia> delete!(s1, 5)
-Set{Int64} with 4 elements:
-  4
-  2
-  3
-  1
+Set([4, 2, 3, 1])
+
 julia> length(s1)  # length counts entries, despite the non-sequential type
 4
 ```
@@ -68,28 +53,16 @@ The following operations on pairs of Sets are supported (shortcuts to the operat
 s1 = Set(1:4)
 s2 = Set(3:6)
 julia> s1 ∪ s2  # union
-Set{Int64} with 6 elements:
-  5
-  4
-  6
-  2
-  3
-  1
+Set([5, 4, 6, 2, 3, 1])
+
 julia> s1 ∩ s2  # intersect
-Set{Int64} with 2 elements:
-  4
-  3
+Set([4, 3])
   
 julia> setdiff(s1, s2)
-Set{Int64} with 2 elements:
-  2
-  1
+Set([2, 1])
+
 julia> symdiff(s1, s2)
-Set{Int64} with 4 elements:
-  5
-  6
-  2
-  1
+Set([5, 6, 2, 1])
   
 julia> s1 ⊇ s2  # issubset
 false


### PR DESCRIPTION
This corrects some inconsistencies in the REPL formatting for the `cater-waiter` exercise, plus a few extraneous whitespaces.