### PR TITLE
Deprecate trinary practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1073,12 +1073,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "arrays",
-          "integers",
-          "math",
-          "strings"
-        ]
+        "status": "deprecated"
       },
       {
         "slug": "accumulate",


### PR DESCRIPTION
See [forum](https://forum.exercism.org/t/deprecate-binary-trinary-and-hexadecimal/19932) wrt C++.

Binary, Trinary, Octal and Hexadecimal used to be separate exercises, but they were all combined into All Your Base a mere 9 years ago. It's time we deprecated `julia/trinary`, I think. That means it will still be visible to students who already started it, hidden from everyone else.