### PR TITLE
Fix types concept about

### DIFF
--- a/concepts/types/about.md
+++ b/concepts/types/about.md
@@ -306,7 +306,7 @@ Float64
 [dijkstra]: https://en.wikipedia.org/wiki/Edsger_W._Dijkstra
 [hierarchy-diagram]: https://discourse.julialang.org/t/diagram-with-all-julia-types/5018
 [primitive]: https://docs.julialang.org/en/v1/manual/types/#Primitive-Types
-[types]: "https://docs.julialang.org/en/v1/manual/types/"
+[types]: https://docs.julialang.org/en/v1/manual/types/
 [inference]: https://en.wikipedia.org/wiki/Type_inference
 [numbers]: https://exercism.org/tracks/julia/concepts/numbers
 [assert]: https://docs.julialang.org/en/v1/base/base/#Base.@assert


### PR DESCRIPTION
Attempts to address issue #1040.

Bad formatting of a URL means invalid Markdown, so our best guess is that the Exercism website can't render it. Probably caused by careless copy-paste from `links.json`, and an author brain too fried to notice...