### PR TITLE
create name badge

### DIFF
--- a/exercises/concept/name-badges/.docs/hints.md
+++ b/exercises/concept/name-badges/.docs/hints.md
@@ -1,20 +1,20 @@
 # Hints
 
-The first three tasks all call the same `print_name_badge()` function.
+The first three tasks all call the same `create_name_badge()` function.
 Implementation of this can be built up stepwise, adding logic for tasks 2 and 3 as you proceed.
 
-## 1. Print a badge for an employee
+## 1. Create a badge for an employee
 
 - This is the default case, just assemble the 3 arguments into a suitable string.
 - [String interpolatation][interpolation] is probably the easiest approach.
 
-## 2. Print a badge for a new employee
+## 2. Create a badge for a new employee
 
 - Now the iID is `missing,` so the target string format is different.
 - [`ismissing()][ismissing] is useful here.
 - Julia has a [ternary operator][ternary] with concise syntax.
 
-## 3. Print a badge for the owner
+## 3. Create a badge for the owner
 
 - Now the department is `nothing`.
 - There is an [`isnothing()`][isnothing] function.

--- a/exercises/concept/name-badges/.docs/hints.md
+++ b/exercises/concept/name-badges/.docs/hints.md
@@ -1,6 +1,6 @@
 # Hints
 
-The first three tasks all call the same `create_name_badge()` function.
+The first three tasks all call the same `print_name_badge()` function.
 Implementation of this can be built up stepwise, adding logic for tasks 2 and 3 as you proceed.
 
 ## 1. Create a badge for an employee

--- a/exercises/concept/name-badges/.docs/instructions.md
+++ b/exercises/concept/name-badges/.docs/instructions.md
@@ -1,42 +1,42 @@
 # Instructions
 
-In this exercise you'll be writing code to print name badges for factory employees. Employees have an ID, name, and department name. Employee badge labels are formatted as follows: `"[id] - name - DEPARTMENT"`.
+In this exercise you'll be writing code to create name badges for factory employees. Employees have an ID, name, and department name. Employee badge labels are formatted as follows: `"[id] - name - DEPARTMENT"`.
 
-## 1. Print a badge for an employee
+## 1. Create a badge for an employee
 
-Implement the `print_name_badge` function. It should take an ID, name, and a department. It should return the badge label, with the department name in uppercase.
+Implement the `create_name_badge` function. It should take an ID, name, and a department. It should return the badge label, with the department name in uppercase.
 
 ```julia-repl
-julia> print_name_badge(67, "Katherine Williams", "Strategic Communication")
+julia> create_name_badge(67, "Katherine Williams", "Strategic Communication")
 "[67] - Katherine Williams - STRATEGIC COMMUNICATION"
 ```
 
-## 2. Print a badge for a new employee
+## 2. Create a badge for a new employee
 
 Due to a quirk in the computer system, new employees occasionally don't yet have an ID when they start working at the factory. As badges are required, they will receive a temporary badge without the ID prefix.
 
-Extend the `print_name_badge` function. When the id is missing, it should print a badge without it.
+Extend the `create_name_badge` function. When the id is missing, it should create a badge without it.
 
 ```julia-repl
-julia> print_name_badge(missing, "Robert Johnson", "Procurement")
+julia> create_name_badge(missing, "Robert Johnson", "Procurement")
 "Robert Johnson - PROCUREMENT"
 ```
 
-## 3. Print a badge for the owner
+## 3. Create a badge for the owner
 
-Even the factory's owner has to wear a badge at all times. However, an owner does not have a department and never will: he is above all the departments. In this case, the label should print `"OWNER"` instead of the department name.
+Even the factory's owner has to wear a badge at all times. However, an owner does not have a department and never will: he is above all the departments. In this case, the label should return `"OWNER"` instead of the department name.
 
-Extend the `print_name_badge` function. When the department is `nothing`, assume the badge belongs to the company owner.
+Extend the `create_name_badge` function. When the department is `nothing`, assume the badge belongs to the company owner.
 
 ```julia-repl
-julia> print_name_badge(204, "Rachel Miller", nothing)
+julia> create_name_badge(204, "Rachel Miller", nothing)
 "[204] - Rachel Miller - OWNER"
 ```
 
 Note that it is possible for the owner to also be a new employee.
 
 ```julia-repl
-julia> print_name_badge(missing, "Rachel Miller", nothing)
+julia> create_name_badge(missing, "Rachel Miller", nothing)
 "Rachel Miller - OWNER"
 ```
 

--- a/exercises/concept/name-badges/.docs/instructions.md
+++ b/exercises/concept/name-badges/.docs/instructions.md
@@ -1,13 +1,13 @@
 # Instructions
 
-In this exercise you'll be writing code to create name badges for factory employees. Employees have an ID, name, and department name. Employee badge labels are formatted as follows: `"[id] - name - DEPARTMENT"`.
+In this exercise you'll be writing code to create name badges for factory employees to wear. Employees have an ID, name, and department name. Employee badge labels are formatted as follows: `"[id] - name - DEPARTMENT"`.
 
 ## 1. Create a badge for an employee
 
-Implement the `create_name_badge` function. It should take an ID, name, and a department. It should return the badge label, with the department name in uppercase.
+Implement the `print_name_badge` function. It should take an ID, name, and a department. It should return the badge label, with the department name in uppercase.
 
 ```julia-repl
-julia> create_name_badge(67, "Katherine Williams", "Strategic Communication")
+julia> print_name_badge(67, "Katherine Williams", "Strategic Communication")
 "[67] - Katherine Williams - STRATEGIC COMMUNICATION"
 ```
 
@@ -15,28 +15,28 @@ julia> create_name_badge(67, "Katherine Williams", "Strategic Communication")
 
 Due to a quirk in the computer system, new employees occasionally don't yet have an ID when they start working at the factory. As badges are required, they will receive a temporary badge without the ID prefix.
 
-Extend the `create_name_badge` function. When the id is missing, it should create a badge without it.
+Extend the `print_name_badge` function. When the id is missing, it should create a badge without it.
 
 ```julia-repl
-julia> create_name_badge(missing, "Robert Johnson", "Procurement")
+julia> print_name_badge(missing, "Robert Johnson", "Procurement")
 "Robert Johnson - PROCUREMENT"
 ```
 
 ## 3. Create a badge for the owner
 
-Even the factory's owner has to wear a badge at all times. However, an owner does not have a department and never will: he is above all the departments. In this case, the label should return `"OWNER"` instead of the department name.
+Even the factory's owner has to wear a badge at all times. However, an owner does not have a department and never will: they are above all the departments. In this case, the label should return `"OWNER"` instead of the department name.
 
-Extend the `create_name_badge` function. When the department is `nothing`, assume the badge belongs to the company owner.
+Extend the `print_name_badge` function. When the department is `nothing`, assume the badge belongs to the company owner.
 
 ```julia-repl
-julia> create_name_badge(204, "Rachel Miller", nothing)
+julia> print_name_badge(204, "Rachel Miller", nothing)
 "[204] - Rachel Miller - OWNER"
 ```
 
 Note that it is possible for the owner to also be a new employee.
 
 ```julia-repl
-julia> create_name_badge(missing, "Rachel Miller", nothing)
+julia> print_name_badge(missing, "Rachel Miller", nothing)
 "Rachel Miller - OWNER"
 ```
 

--- a/exercises/concept/name-badges/.docs/instructions.md
+++ b/exercises/concept/name-badges/.docs/instructions.md
@@ -48,7 +48,7 @@ Implement the `salaries_no_id` function that takes a vector of IDs and a corresp
 
 ```julia-repl
 julia> ids = [204, missing, 210, 352, missing, 263]
-julia> salaries  [23, 21, 47, 35, 17, 101] * 1000
+julia> salaries = [23, 21, 47, 35, 17, 101] * 1000
 julia> salaries_no_id(ids, salaries)
 38,000
 ```

--- a/exercises/concept/name-badges/runtests.jl
+++ b/exercises/concept/name-badges/runtests.jl
@@ -2,14 +2,20 @@ using Test
 
 include("name-badges.jl")
 
+try
+    create_name_badge
+catch err
+    global create_name_badge = print_name_badge
+end
+
 @testset verbose = true "tests" begin
-    @testset "1. print_name_badge" begin
+    @testset "1. create_name_badge" begin
         @testset "prints the employee badge with full data" begin
             id = 455
             name = "Mary M. Brown"
             department = "MARKETING"
             expected = "[455] - Mary M. Brown - MARKETING"
-            @test print_name_badge(id, name, department) == expected
+            @test create_name_badge(id, name, department) == expected
         end
         
         @testset "uppercases the department" begin
@@ -17,17 +23,17 @@ include("name-badges.jl")
             name = "Jack McGregor"
             department = "Procurement"
             expected = "[89] - Jack McGregor - PROCUREMENT"
-            @test print_name_badge(id, name, department) == expected
+            @test create_name_badge(id, name, department) == expected
         end
     end
         
     @testset "2. New employee" begin
-        @testset "prints the employee badge without id" begin
+        @testset "create the employee badge without id" begin
             id = missing
             name = "Barbara White"
             department = "SECURITY"
             expected = "Barbara White - SECURITY"
-            @test print_name_badge(id, name, department) == expected
+            @test create_name_badge(id, name, department) == expected
         end
     end
 
@@ -37,7 +43,7 @@ include("name-badges.jl")
             name = "Anna Johnson"
             department = nothing
             expected = "[1] - Anna Johnson - OWNER"
-            @test print_name_badge(id, name, department) == expected
+            @test create_name_badge(id, name, department) == expected
         end
     end
 

--- a/exercises/concept/name-badges/runtests.jl
+++ b/exercises/concept/name-badges/runtests.jl
@@ -2,20 +2,14 @@ using Test
 
 include("name-badges.jl")
 
-try
-    create_name_badge
-catch err
-    global create_name_badge = print_name_badge
-end
-
 @testset verbose = true "tests" begin
-    @testset "1. create_name_badge" begin
-        @testset "prints the employee badge with full data" begin
+    @testset "1. print_name_badge" begin
+        @testset "creates the employee badge with full data" begin
             id = 455
             name = "Mary M. Brown"
             department = "MARKETING"
             expected = "[455] - Mary M. Brown - MARKETING"
-            @test create_name_badge(id, name, department) == expected
+            @test print_name_badge(id, name, department) == expected
         end
         
         @testset "uppercases the department" begin
@@ -23,7 +17,7 @@ end
             name = "Jack McGregor"
             department = "Procurement"
             expected = "[89] - Jack McGregor - PROCUREMENT"
-            @test create_name_badge(id, name, department) == expected
+            @test print_name_badge(id, name, department) == expected
         end
     end
         
@@ -33,17 +27,17 @@ end
             name = "Barbara White"
             department = "SECURITY"
             expected = "Barbara White - SECURITY"
-            @test create_name_badge(id, name, department) == expected
+            @test print_name_badge(id, name, department) == expected
         end
     end
 
-    @testset "3. prints the owner badge" begin
-        @testset "prints the owner badge" begin
+    @testset "3. creates the owner badge" begin
+        @testset "creates the owner badge" begin
             id = 1
             name = "Anna Johnson"
             department = nothing
             expected = "[1] - Anna Johnson - OWNER"
-            @test create_name_badge(id, name, department) == expected
+            @test print_name_badge(id, name, department) == expected
         end
     end
 


### PR DESCRIPTION
A possible fix for Issue #934 

- exchanged the more specific word `print` for the more general `create` throughout.
- tried to implement backwards compatibility with old solutions, with `exemplar.jl` left with the old function name `print_name_badge` as a test.