### PR TITLE
Corrected description of file_range function output

### DIFF
--- a/exercises/concept/chessboard/.docs/instructions.md
+++ b/exercises/concept/chessboard/.docs/instructions.md
@@ -18,7 +18,7 @@ julia> rank_range()
 ## 2. Define the file range
 
 Implement the `file_range()` function. 
-It should return a range of integers, from the uppercase letter A, to the uppercase letter H.
+It should return a range of characters, from the uppercase letter A, to the uppercase letter H.
 
 ```julia-repl
 julia> file_range()


### PR DESCRIPTION
Error in the instruction.md of the chessboard exercise on the julia track, stating "range of integers" for the file instead of "range of characters"