### PR TITLE
Fix Mecha Munch Management stub

### DIFF
--- a/exercises/concept/mecha-munch-management/mecha-munch-management.jl
+++ b/exercises/concept/mecha-munch-management/mecha-munch-management.jl
@@ -10,7 +10,7 @@ function send_to_store(cart, aislecodes)
     
 end
 
-function update_store_inventory!(cart, inventory)
+function update_store_inventory!(inventory, cart)
     
 end
 


### PR DESCRIPTION
The stub has the arguments in the wrong order. This changes it to align with the tests and exemplar.