### PR TITLE
deprecate minesweeper, add practice exercise flower-field

### DIFF
--- a/config.json
+++ b/config.json
@@ -913,9 +913,9 @@
         ]
       },
       {
-        "slug": "minesweeper",
-        "name": "Minesweeper",
-        "uuid": "9a47bffd-4dd2-48ce-b47b-753271305966",
+        "slug": "flower-field",
+        "name": "Flower Field",
+        "uuid": "3115d01d-8ca0-484d-a6f4-8c85da234b0e",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -930,6 +930,15 @@
           "arrays",
           "text_formatting"
         ]
+      },
+      {
+        "slug": "minesweeper",
+        "name": "Minesweeper",
+        "uuid": "9a47bffd-4dd2-48ce-b47b-753271305966",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "status": "deprecated"
       },
       {
         "slug": "collatz-conjecture",

--- a/exercises/practice/flower-field/.docs/instructions.md
+++ b/exercises/practice/flower-field/.docs/instructions.md
@@ -1,0 +1,26 @@
+# Instructions
+
+Your task is to add flower counts to empty squares in a completed Flower Field garden.
+The garden itself is a rectangle board composed of squares that are either empty (`' '`) or a flower (`'*'`).
+
+For each empty square, count the number of flowers adjacent to it (horizontally, vertically, diagonally).
+If the empty square has no adjacent flowers, leave it empty.
+Otherwise replace it with the count of adjacent flowers.
+
+For example, you may receive a 5 x 4 board like this (empty spaces are represented here with the '·' character for display on screen):
+
+```text
+·*·*·
+··*··
+··*··
+·····
+```
+
+Which your code should transform into this:
+
+```text
+1*3*1
+13*31
+·2*2·
+·111·
+```

--- a/exercises/practice/flower-field/.docs/introduction.md
+++ b/exercises/practice/flower-field/.docs/introduction.md
@@ -1,0 +1,7 @@
+# Introduction
+
+[Flower Field][history] is a compassionate reimagining of the popular game Minesweeper.
+The object of the game is to find all the flowers in the garden using numeric hints that indicate how many flowers are directly adjacent (horizontally, vertically, diagonally) to a square.
+"Flower Field" shipped in regional versions of Microsoft Windows in Italy, Germany, South Korea, Japan and Taiwan.
+
+[history]: https://web.archive.org/web/20020409051321fw_/http://rcm.usr.dsi.unimi.it/rcmweb/fnm/

--- a/exercises/practice/flower-field/.meta/config.json
+++ b/exercises/practice/flower-field/.meta/config.json
@@ -1,0 +1,21 @@
+{
+  "authors": [
+    "habere-et-dispertire"
+  ],
+  "contributors": [
+    "Isaccg",
+    "kotp"
+  ],
+  "files": {
+    "solution": [
+      "flower-field.jl"
+    ],
+    "test": [
+      "runtests.jl"
+    ],
+    "example": [
+      ".meta/example.jl"
+    ]
+  },
+  "blurb": "Mark all the flowers in a garden."
+}

--- a/exercises/practice/flower-field/.meta/example.jl
+++ b/exercises/practice/flower-field/.meta/example.jl
@@ -1,7 +1,7 @@
 # function to check if the current character represents a flower or not
 isflower(ch) = (ch == '*' ? 1 : 0)
 
-function annotate(garden)
+function annotate(flowerfield)
 
     # ans will store our final output of the program
     ans = []

--- a/exercises/practice/flower-field/.meta/example.jl
+++ b/exercises/practice/flower-field/.meta/example.jl
@@ -1,0 +1,51 @@
+# function to check if the current character represents a flower or not
+isflower(ch) = (ch == '*' ? 1 : 0)
+
+function annotate(garden)
+
+    # ans will store our final output of the program
+    ans = []
+
+    # i represents row number
+    for i in 1 : length(flowerfield)
+
+        # ans_row string will be an element of our ans
+        ans_row = ""
+
+        # j represents column number
+        for j in 1 : length(flowerfield[i])
+
+            # check if it is a flower or not
+            if flowerfield[i][j] != '*'
+
+                # calculate the boundary indices of neighbourhood
+                r1 = max(1, i - 1)
+                r2 = min(i + 1, length(flowerfield))
+                c1 = max(1, j - 1)
+                c2 = min(j + 1, length(flowerfield[i]))
+
+                # count will store the number of flowers in the neighbourhood
+                count = 0
+                for x in r1:r2, y in c1:c2
+                    count += isflower(flowerfield[x][y])
+                end
+
+                # append space char if no flower is found else append count
+                if count == 0
+                    ans_row *= ' '
+                else
+                    ans_row *= string(count)
+                end
+
+            # if current cell represents flower then append it
+            else
+                ans_row *= '*'
+            end
+        end
+
+        # push the calculated row_string to our ans
+        push!(ans, ans_row)
+    end
+
+    return ans
+end

--- a/exercises/practice/flower-field/.meta/tests.toml
+++ b/exercises/practice/flower-field/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[237ff487-467a-47e1-9b01-8a891844f86c]
+description = "no rows"
+
+[4b4134ec-e20f-439c-a295-664c38950ba1]
+description = "no columns"
+
+[d774d054-bbad-4867-88ae-069cbd1c4f92]
+description = "no flowers"
+
+[225176a0-725e-43cd-aa13-9dced501f16e]
+description = "garden full of flowers"
+
+[3f345495-f1a5-4132-8411-74bd7ca08c49]
+description = "flower surrounded by spaces"
+
+[6cb04070-4199-4ef7-a6fa-92f68c660fca]
+description = "space surrounded by flowers"
+
+[272d2306-9f62-44fe-8ab5-6b0f43a26338]
+description = "horizontal line"
+
+[c6f0a4b2-58d0-4bf6-ad8d-ccf4144f1f8e]
+description = "horizontal line, flowers at edges"
+
+[a54e84b7-3b25-44a8-b8cf-1753c8bb4cf5]
+description = "vertical line"
+
+[b40f42f5-dec5-4abc-b167-3f08195189c1]
+description = "vertical line, flowers at edges"
+
+[58674965-7b42-4818-b930-0215062d543c]
+description = "cross"
+
+[dd9d4ca8-9e68-4f78-a677-a2a70fd7a7b8]
+description = "large garden"

--- a/exercises/practice/flower-field/runtests.jl
+++ b/exercises/practice/flower-field/runtests.jl
@@ -1,0 +1,123 @@
+using Test
+
+include("flower-field.jl")
+
+@testset verbose = true "tests" begin
+    @testset "no rows" begin
+        @test annotate([]) == []
+    end
+
+    @testset "no columns" begin
+        @test annotate([""]) == [""]
+    end
+
+    @testset "no flowers" begin
+        flowerfield = ["   ",
+                       "   ",
+                       "   "]
+        out = ["   ",
+               "   ",
+               "   "]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "garden full of flowers" begin
+        flowerfield = ["***",
+                       "***",
+                       "***"]
+        out = ["***",
+               "***",
+               "***"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "flower surrounded by spaces" begin
+        flowerfield = ["   ",
+                       " * ",
+                       "   "]
+        out = ["111",
+               "1*1",
+               "111"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "space surrounded by flowers" begin
+        flowerfield = ["***",
+                       "* *",
+                       "***"]
+        out = ["***",
+               "*8*",
+               "***"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "horizontal line" begin
+        flowerfield = [" * * "]
+        out = ["1*2*1"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "horizontal line, flowers at edges" begin
+        flowerfield = ["*   *"]
+        out = ["*1 1*"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "vertical line" begin
+        flowerfield = [" ",
+                       "*",
+                       " ",
+                       "*",
+                       " "]
+        out = ["1",
+               "*",
+               "2",
+               "*",
+               "1"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "vertical line, flowers at edges" begin
+        flowerfield = ["*",
+                       " ",
+                       " ",
+                       " ",
+                       "*"]
+        out = ["*",
+               "1",
+               " ",
+               "1",
+               "*"]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "cross" begin
+        flowerfield = ["  *  ",
+                       "  *  ",
+                       "*****",
+                       "  *  ",
+                       "  *  "]
+        out = [" 2*2 ",
+               "25*52",
+               "*****",
+               "25*52",
+               " 2*2 "]
+        @test annotate(flowerfield) == out
+    end
+
+    @testset "large garden" begin
+        flowerfield = [" *  * ",
+                       "  *   ",
+                       "    * ",
+                       "   * *",
+                       " *  * ",
+                       "      "]
+        out = ["1*22*1",
+               "12*322",
+               " 123*2",
+               "112*4*",
+               "1*22*2",
+               "111111"]
+        @test annotate(flowerfield) == out
+    end
+end


### PR DESCRIPTION
Deprecates the practice exercise `minesweeper` and replaces it with the practice exercise `flower-field` as per Issue #971 

- `minesweeper` files have been copied over, with all mention of mines being removed.
- Slight updates to the test names have been made to align with `problem-specifications`