### PR TITLE
Swift Scheduling practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1384,6 +1384,18 @@
         "difficulty": 4
       },
       {
+        "slug": "swift-scheduling",
+        "name": "Swift Scheduling",
+        "uuid": "16cd6419-2e94-4648-9796-24a245e4f812",
+        "practices": [
+          "dates-times"
+        ],
+        "prerequisites": [
+          "dates-times"
+        ],
+        "difficulty": 4
+      },
+      {
         "slug": "killer-sudoku-helper",
         "name": "Killer Sudoku Helper",
         "uuid": "e0142403-af9e-406e-827a-1fd37187d1ea",

--- a/exercises/practice/swift-scheduling/.docs/hints.md
+++ b/exercises/practice/swift-scheduling/.docs/hints.md
@@ -1,0 +1,25 @@
+# Hints
+
+## General
+
+- Input for `delivery_date()` is two `String` arguments, and the output is a `String`.
+- All date strings are in [ISO 8601][iso] format, Julia's default string representation.
+- Useful documentation for the `Dates` module includes:
+  - The Exercism [Learning Track][dates-times].
+  - The [Julia manual][Dates].
+  - The [Wikibook][Wikibook].
+- At a minimum, you will need familiarity with [DateTime][datetime] constructors and adding or subtracting [Periods][period].
+- Useful functions include [`dayofweek()`][dayofweek] and (optionally) [`lastdayofmonth()`][lastdayofmonth].
+- To extract integers from strings, the [`parse()`][parse] function will be important.
+
+
+[dates-times]: https://exercism.org/tracks/julia/concepts/dates-times
+[iso]: https://en.wikipedia.org/wiki/ISO_8601
+[Dates]: https://docs.julialang.org/en/v1/stdlib/Dates/
+[Wikibook]: https://en.wikibooks.org/wiki/Introducing_Julia/Working_with_dates_and_times
+[period]: https://docs.julialang.org/en/v1/stdlib/Dates/#Period-Types
+[query-func]: https://docs.julialang.org/en/v1/stdlib/Dates/#Query-Functions
+[dayofweek]: https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.dayofweek
+[lastdayofmonth]: https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.lastdayofmonth
+[datetime]: https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime-NTuple{7,%20Int64}
+[parse]: https://docs.julialang.org/en/v1/base/numbers/#Base.parse

--- a/exercises/practice/swift-scheduling/.docs/instructions.md
+++ b/exercises/practice/swift-scheduling/.docs/instructions.md
@@ -1,0 +1,50 @@
+# Instructions
+
+Your task is to convert delivery date descriptions to _actual_ delivery dates, based on when the meeting started.
+
+There are two types of delivery date descriptions:
+
+1. Fixed: a predefined set of words.
+2. Variable: words that have a variable component, but follow a predefined set of patterns.
+
+## Fixed delivery date descriptions
+
+There are three fixed delivery date descriptions:
+
+- `"NOW"`
+- `"ASAP"` (As Soon As Possible)
+- `"EOW"` (End Of Week)
+
+The following table shows how to translate them:
+
+| Description | Meeting start                 | Delivery date                       |
+| ----------- | ----------------------------- | ----------------------------------- |
+| `"NOW"`     | -                             | Two hours after the meeting started |
+| `"ASAP"`    | Before 13:00                  | Today at 17:00                      |
+| `"ASAP"`    | After or at 13:00             | Tomorrow at 13:00                   |
+| `"EOW"`     | Monday, Tuesday, or Wednesday | Friday at 17:00                     |
+| `"EOW"`     | Thursday or Friday            | Sunday at 20:00                     |
+
+## Variable delivery date descriptions
+
+There are two variable delivery date description patterns:
+
+- `"<N>M"` (N-th month)
+- `"Q<N>"` (N-th quarter)
+
+| Description | Meeting start             | Delivery date                                             |
+| ----------- | ------------------------- | --------------------------------------------------------- |
+| `"<N>M"`    | Before N-th month         | At 8:00 on the _first_ workday of this year's N-th month  |
+| `"<N>M"`    | After or in N-th month    | At 8:00 on the _first_ workday of next year's N-th month  |
+| `"Q<N>"`    | Before or in N-th quarter | At 8:00 on the _last_ workday of this year's N-th quarter |
+| `"Q<N>"`    | After N-th quarter        | At 8:00 on the _last_ workday of next year's N-th quarter |
+
+~~~~exercism/note
+A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.
+
+A year has four quarters, each with three months:
+1. January/February/March
+2. April/May/June
+3. July/August/September
+4. October/November/December.
+~~~~

--- a/exercises/practice/swift-scheduling/.docs/introduction.md
+++ b/exercises/practice/swift-scheduling/.docs/introduction.md
@@ -1,0 +1,6 @@
+# Introduction
+
+This week, it is your turn to take notes in the department's planning meeting.
+In this meeting, your boss will set delivery dates for all open work items.
+Annoyingly, instead of specifying the _actual_ delivery dates, your boss will only _describe them_ in an abbreviated format.
+As many of your colleagues won't be familiar with this corporate lingo, you'll need to convert these delivery date descriptions to actual delivery dates.

--- a/exercises/practice/swift-scheduling/.meta/config.json
+++ b/exercises/practice/swift-scheduling/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "colinleach"
+  ],
+  "files": {
+    "solution": [
+      "swift-scheduling.jl"
+    ],
+    "test": [
+      "runtests.jl"
+    ],
+    "example": [
+      ".meta/example.jl"
+    ]
+  },
+  "blurb": "Convert delivery date descriptions to actual delivery dates.",
+  "source": "Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/pull/2536"
+}

