### PR TITLE
Simple Correction in Captains Log Exercise

### DIFF
--- a/exercises/concept/captains-log/.docs/instructions.md
+++ b/exercises/concept/captains-log/.docs/instructions.md
@@ -34,7 +34,7 @@ What's the use of a log if it doesn't include dates?
 
 A stardate is a floating point number. The adventures of the _Starship Enterprise_ from the first season of _The Next Generation_ take place between the stardates 41000.0 and 42000.0. The "4" stands for the 24th century, the "1" for the first season.
 
-Implement the function `random_stardate` that returns a floating point number between 41000.0 and 42000.0 (inclusive).
+Implement the function `random_stardate` that returns a floating point number between 41000.0 and 42000.0.
 
 ```julia-repl
 julia> random_stardate()

--- a/exercises/concept/captains-log/.docs/instructions.md
+++ b/exercises/concept/captains-log/.docs/instructions.md
@@ -34,7 +34,7 @@ What's the use of a log if it doesn't include dates?
 
 A stardate is a floating point number. The adventures of the _Starship Enterprise_ from the first season of _The Next Generation_ take place between the stardates 41000.0 and 42000.0. The "4" stands for the 24th century, the "1" for the first season.
 
-Implement the function `random_stardate` that returns a floating point number between 41000.0 and 42000.0.
+Implement the function `random_stardate` that returns a floating point number between 41000.0 (inclusive) and 42000.0.
 
 ```julia-repl
 julia> random_stardate()

--- a/exercises/concept/captains-log/.meta/exemplar.jl
+++ b/exercises/concept/captains-log/.meta/exemplar.jl
@@ -4,7 +4,7 @@ random_planet() = rand(planetary_classes)
 
 random_ship_registry_number() = "NCC-$(rand(1000:9999))"
 
-random_stardate() = rand() .* 1000 .+ 41000
+random_stardate() = rand() * 1000 + 41000
 
 random_stardate_v2() = rand(41000.0:0.1:42000.0)
 


### PR DESCRIPTION
Both changes are related to Task 3 of the Captain's Log exercise.

**1) Change to** `instructions.md`

In `instructions.md`, Task 3 states that the generator should produce "_a floating point number between 41000.0 and 42000.0 (inclusive)_". However, `rand()` returns a value from a continuous uniform distribution over the open interval (0, 1). Because the distribution is continuous, the probability of generating exactly any single value (including the endpoints 0 and 1) is zero.

As a result, the expression `rand() * 1000 + 41000` produces values from the interval (41000, 42000)—excluding the endpoints. Including the word “inclusive” here could be misleading, unless we intentionally implement a method to ensure inclusion of 41000 or 42000 (e.g., via a mixture model), which does not appear to be the case.

Therefore, I suggest removing the word "(inclusive)" to better reflect the behavior of the function.

Note: In Task 4, a discrete uniform distribution is used, so the use of "(inclusive)" remains appropriate there.

**2) Change to** `exemplar.jl`

Since `rand()`—and by extension `random_stardate()`—returns a scalar, the broadcast operator seems unnecessary in this context. I've removed it for clarity and simplicity.

Best regards,
Matheus Castro