### PR TITLE
Add [compat] section to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,3 +4,6 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+
+[compat]
+Combinatorics = "1.0.2"


### PR DESCRIPTION
Pushes Combinatorics version to 1.0.2 in line with change at the test runner.