### PR TITLE
Fix broken link

### DIFF
--- a/concepts/composite-types/about.md
+++ b/concepts/composite-types/about.md
@@ -163,7 +163,7 @@ Field types will be checked for compatibility with the type definition, and an e
 
 Suppose we want constraints on the _values_ passed in, not just the _types_?
 
-Then we can include an `inner constructor` within the type definition, to carry out appropriate checks prom.
+Then we can include an `inner constructor` within the type definition, to carry out appropriate checks.
 
 For example, we have an abstract type `AbstractPoint`, intended to take `(x, y)` coordinates, but want a subtype with the constraint `y > x`.
 


### PR DESCRIPTION
Tiny fix to `composite-types/about.md`, to make the link name match correctly.

I spotted this when re-reading the document while tackling the `rational-numbers` practice exercise - which in the Julia version is crazy difficult and goes ***far*** beyond the problem specs. I learned a lot (after cheating and looking at Sasha's example solution), but I'm reluctant to link this to the `multiple-dispatch` concept. We could drive away a lot of students!