### PR TITLE
Sync `introduction.md` files for 3 concepts with concept exercises

### DIFF
--- a/concepts/comprehensions/introduction.md
+++ b/concepts/comprehensions/introduction.md
@@ -4,7 +4,7 @@ Anyone who has used Python has almost certainly used list comprehensions, which 
 
 Something so convenient gradually finds its way into other languages, including Julia.
 
-Comprehensions] are an option rather than a necessity for Julia programmers, as there are usually alternatives (broadcasting, higher-order functions, etc).
+Comprehensions are an option rather than a necessity for Julia programmers, as there are usually alternatives (broadcasting, higher-order functions, etc).
 
 However, a comprehension will often provide a simple, readable and performant way to construct an array.
 Use is ultimately a matter of personal taste, and how you feel about Python versus functional languages.
@@ -21,7 +21,6 @@ julia> [x^2 for x in 1:3]
  1
  4
  9
-
 julia> [x^2 for x in 1:3 if isodd(x^2)]
 2-element Vector{Int64}:
  1
@@ -35,12 +34,10 @@ julia> m
 2×3 Matrix{Int64}:
  1  2  3
  4  5  6
-
 julia> [x^2 for x in m]
 2×3 Matrix{Int64}:
   1   4   9
  16  25  36
-
 julia> [x^2 for x in m if isodd(x^2)] 
 3-element Vector{Int64}:
   1
@@ -64,7 +61,6 @@ julia> [x * y for x in 1:3 for y in 4:6]
  12
  15
  18
-
 julia> [x * y for x in 1:3 for y in 4:6 if isodd(x * y)]
 2-element Vector{Int64}:
   5
@@ -79,7 +75,6 @@ julia> m
 2×3 Matrix{Int64}:
  1  2  3
  4  5  6
-
 julia> [x*y for x in m for y in m]
 36-element Vector{Int64}:
   1
@@ -117,18 +112,15 @@ When the brackets are replaced by parentheses `( ... )` something different happ
 ```julia-repl
 julia> g = ((x, y) for x in 1:3, y in 4:6)
 Base.Generator{Base.Iterators.ProductIterator{Tuple{UnitRange{Int64}, UnitRange{Int64}}}, var"#9#10"}(var"#9#10"(), Base.Iterators.ProductIterator{Tuple{UnitRange{Int64}, UnitRange{Int64}}}((1:3, 4:6)))
-
 # Indexing fails with a generator, the entries don't exist yet
 julia> g[1, 2]
 ERROR: MethodError: no method matching getindex(::Base.Generator{Base.Iterators.ProductIterator{Tuple{UnitRange{…}, UnitRange{…}}}, var"#9#10"}, ::Int64, ::Int64)
-
 # conversion to array
 julia> collect(g)
 3×3 Matrix{Tuple{Int64, Int64}}:
  (1, 4)  (1, 5)  (1, 6)
  (2, 4)  (2, 5)  (2, 6)
  (3, 4)  (3, 5)  (3, 6)
-
 # generators are mainly designed for iteration
 julia> [i * j for (i, j) in g]
 3×3 Matrix{Int64}:
@@ -144,10 +136,8 @@ A generator used as a function argument does not need additional parentheses.
 ```julia-repl
 # inefficient
 julia> v = [x^2 for x in 1:1e6];
-
 julia> sum(v)
 3.333338333335e17
-
 # better - use a generator
 julia> sum(x^2 for x in 1:1e6)
 3.3333383333312755e17

--- a/concepts/higher-order-functions/introduction.md
+++ b/concepts/higher-order-functions/introduction.md
@@ -12,9 +12,9 @@ The term usually refers to functions such as `filter`, `map` and `reduce` which 
 
 By this point in the syllabus, we have already seen various ways to apply an operation to all elements of an iterable collection, such as a Vector:
 
