### PR TITLE
Captain's Log/Randomness: Addition of 'inclusive' to the Uniform definition.

### DIFF
--- a/concepts/randomness/about.md
+++ b/concepts/randomness/about.md
@@ -26,7 +26,7 @@ Julia divides random functionality into multiple locations:
 What this function does depends on the arguments you give it.
 There are _many_ options.
 
-With no arguments, it generates a float between 0 and 1.
+With no arguments, it generates a float between 0 (inclusive) and 1.
 This is a [`uniform`][uniform] distribution with all values equally likely, as discussed in the Working with Distributions section, below.
 
 A single integer argument generates a vector of that length.

--- a/concepts/randomness/introduction.md
+++ b/concepts/randomness/introduction.md
@@ -26,7 +26,7 @@ Julia divides random functionality into multiple locations:
 What this function does depends on the arguments you give it.
 There are _many_ options.
 
-With no arguments, it generates a float between 0 and 1.
+With no arguments, it generates a float between 0 (inclusive) and 1.
 This is a `uniform` distribution with all values equally likely, as discussed in the Working with Distributions section, below.
 
 A single integer argument generates a vector of that length.

--- a/exercises/concept/captains-log/.docs/introduction.md
+++ b/exercises/concept/captains-log/.docs/introduction.md
@@ -26,7 +26,7 @@ Julia divides random functionality into multiple locations:
 What this function does depends on the arguments you give it.
 There are _many_ options.
 
-With no arguments, it generates a float between 0 and 1.
+With no arguments, it generates a float between 0 (inclusive) and 1.
 This is a `uniform` distribution with all values equally likely, as discussed in the Working with Distributions section, below.
 
 A single integer argument generates a vector of that length.


### PR DESCRIPTION
As requested by @depial in [PR #931](https://github.com/exercism/julia/pull/931), this update synchronizes the content between `about.md` and `introduction.md` in the [Randomness concept](https://github.com/exercism/julia/tree/main/concepts/randomness), and `introduction.md` and `instructions.md` in the [Captain's Log exercise](https://github.com/exercism/julia/tree/main/exercises/concept/captains-log).

Basically, it ensures that the possibility of 0 being an outcome of `rand()` is always mentioned.