--- a/exercises/practice/swift-scheduling/.meta/example.jl
+++ b/exercises/practice/swift-scheduling/.meta/example.jl
@@ -1,0 +1,42 @@
+using Dates
+
+delivery_date(start, description) = "$(delivery_date_time(start, description))"
+
+function delivery_date_time(start, description)
+    start_dt = DateTime(start)
+
+    description == "NOW" && return start_dt + Hour(2)
+
+    if description == "ASAP"
+        start_day = Date(start_dt)
+        return Time(start_dt) < Time(13, 0, 0) ? 
+            DateTime(start_day, Time(17, 0, 0)) :
+            DateTime(start_day + Day(1), Time(13, 0, 0))
+    end
+
+    if description == "EOW"
+        day_of_week = dayofweek(start_dt)
+        return day_of_week ≤ 3 ?
+            DateTime(Date(start_dt + Day(5 - day_of_week)), Time(17, 0, 0)) :
+            DateTime(Date(start_dt + Day(7 - day_of_week)), Time(20, 0, 0))
+    end
+    
+    if endswith(description, "M")
+        m = parse(Int, chop(description))
+        y = month(start_dt) ≥ m ? year(start_dt) + 1 : year(start_dt)
+        target = DateTime(y, m, 1, 8, 0, 0)
+
+        return dayofweek(target) ≤ 5 ? target : target + Day(8 - dayofweek(target))
+    end
+
+    if startswith(description, "Q")
+        q = parse(Int, chop(description, head=1, tail=0))
+        current = (month(start_dt) + 2) ÷ 3
+        m = (3q + 1) % 12
+        rollover = (current > q || q == 4) ? 1 : 0
+
+        due_date = DateTime(year(start_dt) + rollover, m, 1, 8, 0, 0) - Day(1)
+        day_of_week = dayofweek(due_date)
+        day_of_week ≤ 5 ? due_date : due_date - Day(day_of_week - 5)
+    end
+end

--- a/exercises/practice/swift-scheduling/.meta/tests.toml
+++ b/exercises/practice/swift-scheduling/.meta/tests.toml
@@ -1,0 +1,58 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1d0e6e72-f370-408c-bc64-5dafa9c6da73]
+description = "NOW translates to two hours later"
+
+[93325e7b-677d-4d96-b017-2582af879dc2]
+description = "ASAP before one in the afternoon translates to today at five in the afternoon"
+
+[cb4252a3-c4c1-41f6-8b8c-e7269733cef8]
+description = "ASAP at one in the afternoon translates to tomorrow at one in the afternoon"
+
+[6fddc1ea-2fe9-4c60-81f7-9220d2f45537]
+description = "ASAP after one in the afternoon translates to tomorrow at one in the afternoon"
+
+[25f46bf9-6d2a-4e95-8edd-f62dd6bc8a6e]
+description = "EOW on Monday translates to Friday at five in the afternoon"
+
+[0b375df5-d198-489e-acee-fd538a768616]
+description = "EOW on Tuesday translates to Friday at five in the afternoon"
+
+[4afbb881-0b5c-46be-94e1-992cdc2a8ca4]
+description = "EOW on Wednesday translates to Friday at five in the afternoon"
+
+[e1341c2b-5e1b-4702-a95c-a01e8e96e510]
+description = "EOW on Thursday translates to Sunday at eight in the evening"
+
+[bbffccf7-97f7-4244-888d-bdd64348fa2e]
+description = "EOW on Friday translates to Sunday at eight in the evening"
+
+[d651fcf4-290e-407c-8107-36b9076f39b2]
+description = "EOW translates to leap day"
+
+[439bf09f-3a0e-44e7-bad5-b7b6d0c4505a]
+description = "2M before the second month of this year translates to the first workday of the second month of this year"
+
+[86d82e83-c481-4fb4-9264-625de7521340]
+description = "11M in the eleventh month translates to the first workday of the eleventh month of next year"
+
+[0d0b8f6a-1915-46f5-a630-1ff06af9da08]
+description = "4M in the ninth month translates to the first workday of the fourth month of next year"
+
+[06d401e3-8461-438f-afae-8d26aa0289e0]
+description = "Q1 in the first quarter translates to the last workday of the first quarter of this year"
+
+[eebd5f32-b16d-4ecd-91a0-584b0364b7ed]
+description = "Q4 in the second quarter translates to the last workday of the fourth quarter of this year"
+
+[c920886c-44ad-4d34-a156-dc4176186581]
+description = "Q3 in the fourth quarter translates to the last workday of the third quarter of next year"

