### PR TITLE
Update tests for two-bucket

### DIFF
--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -27,6 +27,12 @@ description = "Measure one step using bucket one of size 1 and bucket two of siz
 [eb329c63-5540-4735-b30b-97f7f4df0f84]
 description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
 
+[58d70152-bf2b-46bb-ad54-be58ebe94c03]
+description = "Measure using bucket one much bigger than bucket two"
+
+[9dbe6499-caa5-4a58-b5ce-c988d71b8981]
+description = "Measure using bucket one much smaller than bucket two"
+
 [449be72d-b10a-4f4b-a959-ca741e333b72]
 description = "Not possible to reach the goal"
 

--- a/exercises/practice/two-bucket/runtests.jl
+++ b/exercises/practice/two-bucket/runtests.jl
@@ -27,6 +27,14 @@ include("two-bucket.jl")
         @test twobucket(2, 3, 3, 1) == (2, 2, 2)
     end
 
+    @testset "Measure using bucket one much bigger than bucket two" begin
+        @test twobucket(5, 1, 2, 1) == (6, 1, 1)
+    end
+
+    @testset "Measure using bucket one much smaller than bucket two" begin
+        @test twobucket(3, 15, 9, 1) == (6, 2, 0)
+    end
+
     @testset "Not possible to reach the goal" begin
         @test_throws DomainError twobucket(6, 15, 5, 1) 
     end


### PR DESCRIPTION
Addresses issue #1003.

Probably worth adding `[no important files changed]`, though there are only 23 completions for this exercise.