### PR TITLE
add concept exercise boutique-suggestions

### DIFF
--- a/config.json
+++ b/config.json
@@ -388,7 +388,8 @@
         ],
         "prerequisites": [
           "pairs-and-dicts"
-        ]
+        ],
+        "status": "beta"
       },
       {
         "slug": "old-elyses-enchantments",

--- a/config.json
+++ b/config.json
@@ -381,7 +381,7 @@
       },
       {
         "slug": "boutique-suggestions",
-        "name": "boutique-suggestions",
+        "name": "Boutique Suggestions",
         "uuid": "e8019ab1-f82a-4fd2-bcc3-b72c460a4db2",
         "concepts": [
           "comprehensions"

--- a/config.json
+++ b/config.json
@@ -387,9 +387,10 @@
           "comprehensions"
         ],
         "prerequisites": [
-          "pairs-and-dicts"
+          "pairs-and-dicts",
+          "multi-dimensional-arrays"
         ],
-        "status": "beta"
+        "status": "wip"
       },
       {
         "slug": "old-elyses-enchantments",

--- a/config.json
+++ b/config.json
@@ -380,6 +380,17 @@
         "status": "beta"
       },
       {
+        "slug": "boutique-suggestions",
+        "name": "boutique-suggestions",
+        "uuid": "e8019ab1-f82a-4fd2-bcc3-b72c460a4db2",
+        "concepts": [
+          "comprehensions"
+        ],
+        "prerequisites": [
+          "pairs-and-dicts"
+        ]
+      },
+      {
         "slug": "old-elyses-enchantments",
         "name": "Old Elyse's Enchantments",
         "uuid": "234466a0-08ce-45a1-aebc-5ec0b0cde24f",

--- a/exercises/concept/boutique-suggestions/.docs/hints.md
+++ b/exercises/concept/boutique-suggestions/.docs/hints.md
@@ -1,0 +1,25 @@
+# Hints
+
+## 1. Create clothing item
+
+- Some functions can be used with the comprehension syntax to construct them.
+- `Dict` is just such a function, review **Generator expressions** in the introduction.
+- The category at index `i` matches with the quality at index `i`
+
+## 2. Suggest combinations
+
+- There is a succint syntax for creating multidimensional arrays from a comprehension.
+- Review **Multi-variable, multi-dimensional output** in the introduction
+- Make sure the order of your iterators (`tops` / `bottoms`) is correct.
+
+## 3. Add up outfit prices
+
+- You will have to access the price from both pieces of clothing and add them together.
+- Make sure that the output array shape is the same as the input array shape.
+- Review **Single variable** in the introduction.
+
+## 4. Filter out clashing outfits
+
+- You will need to compare the `base_color` from both pieces of clothing and discard the outfits that have the same `base_color`.
+- With `Matrix` input, make sure your output is in the most efficient order (i.e. column major).
+- Review **Single variable** in the introduction.

--- a/exercises/concept/boutique-suggestions/.docs/hints.md
+++ b/exercises/concept/boutique-suggestions/.docs/hints.md
@@ -4,7 +4,7 @@
 
 - Some functions can be used with the comprehension syntax to construct them.
 - `Dict` is just such a function, review **Generator expressions** in the introduction.
-- The category at index `i` matches with the quality at index `i`
+- The category at index `i` matches with the quality at index `i` ([eachindex()][index] may be useful)
 
 ## 2. Suggest combinations
 
@@ -23,3 +23,5 @@
 - You will need to compare the `base_color` from both pieces of clothing and discard the outfits that have the same `base_color`.
 - With `Matrix` input, make sure your output is in the most efficient order (i.e. column major).
 - Review **Single variable** in the introduction.
+
+[index]: https://docs.julialang.org/en/v1/base/arrays/#Base.eachindex

--- a/exercises/concept/boutique-suggestions/.docs/instructions.md
+++ b/exercises/concept/boutique-suggestions/.docs/instructions.md
@@ -1,0 +1,112 @@
+# Instructions
+
+You work at an online fashion boutique store. 
+You come up with the idea for a website feature where outfits are suggested to the user.
+Of interest are the potential outfits, their prices and eliminating clashing options.
+
+~~~~exercism/note
+While there may be different ways to solve the following problems, all can be solved with a comprehension.
+~~~~
+
+## 1. Create clothing item
+
+
+Implement `clothingitem()` to take two `Tuple`s, one of `categories` and the other of their respective `qualities`.
+The function should return a `Dict` with the `categories` as keys and `qualities` as values.
+
+```julia-repl
+julia> categories = ("item_name", "price", "color", "base_color");
+
+julia> qualities = ("Descriptive Name", 99.00, "Ochre Red", "red");
+
+julia> clothingitem(categories, qualities)
+Dict{String, Any} with 4 entries:
+  "price"      => 99.0
+  "item_name"  => "Descriptive Name"
+  "base_color" => "red"
+  "color"      => "Ochre Red"
+```
+
+Your function should be able to handle any number of `categories`.
+
+## 2. Suggest combinations
+
+Implement `get_combinations()` to take a `Tuple` of tops and a `Tuple` of bottoms.
+The function should return the `cartesian product` of the tuples as a 2-D array (i.e. `Matrix`).
+Each entry is a `(top, bottom)` combination as a `Tuple`.
+Tops change down the rows, bottoms change across the columns.
+
+```julia-repl
+julia> tops = (
+        Dict("item_name" => "Dress shirt"),
+        Dict("item_name" => "Casual shirt")
+        );
+
+julia> bottoms = (
+        Dict("item_name" => "Jeans"),
+        Dict("item_name" => "Dress trousers")
+       );
+
+julia> get_combinations(tops, bottoms)
+2×2 Matrix{Tuple{Dict{String, String}, Dict{String, String}}}:
+ (Dict("item_name"=>"Dress shirt"), Dict("item_name"=>"Jeans"))   (Dict("item_name"=>"Dress shirt"), Dict("item_name"=>"Dress trousers"))
+ (Dict("item_name"=>"Casual shirt"), Dict("item_name"=>"Jeans"))  (Dict("item_name"=>"Casual shirt"), Dict("item_name"=>"Dress trousers"))
+```
+
+## 3. Add up outfit prices
+
+Each piece of clothing has a `price` field associated with it, so it could be helpful to be able to compare the full price of outfits.
+Implement `get_prices()` which takes an array of clothing combinations.
+The function should return a similarly shaped array with the prices of the outfits in their respective positions.
+
+```julia-repl
+julia> tops = (
+        Dict("item_name" => "Dress shirt", "base_color" => "blue", "price" => 35),
+        Dict("item_name" => "Casual shirt", "base_color" => "black", "price" => 20)
+       );
+
+julia> bottoms = (
+        Dict("item_name" => "Jeans", "base_color" => "blue", "price" => 30),
+        Dict("item_name" => "Dress trousers", "base_color" => "black", "price" => 75)
+       );
+
+julia> combomatrix = get_combinations(tops, bottoms);
+
+julia> get_prices(combomatrix)
+2×2 Matrix{Int}::
+ 65  110
+ 50   95
+
+julia> filteredmatrix = filter_clashing(combomatrix)
+1-element Vector{Tuple{Dict{String, Any}, Dict{String, Any}}}:
+ (Dict("price" => 20, "item_name" => "Casual shirt", "base_color" => "black"), Dict("price" => 30, "item_name" => "Jeans", "base_color" => "blue"))
+
+julia> get_prices(filteredmatrix)
+1-element Vector{Int}:
+ 50
+```
+
+## 4. Filter out clashing outfits
+
+Each piece of clothing has a `base_color` field.
+Use this field to remove all combinations where the top and the bottom have the same base color.
+Implement `filter_clashing()` to take an array of clothing combinations.
+Return a 1-D array (i.e. `Vector`) of the matching combinations.
+
+```julia-repl
+julia> tops = (
+        Dict("item_name" => "Dress shirt", "base_color" => "blue", "price" => 35),
+        Dict("item_name" => "Casual shirt", "base_color" => "black", "price" => 20)
+       );
+
+julia> bottoms = (
+        Dict("item_name" => "Jeans", "base_color" => "blue", "price" => 30),
+        Dict("item_name" => "Dress trousers", "base_color" => "black", "price" => 75)
+       );
+
+julia> combos = get_combinations(tops, bottoms);
+
+julia> filter_clashing(combos)
+1-element Vector{Tuple{Dict{String, Any}, Dict{String, Any}}}:
+ (Dict("price" => 20, "item_name" => "Casual shirt", "base_color" => "black"), Dict("price" => 30, "item_name" => "Jeans", "base_color" => "blue"))
+```

--- a/exercises/concept/boutique-suggestions/.docs/introduction.md
+++ b/exercises/concept/boutique-suggestions/.docs/introduction.md
@@ -1,0 +1,158 @@
+# Introduction
+
+Anyone who has used Python has almost certainly used list comprehensions, which have been central to Python syntax since early versions.
+
+Something so convenient gradually finds its way into other languages, including Julia.
+
+Comprehensions are an option rather than a necessity for Julia programmers, as there are usually alternatives (broadcasting, higher-order functions, etc).
+
+However, a comprehension will often provide a simple, readable and performant way to construct an array.
+Use is ultimately a matter of personal taste, and how you feel about Python versus functional languages.
+
+The syntax is mostly a direct copy of Python, but with extensions for higher-dimensional arrays.
+
+## Single variable
+
+Very Pythonic, including the optional `if` clause.
+
+```julia-repl
+julia> [x^2 for x in 1:3]
+3-element Vector{Int64}:
+ 1
+ 4
+ 9
+julia> [x^2 for x in 1:3 if isodd(x^2)]
+2-element Vector{Int64}:
+ 1
+ 9
+```
+
+Output shape depends on the details of the comprehension: typically the same as the input collection in simple cases, but flattened to a Vector by an `if` clause.
+
+```julia-repl
+julia> m
+2×3 Matrix{Int64}:
+ 1  2  3
+ 4  5  6
+julia> [x^2 for x in m]
+2×3 Matrix{Int64}:
+  1   4   9
+ 16  25  36
+julia> [x^2 for x in m if isodd(x^2)] 
+3-element Vector{Int64}:
+  1
+ 25
+  9
+```
+
+## Multi-variable, Vector output
+
+Like Python, we can have multiple `for` clauses with different variables, with the same or different input collections.
+
+```julia-repl
+julia> [x * y for x in 1:3 for y in 4:6]
+9-element Vector{Int64}:
+  4
+  5
+  6
+  8
+ 10
+ 12
+ 12
+ 15
+ 18
+julia> [x * y for x in 1:3 for y in 4:6 if isodd(x * y)]
+2-element Vector{Int64}:
+  5
+ 15
+```
+
+This is equivalent to nested loops.
+The output is one-dimensional, even with matrix input.
+
+```julia-repl
+julia> m
+2×3 Matrix{Int64}:
+ 1  2  3
+ 4  5  6
+julia> [x*y for x in m for y in m]
+36-element Vector{Int64}:
+  1
+  4
+  2
+  5
+(truncated output...)
+```
+
+## Multi-variable, multi-dimensional output
+
+The previous section described multiple `for` clauses separated only by spaces.
+
+In this section, there is a single `for` and the variables are comma-separated.
+
+```julia-repl
+julia> [(x, y) for x in 1:3, y in 4:6]
+3×3 Matrix{Tuple{Int64, Int64}}:
+ (1, 4)  (1, 5)  (1, 6)
+ (2, 4)  (2, 5)  (2, 6)
+ (3, 4)  (3, 5)  (3, 6)
+```
+
+Each variable in the comprehension creates a new dimension in the output, with an entry for each possible combination of the variables.
+
+In the example above, `x` increases down the rows, `y` increases across the columns.
+Higher dimensions are possible, with the usual warnings about readability of the output.
+
+## Generator expressions
+
+The previous sections have concentrated on array output, with the comprehension placed inside brackets `[ ... ]`.
+
+When the brackets are replaced by parentheses `( ... )` something different happens: we get a `generator expression`: a lazily-evaluated iterator which can yield the next value on demand.
+
+```julia-repl
+julia> g = ((x, y) for x in 1:3, y in 4:6)
+Base.Generator{Base.Iterators.ProductIterator{Tuple{UnitRange{Int64}, UnitRange{Int64}}}, var"#9#10"}(var"#9#10"(), Base.Iterators.ProductIterator{Tuple{UnitRange{Int64}, UnitRange{Int64}}}((1:3, 4:6)))
+# Indexing fails with a generator, the entries don't exist yet
+julia> g[1, 2]
+ERROR: MethodError: no method matching getindex(::Base.Generator{Base.Iterators.ProductIterator{Tuple{UnitRange{…}, UnitRange{…}}}, var"#9#10"}, ::Int64, ::Int64)
+# conversion to array
+julia> collect(g)
+3×3 Matrix{Tuple{Int64, Int64}}:
+ (1, 4)  (1, 5)  (1, 6)
+ (2, 4)  (2, 5)  (2, 6)
+ (3, 4)  (3, 5)  (3, 6)
+# generators are mainly designed for iteration
+julia> [i * j for (i, j) in g]
+3×3 Matrix{Int64}:
+  4   5   6
+  8  10  12
+ 12  15  18
+```
+
+When the result of a comprehension is immediately used for further processing, a generator can be memory-efficient, avoiding the need to store a large intermediate array.
+
+A generator used as a function argument does not need additional parentheses.
+
+```julia-repl
+# inefficient
+julia> v = [x^2 for x in 1:1e6];
+julia> sum(v)
+3.333338333335e17
+# better - use a generator
+julia> sum(x^2 for x in 1:1e6)
+3.3333383333312755e17
+```
+
+Generator syntax is identical to comprehensions, other than the surrounding brackets.
+
+Generators can also be convenient in dictionary constructors.
+
+```julia-repl
+julia> Dict(x => x^2 for x in 1:5)
+Dict{Int64, Int64} with 5 entries:
+  5 => 25
+  4 => 16
+  2 => 4
+  3 => 9
+  1 => 1
+```

--- a/exercises/concept/boutique-suggestions/.meta/config.json
+++ b/exercises/concept/boutique-suggestions/.meta/config.json
@@ -1,0 +1,23 @@
+{
+  "authors": [
+    "colinleach"
+  ],
+  "files": {
+    "solution": [
+      "boutique-suggestions.jl"
+    ],
+    "test": [
+      "runtests.jl"
+    ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
+    "auxiliary": [
+      "testtools.jl"
+    ]
+  },
+  "forked_from": [
+    "elixir/boutique-suggestions"
+  ],
+  "blurb": "Learn about comprehensions by generating outfit suggestions for the clients of your fashion boutique."
+}

--- a/exercises/concept/boutique-suggestions/.meta/config.json
+++ b/exercises/concept/boutique-suggestions/.meta/config.json
@@ -11,9 +11,6 @@
     ],
     "exemplar": [
       ".meta/exemplar.jl"
-    ],
-    "auxiliary": [
-      "testtools.jl"
     ]
   },
   "forked_from": [

--- a/exercises/concept/boutique-suggestions/.meta/design.md
+++ b/exercises/concept/boutique-suggestions/.meta/design.md
@@ -1,0 +1,26 @@
+# Design
+
+## Goal
+
+The goal of this exercise is to introduce the student to comprehensions in Julia.
+
+## Learning objectives
+
+- Understand comprehensions in functions.
+- Understand comprehensions with multidimensional array output.
+- Understand comprehensions with simple functions in the body.
+- Understand comprehensions as filters.
+
+## Out of scope
+
+- generators with comprehension syntax
+
+## Concepts
+
+The Concepts this exercise unlocks are:
+
+- none
+
+## Prerequisites
+
+- `pairs-and-dicts`

--- a/exercises/concept/boutique-suggestions/.meta/exemplar.jl
+++ b/exercises/concept/boutique-suggestions/.meta/exemplar.jl
@@ -1,0 +1,15 @@
+function clothingitem(categories, qualities)
+    Dict(categories[i] => qualities[i] for i in eachindex(categories))
+end
+
+function get_combinations(tops, bottoms)
+    [(top, bottom) for top in tops, bottom in bottoms]
+end
+
+function get_prices(combos)
+    [first(combo)["price"] + last(combo)["price"] for combo in combos]
+end
+
+function filter_clashing(combos)
+    [combo for combo in combos if first(combo)["base_color"] ≠ last(combo)["base_color"]]
+end

--- a/exercises/concept/boutique-suggestions/boutique-suggestions.jl
+++ b/exercises/concept/boutique-suggestions/boutique-suggestions.jl
@@ -1,0 +1,15 @@
+function clothingitem(categories, qualities)
+
+end
+
+function get_combinations(tops, bottoms)
+
+end
+
+function get_prices(combos)
+    
+end
+
+function filter_clashing(combos)
+
+end

--- a/exercises/concept/boutique-suggestions/runtests.jl
+++ b/exercises/concept/boutique-suggestions/runtests.jl
@@ -1,0 +1,165 @@
+using Test
+
+include("boutique-suggestions.jl")
+include("testtools.jl")
+
+@testset verbose = true "tests" begin
+    @testset "Create clothing item" begin
+        @testset "Creates an item with canonical categories" begin
+            categories = ("item_name", "price", "color", "base_color")
+            qualities = ("Long Sleeve T-shirt", 19.95, "Deep Red", "red")
+            expected = testitem(categories, qualities)
+            @test clothingitem(categories, qualities) == expected
+        end
+
+        @testset "Creates an item without canonical categories" begin
+            categories = ("item_name",)
+            qualities = ("Long Sleeve T-shirt",)
+            expected = Dict("item_name" => "Long Sleeve T-shirt")
+            @test clothingitem(categories, qualities) == expected
+        end
+    end
+    
+    @testset "Suggest combinations" begin
+        @testset "Generates one pair from one top and one bottom" begin
+            categories = ("item_name", "price", "color", "base_color")
+
+            topquals = ("Long Sleeve T-shirt", 19.95, "Deep Red", "red")
+            botquals = ("Wonderwall Pants", 48.97, "French Navy", "blue")
+            top = testitem(categories, topquals)
+            bottom = testitem(categories, botquals)
+
+            @test get_combinations((top,), (bottom,)) == [(top, bottom);;]
+        end
+
+        @testset "Generates nine pairs from three tops and three bottoms" begin
+            categories = ("item_name", "price", "color", "base_color")
+
+            top1quals = ("Long Sleeve T-shirt", 19.95, "Deep Red", "red")
+            top2quals = ("Brushwood Shirt", 19.10, "Camel-Sandstone Woodland Plaid", "brown")
+            top3quals = ("Sano Long Sleeve Shirt", 45.47, "Linen Chambray", "yellow")
+            top1 = testitem(categories, top1quals)
+            top2 = testitem(categories, top2quals)
+            top3 = testitem(categories, top3quals)
+
+            bot1quals = ("Wonderwall Pants", 48.97, "French Navy", "blue")
+            bot2quals = ("Terrena Stretch Pants", 79.95, "Cast Iron", "grey")
+            bot3quals = ("Happy Hike Studio Pants", 99.00, "Ochre Red", "red")
+            bottom1 = testitem(categories, bot1quals)
+            bottom2 = testitem(categories, bot2quals)
+            bottom3 = testitem(categories, bot3quals)
+
+            tops = (top1, top2, top3)
+            bottoms = (bottom1, bottom2, bottom3)
+            expected = [(top1, bottom1) (top1, bottom2) (top1, bottom3) 
+                        (top2, bottom1) (top2, bottom2) (top2, bottom3)
+                        (top3, bottom1) (top3, bottom2) (top3, bottom3)]
+            @test get_combinations(tops, bottoms) == expected
+       end
+    end
+
+    @testset "Add up outfit prices" begin
+        @testset "Returns a Vector for Vector input" begin
+            categories = ("item_name", "price", "color", "base_color")
+
+            top1quals = ("Long Sleeve T-shirt", 19, "Deep Red", "red")
+            top2quals = ("Brushwood Shirt", 21, "Camel-Sandstone Woodland Plaid", "brown")
+            top1 = testitem(categories, top1quals)
+            top2 = testitem(categories, top2quals)
+
+            bot1quals = ("Wonderwall Pants", 48, "French Navy", "blue")
+            bot2quals = ("Terrena Stretch Pants", 79, "Cast Iron", "grey")
+            bottom1 = testitem(categories, bot1quals)
+            bottom2 = testitem(categories, bot2quals)
+
+            combos = [(top1, bottom1), (top1, bottom2), (top2, bottom1), (top2, bottom2)]
+            expected = [67, 98, 69, 100]
+            @test get_prices(combos) == expected
+        end
+
+        @testset "Returns a Matrix for Matrix input" begin
+            categories = ("item_name", "price", "color", "base_color")
+
+            top1quals = ("Long Sleeve T-shirt", 19, "Deep Red", "red")
+            top2quals = ("Brushwood Shirt", 21, "Camel-Sandstone Woodland Plaid", "brown")
+            top1 = testitem(categories, top1quals)
+            top2 = testitem(categories, top2quals)
+
+            bot1quals = ("Wonderwall Pants", 48, "French Navy", "blue")
+            bot2quals = ("Terrena Stretch Pants", 79, "Cast Iron", "grey")
+            bottom1 = testitem(categories, bot1quals)
+            bottom2 = testitem(categories, bot2quals)
+
+            combos = [(top1, bottom1) (top1, bottom2) 
+                      (top2, bottom1) (top2, bottom2)]
+            expected = [67 98
+                        69 100]
+            @test get_prices(combos) == expected
+       end
+    end
+
+    @testset "Filter out clashing outfits" begin
+        @testset "Filters suggestions that 'clash'" begin
+            categories = ("item_name", "price", "color", "base_color")
+            topqualities = ("Long Sleeve T-shirt", 19.95, "Deep Red", "red")
+            bottomqualities = ("Happy Hike Studio Pants", 19.00, "Ochre Red", "red")
+            top = testitem(categories, topqualities)
+            bottom = testitem(categories, bottomqualities)
+            
+            combos = get_combinations((top,), (bottom,))
+            @test filter_clashing(combos) == []
+        end
+
+        @testset "Flattens a matrix with clashing outfits" begin
+            categories = ("item_name", "price", "color", "base_color")
+
+            top1quals = ("Long Sleeve T-shirt", 19.95, "Deep Red", "red")
+            top2quals = ("Brushwood Shirt", 19.10, "Camel-Sandstone Woodland Plaid", "brown")
+            top3quals = ("Sano Long Sleeve Shirt", 45.47, "Linen Chambray", "yellow")
+            top1 = testitem(categories, top1quals)
+            top2 = testitem(categories, top2quals)
+            top3 = testitem(categories, top3quals)
+
+            bot1quals = ("Wonderwall Pants", 48.97, "French Navy", "blue")
+            bot2quals = ("Terrena Stretch Pants", 79.95, "Cast Iron", "grey")
+            bot3quals = ("Happy Hike Studio Pants", 99.00, "Ochre Red", "red")
+            bottom1 = testitem(categories, bot1quals)
+            bottom2 = testitem(categories, bot2quals)
+            bottom3 = testitem(categories, bot3quals)
+
+            combos = [(top1, bottom1) (top1, bottom2) (top1, bottom3) 
+                      (top2, bottom1) (top2, bottom2) (top2, bottom3)
+                      (top3, bottom1) (top3, bottom2) (top3, bottom3)]
+            expected = [(top1, bottom1), (top2, bottom1), (top3, bottom1),
+                        (top1, bottom2), (top2, bottom2), (top3, bottom2),
+                                         (top2, bottom3), (top3, bottom3)]
+            @test filter_clashing(combos) == expected
+        end
+
+        @testset "Flattens a matrix without clashing outfits" begin
+            categories = ("item_name", "price", "color", "base_color")
+
+            top1quals = ("Long Sleeve T-shirt", 19.95, "Deep Red", "red")
+            top2quals = ("Brushwood Shirt", 19.10, "Camel-Sandstone Woodland Plaid", "brown")
+            top3quals = ("Sano Long Sleeve Shirt", 45.47, "Linen Chambray", "yellow")
+            top1 = testitem(categories, top1quals)
+            top2 = testitem(categories, top2quals)
+            top3 = testitem(categories, top3quals)
+
+            bot1quals = ("Wonderwall Pants", 48.97, "French Navy", "blue")
+            bot2quals = ("Terrena Stretch Pants", 79.95, "Cast Iron", "grey")
+            bot3quals = ("Happy Hike Studio Pants", 99.00, "Ochre Red", "pink")
+            bottom1 = testitem(categories, bot1quals)
+            bottom2 = testitem(categories, bot2quals)
+            bottom3 = testitem(categories, bot3quals)
+
+            combos = [(top1, bottom1) (top1, bottom2) (top1, bottom3) 
+                      (top2, bottom1) (top2, bottom2) (top2, bottom3)
+                      (top3, bottom1) (top3, bottom2) (top3, bottom3)]
+            expected = [(top1, bottom1), (top2, bottom1), (top3, bottom1),
+                        (top1, bottom2), (top2, bottom2), (top3, bottom2),
+                        (top1, bottom3), (top2, bottom3), (top3, bottom3)]
+            @test filter_clashing(combos) == expected
+       end
+    end
+end

--- a/exercises/concept/boutique-suggestions/runtests.jl
+++ b/exercises/concept/boutique-suggestions/runtests.jl
@@ -1,7 +1,6 @@
 using Test
 
 include("boutique-suggestions.jl")
-include("testtools.jl")
 
 @testset verbose = true "tests" begin
     testitem = Dict ∘ zip

--- a/exercises/concept/boutique-suggestions/runtests.jl
+++ b/exercises/concept/boutique-suggestions/runtests.jl
@@ -4,6 +4,7 @@ include("boutique-suggestions.jl")
 include("testtools.jl")
 
 @testset verbose = true "tests" begin
+    testitem = Dict ∘ zip
     @testset "Create clothing item" begin
         @testset "Creates an item with canonical categories" begin
             categories = ("item_name", "price", "color", "base_color")

--- a/exercises/concept/boutique-suggestions/testtools.jl
+++ b/exercises/concept/boutique-suggestions/testtools.jl
@@ -1,0 +1,1 @@
+testitem = Dict ∘ zip

--- a/exercises/concept/boutique-suggestions/testtools.jl
+++ b/exercises/concept/boutique-suggestions/testtools.jl
@@ -1,1 +1,0 @@
-testitem = Dict ∘ zip


### PR DESCRIPTION
This is a redesign of `boutique-suggestions` from PR #992. Some notes:

- There are four problems, with all being solvable by different variations of comprehensions (see `exemplar.jl`).
- There are also some added tests to emphasize the column major aspect of Julia (but this will go unnoticed if simple comprehension are used naively).
- Specific concepts from `introduction.md` have been included and referenced in `hints.md`.
- It would be possible to have a final test where all the student's functions are tested in conjunction, but I don't see this as necessary.
- A helper function was used to shorten up `runtests.jl` (and ease modification), but this is not strictly necessary, so explicit `Dict`s can be reintroduced if desired.
- There is an `auxiliary` file used for the helper function, but this might not be necessary since the tests are not student facing in the first place.
- The order of the problems has been shuffled, since this felt a bit more of a natural progression.
- Prereq is set as `pairs-and-dicts` due to the use of `Dict`s.

I have to admit that I didn't take in the push for a single comprehension as a solution in the original `instructions.md`:
> While you want to give lots of suggestions, you don't want to give bad suggestions, so you decide to use a comprehension since you can easily _generate_ outfit combinations, and _filter_ them by some criteria.

I'm not adverse to going with the original idea, since it does give "real world" backing to choosing this option. I also don't mind if we go with the original idea, since the idea here is following somewhat of a template for exercises that I seem to be using, so it might not be bad to step outside of that occasionally to provide some variety. That said, I do feel this version hits is more aligned with the information given in `introduction.md`.

We can go with this one, the other one, or some combination of the two.

All/any feedback is welcome!