--- a/exercises/practice/swift-scheduling/runtests.jl
+++ b/exercises/practice/swift-scheduling/runtests.jl
@@ -1,0 +1,70 @@
+using Test
+
+include("swift-scheduling.jl")
+
+@testset verbose = true "tests" begin
+    @testset "NOW translates to two hours later" begin
+        @test delivery_date("2012-02-13T09:00:00", "NOW") ==  "2012-02-13T11:00:00"
+    end
+
+    @testset "ASAP before one in the afternoon translates to today at five in the afternoon" begin
+        @test delivery_date("1999-06-03T09:45:00", "ASAP") ==  "1999-06-03T17:00:00"
+    end
+
+    @testset "ASAP at one in the afternoon translates to tomorrow at one in the afternoon" begin
+        @test delivery_date("2008-12-21T13:00:00", "ASAP") ==  "2008-12-22T13:00:00"
+    end
+
+    @testset "ASAP after one in the afternoon translates to tomorrow at one in the afternoon" begin
+        @test delivery_date("2008-12-21T14:50:00", "ASAP") ==  "2008-12-22T13:00:00"
+    end
+
+    @testset "EOW on Monday translates to Friday at five in the afternoon" begin
+        @test delivery_date("2025-02-03T16:00:00", "EOW") ==  "2025-02-07T17:00:00"
+    end
+
+    @testset "EOW on Tuesday translates to Friday at five in the afternoon" begin
+        @test delivery_date("1997-04-29T10:50:00", "EOW") ==  "1997-05-02T17:00:00"
+    end
+
+    @testset "EOW on Wednesday translates to Friday at five in the afternoon" begin
+        @test delivery_date("2005-09-14T11:00:00", "EOW") ==  "2005-09-16T17:00:00"
+    end
+
+    @testset "EOW on Thursday translates to Sunday at eight in the evening" begin
+        @test delivery_date("2011-05-19T08:30:00", "EOW") ==  "2011-05-22T20:00:00"
+    end
+
+    @testset "EOW on Friday translates to Sunday at eight in the evening" begin
+        @test delivery_date("2022-08-05T14:00:00", "EOW") ==  "2022-08-07T20:00:00"
+    end
+
+    @testset "EOW translates to leap day" begin
+        @test delivery_date("2008-02-25T10:30:00", "EOW") ==  "2008-02-29T17:00:00"
+    end
+
+    @testset "2M before the second month of this year translates to the first workday of the second month of this year" begin
+        @test delivery_date("2007-01-02T14:15:00", "2M") ==  "2007-02-01T08:00:00"
+    end
+
+    @testset "11M in the eleventh month translates to the first workday of the eleventh month of next year" begin
+        @test delivery_date("2013-11-21T15:30:00", "11M") ==  "2014-11-03T08:00:00"
+    end
+
+    @testset "4M in the ninth month translates to the first workday of the fourth month of next year" begin
+        @test delivery_date("2019-11-18T15:15:00", "4M") ==  "2020-04-01T08:00:00"
+    end
+
+    @testset "Q1 in the first quarter translates to the last workday of the first quarter of this year" begin
+        @test delivery_date("2003-01-01T10:45:00", "Q1") ==  "2003-03-31T08:00:00"
+    end
+
+    @testset "Q4 in the second quarter translates to the last workday of the fourth quarter of this year" begin
+        @test delivery_date("2001-04-09T09:00:00", "Q4") ==  "2001-12-31T08:00:00"
+    end
+
+    @testset "Q3 in the fourth quarter translates to the last workday of the third quarter of next year" begin
+        @test delivery_date("2022-10-06T11:00:00", "Q3") ==  "2023-09-29T08:00:00"
+    end
+
+end

--- a/exercises/practice/swift-scheduling/swift-scheduling.jl
+++ b/exercises/practice/swift-scheduling/swift-scheduling.jl
@@ -1,0 +1,3 @@
+function delivery_date(start, description)
+    
+end


### PR DESCRIPTION
Another workout for skills with the `Dates` module.

I've set difficulty 4, the same as Python and Java. C# and Elixir chose 6, but I guess their library modules are less supportive than Julia's. The code ends up fairly simple, but the problem needs some careful thought and will no doubt confuse some students (_educational_ - the Concept docs clearly warn them that this subject isn't as simple as some people think).

The GH infrastructure problems delayed `baffling-birthdays`, the Exercism glitch delayed `intergalactic-transmission`. Third time lucky?