### PR TITLE
revert function name change

### DIFF
--- a/exercises/concept/inventory-management/.docs/hints.md
+++ b/exercises/concept/inventory-management/.docs/hints.md
@@ -1,5 +1,8 @@
 # Hints
 
+**Remember**: The tests in this exercise are mutation agnostic, but the function names indicate they should be non-mutating.
+If you would like to use functions from the introduction while not mutating the input, the function `copy()` will be helpful.
+
 ## 1. Create an inventory based on a vector
 
 - It may help to look at Task 2 before starting this.
@@ -18,7 +21,6 @@
 ## 4. Remove an entry entirely from the inventory
 
 - Julia has a function to do exactly this: read the Introduction.
-- Remember, since this function has a `!`, it mutates the input.
 
 ## 5. Return the entire content of the inventory
 

--- a/exercises/concept/inventory-management/.docs/instructions.md
+++ b/exercises/concept/inventory-management/.docs/instructions.md
@@ -10,6 +10,10 @@ You will also have to handle deleting items from an inventory by decreasing quan
 
 Finally, you will need to implement a function that will return all the key-value pairs in a given inventory as a `vector` of `pair`s.
 
+~~~~exercism/note
+The tests in this exercise are mutation agnostic, but the function names indicate they should be non-mutating.
+If you would like to use functions from the introduction while not mutating the input, the function `copy()` will be helpful.
+~~~~
 
 ## 1. Create an inventory based on a vector
 
@@ -51,7 +55,7 @@ Dict("coal" => 0, "wood" => 0, "diamond" => 1)
 
 ## 4. Remove an entry entirely from the inventory
 
-Implement the `remove_item!(<inventory dict>, <item>)` function that removes an item and its count entirely from an inventory:
+Implement the `remove_item(<inventory dict>, <item>)` function that removes an item and its count entirely from an inventory:
 
 ```julia-repl
 julia> remove_item!(Dict("coal" => 2, "wood" => 1, "diamond" => 2), "coal")
@@ -61,7 +65,7 @@ Dict("wood" => 1, "diamond" => 2)
 If the item is not found in the inventory, the function should return the original inventory unchanged.
 
 ```julia-repl
-julia> remove_item!(Dict("coal" => 2, "wood" => 1, "diamond" => 2), "gold")
+julia> remove_item(Dict("coal" => 2, "wood" => 1, "diamond" => 2), "gold")
 Dict("coal" => 2, "wood" => 1, "diamond" => 2)
 ```
 

--- a/exercises/concept/inventory-management/.meta/exemplar.jl
+++ b/exercises/concept/inventory-management/.meta/exemplar.jl
@@ -16,6 +16,6 @@ function decrement_items(inventory, items)
     inventory
 end
 
-remove_item!(inventory, item) = delete!(inventory, item)
+remove_item(inventory, item) = delete!(copy(inventory), item)
 
 list_inventory(inventory) = sort([item for item in inventory if item.second > 0])

--- a/exercises/concept/inventory-management/inventory-management.jl
+++ b/exercises/concept/inventory-management/inventory-management.jl
@@ -10,7 +10,7 @@ function decrement_items(inventory, items)
 
 end
 
-function remove_item!(inventory, item)
+function remove_item(inventory, item)
 
 end
 

--- a/exercises/concept/inventory-management/runtests.jl
+++ b/exercises/concept/inventory-management/runtests.jl
@@ -57,17 +57,17 @@ include("inventory-management.jl")
     end
 
     @testset "4. remove_item" begin
-        @isdefined(remove_item) && (global remove_item! = remove_item)
+        @isdefined(remove_item!) && (global remove_item = remove_item!)
         @testset "test_remove_item" begin
             inventory = Dict("iron" => 1, "diamond" => 2, "gold" => 1)
             expected = Dict("iron" => 1, "gold" => 1)
-            @test remove_item!(inventory, "diamond") == expected
+            @test remove_item(inventory, "diamond") == expected
         end
 
         @testset "test_remove_item_not_in_inventory" begin
             inventory = Dict("iron" => 1, "diamond" => 2, "gold" => 1)
             expected = Dict("iron" => 1, "gold" => 1, "diamond" => 2)
-            @test remove_item!(inventory, "wood") == expected
+            @test remove_item(inventory, "wood") == expected
         end
     end
 


### PR DESCRIPTION
After spending more time looking at the exercise, I think it's best we leave it as it was, but include extra information about mutating inputs. To that effect, `hints.md` and `instructions.md` have been updated to include information on the existence of `copy()`.

The main thing was that the easiest way to complete the exercise while using the desired functionality will likely lead students to mutate the input if they don't know how to produce a copy.