-- Use a [loop][loops] (like most programming languages since the dawn of digital computing).
-- Use a [comprehension][comprehensions] (Python-style).
-- Use [broadcasting][broadcasting] (distinctively Julia syntax, though with a large debt to R, Matlab and NumPy).
+- Use a loop (like most programming languages since the dawn of digital computing).
+- Use a comprehension (Python-style).
+- Use broadcasting (distinctively Julia syntax, though with a large debt to R, Matlab and NumPy).
 
 This Concept will focus on higher-order functions (familiar from any functional language, such as Haskell or F#).
 
@@ -80,7 +80,7 @@ There is also an in-place version, `filter!()`, as there is for many of the func
 ## Mapping
 
 The `map()` function transforms a collection by applying a function to each element.
-This can be similar to [broadcasting][broadcasting] in simple cases, with the output shape matching the input.
+This can be similar to broadcasting in simple cases, with the output shape matching the input.
 
 ```julia-repl
 julia> map(√, [1, 4, 9])
@@ -122,7 +122,7 @@ _This is only a rough analogy, implying nothing about the implementation!_
 As with `zip()`, collections of mismatched shape are truncated to the dimension(s) of the smallest.
 
 Sometimes only the side effects of the passed-in function are needed, such as a database write or a `push!` to an array.
-Then the higher-order function `foreach()` is available, which always returns [`nothing`][nothingness].
+Then the higher-order function `foreach()` is available, which always returns `nothing`.
 
 ## Reducing
 
@@ -208,9 +208,3 @@ julia> sum(map(x -> x^2 + 1, 1:3))
 ```
 
 As we might expect, Julia also has `mapfoldl()` and `mapfoldr()` functions for sitations where direction is important.
-
-
-[loops]: https://exercism.org/tracks/julia/concepts/loops
-[comprehensions]: https://exercism.org/tracks/julia/concepts/comprehensions
-[nothingness]: https://exercism.org/tracks/julia/concepts/nothingness
-[broadcasting]: https://exercism.org/tracks/julia/concepts/vector-operations

--- a/concepts/multi-dimensional-arrays/introduction.md
+++ b/concepts/multi-dimensional-arrays/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Far back in the [Vectors][vectors] Concept, we noted that "_arrays can be of arbitrary size (subject only to memory constraints in your hardware), and can have arbitrarily many dimensions._"
+Far back in the `Vectors` Concept, we noted that "_arrays can be of arbitrary size (subject only to memory constraints in your hardware), and can have arbitrarily many dimensions._"
 
 Since then, we have largely ignored arrays with more than one dimension, just to keep things simple.
 This decision will make more sense if you try reading the Julia reference documents, in their full complexity.
@@ -94,7 +94,7 @@ julia> m = [1 2 3; 4 5 6]
  4  5  6
 ```
 
-However, be aware that Julia (like Fortran, R and Matlab, but _unlike_ C/C++ or NumPy) stores N-dimension arrays in [column-major order][col-major], and this can make a huge performance difference if you loop over the elements.
+However, be aware that Julia (like Fortran, R and Matlab, but _unlike_ C/C++ or NumPy) stores N-dimension arrays in column-major order, and this can make a huge performance difference if you loop over the elements.
 _Help your CPU cache to help you!_
 
 ```julia-repl
@@ -126,33 +126,6 @@ julia> rand(Float32, 2, 3)  # random numbers in the interval [0, 1)
  0.768823  0.169633  0.632565
  0.388451  0.109176  0.850381
 ```
-
-### Generating evenly-spaced values
-
-NumPy enthusiasts will be aware that `np.linspace` is a widely-used function to generate an array of specified length, with specified endpoints and evenly-spaced values.
-This is typically used as the x-axis of a graph, or as the independent variable in linear models.
-
-Julia has no exact equivalent, but the very flexible `range()` function can mimic it by specifying the lower and upper bounds, plus the `length` keyword argument.
-
-```julia-repl
-julia> x = range(0, 2π; length=100)
-0.0:0.06346651825433926:6.283185307179586
-
-julia> typeof(x)
-StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}
-
-julia> vals = [x sin.(x) cos.(x)]
-100×3 Matrix{Float64}:
- 0.0         0.0           1.0
- 0.0634665   0.0634239     0.997987
- 0.126933    0.126592      0.991955
- 0.1904      0.189251      0.981929
-(...truncated)
-```
-
-The `StepRangeLen` can be used like a vector, including conversion to a matrix column.
-
-See also the equivalent `logrange()` function, to generate values equally-spaced on a log axis.
 
 ## Indexing
 
@@ -308,11 +281,11 @@ Julia arrays can potentially be Terabytes in size, so copying is potentially a p
 A view like this can be used for looping, broadcasting, or all the other operations we saw in the syllabus so far.
 
 Also, comprehensions can be powerful and versatile with array input.
-Simple cases were mentioned in the [Loops][loops] concept, but there will be an expanded discussion in a later concept.
+Simple cases were mentioned in the `Loops` concept, but there will be an expanded discussion in a later concept.
 
 ## Broadcasting in multiple dimansions
 
-We discussed the 1-D case in the [Vector Operations][vector-ops] concept.
+We discussed the 1-D case in the `Vector Operations` concept.
 
 ```julia-repl
 julia> v = [1.2, 1.5, 1.7]
@@ -358,9 +331,3 @@ julia> (x -> x^2).(m)  # broadcast a function to all elements
 ```
 
 In general, Julia will broadcast any singleton dimension(s) to match the shape of the larger array.
-
-
-[vectors]: https://exercism.org/tracks/julia/concepts/vectors
-[loops]: https://exercism.org/tracks/julia/concepts/loops
-[vector-ops]: https://exercism.org/tracks/julia/concepts/vector-operations
-[col-major]: https://en.wikipedia.org/wiki/Row-_and_column-major_order


### PR DESCRIPTION
I've overwritten my earlier concept draft with whatever is now merged for each exercise.

Affects:
- `multi-dimensional-arrays` (from `exercism-matrix`)
- `higher-order-functions` (from `cheese-club`)
- `comprehensions` (from `boutique-suggestions`)