### PR TITLE
Update config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -390,7 +390,7 @@
           "pairs-and-dicts",
           "multi-dimensional-arrays"
         ],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "exercism-matrix",
@@ -402,7 +402,7 @@
         "prerequisites": [
           "function-composition"
         ],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "cheese-club",
@@ -414,7 +414,7 @@
         "prerequisites": [
           "multi-dimensional-arrays"
         ],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "old-elyses-enchantments",


### PR DESCRIPTION
Change the status of three concept exercises from "wip" to "beta". 

We had held off with publishing due to possible overlap between the concepts and a need to coordinate docs.

However, after a cursory look, the exercises seem to be self-contained enough that I don't see any need to amend the concept docs.