### PR TITLE
Editor tab

### DIFF
--- a/exercises/concept/cater-waiter/.meta/config.json
+++ b/exercises/concept/cater-waiter/.meta/config.json
@@ -12,7 +12,7 @@
     "exemplar": [
       ".meta/exemplar.jl"
     ],
-    "editor": [
+    "auxiliary": [
       "sets_categories_data.jl"
     ]
   },

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -13,7 +13,7 @@
     "example": [
       ".meta/example.jl"
     ],
-    "editor": [
+    "auxiliary": [
       "permutations.jl"
     ]
   },

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -13,7 +13,7 @@
     "example": [
       ".meta/example.jl"
     ],
-    "auxiliary": [
+    "editor": [
       "permutations.jl"
     ]
   },

--- a/exercises/practice/alphametics/permutations.jl
+++ b/exercises/practice/alphametics/permutations.jl
@@ -1,8 +1,7 @@
 # Extract of Combinatorics.jl
 #
 # You may (or may not!) want to call the function `permutations(a, t)` in your
-# solution. If you would like to use it, include this file with
-# `include("permutations.jl")`.
+# solution.
 #
 # License:
 #

--- a/runtestrunner.jl
+++ b/runtestrunner.jl
@@ -25,8 +25,8 @@ eachexercise(ARGS) do exercise, exercise_type, exercise_path, example_path
     cp(example_path, joinpath(tmp, solution_file))
 
     # Copy auxiliary files to temporary directory
-    if haskey(meta_cfg["files"], "editor")
-        for aux_file in meta_cfg["files"]["editor"]
+    if haskey(meta_cfg["files"], "auxiliary")
+        for aux_file in meta_cfg["files"]["auxiliary"]
             cp(joinpath(exercise_path, aux_file), joinpath(tmp, aux_file))
         end
     end

--- a/runtests.jl
+++ b/runtests.jl
@@ -40,8 +40,8 @@ include("eachexercise.jl")
             # so we define our own.
             @eval m include(s) = Base.include($m, $example_path)
             running_in_gha || @info "[$(uppercase(exercise_type))] Testing $exercise"
-            if haskey(cfg["files"], "editor")
-                for aux_file in cfg["files"]["editor"]
+            if haskey(cfg["files"], "auxiliary")
+                for aux_file in cfg["files"]["auxiliary"]
                     Base.include(m, joinpath(exercise_path, aux_file))
                 end
             end


### PR DESCRIPTION
Attempts to provide a new field `"auxiliary"` in `config.json` for `cater-waiter` to prevent `sets_categories_data.jl` being shown in a separate tab in the online editor.