### PR TITLE
Update exercism-matrix docs for more clarity on broadcasting

### DIFF
--- a/concepts/multi-dimensional-arrays/about.md
+++ b/concepts/multi-dimensional-arrays/about.md
@@ -389,8 +389,7 @@ The dotted operator `.-` treats the singleton `0.5` as equivalent to `[0.5, 0.5,
 
 Extending this to higher dimensions is really just more of the same.
 
-You may feel at first that the scope for programmer confusion scales exponentially in the number of dimensions, but practice helps a lot.
-Also, familiarity with NumPy arrays translates quite well to Julia, despite the different syntax.
+For example, when broadcasting the multiplication of a 2x1 row vector `[1.0 1.5 2.0]` with the 2x3 matrix [1 2 3; 4 5 6], broadcasting is equivalent to broadcasting `[1.0 1.5 2.0]` to `[1.0 1.5 2.0; 1.0 1.5 2.0]` with multiplication then done element-wise.
 
 ```julia-repl
 julia> m
@@ -398,15 +397,36 @@ julia> m
  1  2  3
  4  5  6
 
-julia> m .* [1.0 1.5 2.0]  # broadcast a row vector down
+julia> m .* [1.0 1.5 2.0]  # broadcast a 1x3 row vector down
 2×3 Matrix{Float64}:
  1.0  3.0   6.0
  4.0  7.5  12.0
 
-julia> m ./ [1, 2]  # broadcast a column vector across
+julia> m .* [1.0 1.5 2.0; 1.0 1.5 2.0]  # 2x3 elementwise multiplication
+2×3 Matrix{Float64}:
+ 1.0  3.0   6.0
+ 4.0  7.5  12.0
+
+julia> m ./ [1, 2]  # broadcast a 2x1 column vector across
 2×3 Matrix{Float64}:
  1.0  2.0  3.0
  2.0  2.5  3.0
+
+julia> m ./ [1 1 1; 2 2 2]  # 2x3 elementwise division
+2×3 Matrix{Float64}:
+ 1.0  2.0  3.0
+ 2.0  2.5  3.0
+```
+
+**Note:** It is the non-singleton dimensions should match in size (e.g. `2x3 Matrix .* 2x1 Matrix`) for broadcasting.
+
+Furthermore, a function can be broadcast to each element of a `Matrix` exactly how it is done with a `Vector`.
+
+```julia-repl
+julia> m
+2×3 Matrix{Int64}:
+ 1  2  3
+ 4  5  6
 
 julia> (x -> x^2).(m)  # broadcast a function to all elements
 2×3 Matrix{Int64}:
@@ -414,7 +434,8 @@ julia> (x -> x^2).(m)  # broadcast a function to all elements
  16  25  36
 ```
 
-In general, Julia will broadcast any singleton dimension(s) to match the shape of the larger array.
+You may feel at first that the scope for programmer confusion scales exponentially in the number of dimensions, but practice helps a lot.
+Also, familiarity with NumPy arrays translates quite well to Julia, despite the different syntax.
 
 ## Further Reading
 

--- a/concepts/multi-dimensional-arrays/introduction.md
+++ b/concepts/multi-dimensional-arrays/introduction.md
@@ -305,8 +305,7 @@ The dotted operator `.-` treats the singleton `0.5` as equivalent to `[0.5, 0.5,
 
 Extending this to higher dimensions is really just more of the same.
 
-You may feel at first that the scope for programmer confusion scales exponentially in the number of dimensions, but practice helps a lot.
-Also, familiarity with NumPy arrays translates quite well to Julia, despite the different syntax.
+For example, when broadcasting the multiplication of a 2x1 row vector `[1.0 1.5 2.0]` with the 2x3 matrix [1 2 3; 4 5 6], broadcasting is equivalent to broadcasting `[1.0 1.5 2.0]` to `[1.0 1.5 2.0; 1.0 1.5 2.0]` with multiplication then done element-wise.
 
 ```julia-repl
 julia> m
@@ -314,15 +313,36 @@ julia> m
  1  2  3
  4  5  6
 
-julia> m .* [1.0 1.5 2.0]  # broadcast a row vector down
+julia> m .* [1.0 1.5 2.0]  # broadcast a 1x3 row vector down
 2×3 Matrix{Float64}:
  1.0  3.0   6.0
  4.0  7.5  12.0
 
-julia> m ./ [1, 2]  # broadcast a column vector across
+julia> m .* [1.0 1.5 2.0; 1.0 1.5 2.0]  # 2x3 elementwise multiplication
+2×3 Matrix{Float64}:
+ 1.0  3.0   6.0
+ 4.0  7.5  12.0
+
+julia> m ./ [1, 2]  # broadcast a 2x1 column vector across
 2×3 Matrix{Float64}:
  1.0  2.0  3.0
  2.0  2.5  3.0
+
+julia> m ./ [1 1 1; 2 2 2]  # 2x3 elementwise division
+2×3 Matrix{Float64}:
+ 1.0  2.0  3.0
+ 2.0  2.5  3.0
+```
+
+**Note:** It is the non-singleton dimensions should match in size (e.g. `2x3 Matrix .* 2x1 Matrix`) for broadcasting.
+
+Furthermore, a function can be broadcast to each element of a `Matrix` exactly how it is done with a `Vector`.
+
+```julia-repl
+julia> m
+2×3 Matrix{Int64}:
+ 1  2  3
+ 4  5  6
 
 julia> (x -> x^2).(m)  # broadcast a function to all elements
 2×3 Matrix{Int64}:
@@ -330,4 +350,5 @@ julia> (x -> x^2).(m)  # broadcast a function to all elements
  16  25  36
 ```
 
-In general, Julia will broadcast any singleton dimension(s) to match the shape of the larger array.
+You may feel at first that the scope for programmer confusion scales exponentially in the number of dimensions, but practice helps a lot.
+Also, familiarity with NumPy arrays translates quite well to Julia, despite the different syntax.

--- a/exercises/concept/exercism-matrix/.docs/hints.md
+++ b/exercises/concept/exercism-matrix/.docs/hints.md
@@ -23,11 +23,11 @@ Task 5 (rendering) can be done earlier to help with visualization, but be carefu
 ## 4. Change dots to column pixel counts
 
 - Broadcasting is a great way to do this concisely.
-- To broadcast, you'll need a vector with the column dot counts.
+- To broadcast, you'll need a *row* vector with the column dot counts.
 - To get a vector with column dot counts, you can apply a function to the `Matrix` with the `dims` specified.
 
 ## 5. Render a dot matrix
 
-- The dots (e.g. `1`, `2`, etc.) and `0`s need to be changed to `X`s and `O`s, respectively.
-- Using `eachrow()` to loop may work here.
-- The function `join()` can also help to make things more concise.
+- The dots (e.g. `1`, `2`, etc.) and `0`s need to be changed to `"X"` and `" "`, respectively.
+- Using `eachrow()` for an inner loop may be useful here but is not necessary.
+- The function `join()` can also help to make things more concise and could even be broadcast.

--- a/exercises/concept/exercism-matrix/.docs/introduction.md
+++ b/exercises/concept/exercism-matrix/.docs/introduction.md
@@ -305,8 +305,7 @@ The dotted operator `.-` treats the singleton `0.5` as equivalent to `[0.5, 0.5,
 
 Extending this to higher dimensions is really just more of the same.
 
-You may feel at first that the scope for programmer confusion scales exponentially in the number of dimensions, but practice helps a lot.
-Also, familiarity with NumPy arrays translates quite well to Julia, despite the different syntax.
+For example, when broadcasting the multiplication of a 2x1 row vector `[1.0 1.5 2.0]` with the 2x3 matrix [1 2 3; 4 5 6], broadcasting is equivalent to broadcasting `[1.0 1.5 2.0]` to `[1.0 1.5 2.0; 1.0 1.5 2.0]` with multiplication then done element-wise.
 
 ```julia-repl
 julia> m
@@ -314,15 +313,36 @@ julia> m
  1  2  3
  4  5  6
 
-julia> m .* [1.0 1.5 2.0]  # broadcast a row vector down
+julia> m .* [1.0 1.5 2.0]  # broadcast a 1x3 row vector down
 2×3 Matrix{Float64}:
  1.0  3.0   6.0
  4.0  7.5  12.0
 
-julia> m ./ [1, 2]  # broadcast a column vector across
+julia> m .* [1.0 1.5 2.0; 1.0 1.5 2.0]  # 2x3 elementwise multiplication
+2×3 Matrix{Float64}:
+ 1.0  3.0   6.0
+ 4.0  7.5  12.0
+
+julia> m ./ [1, 2]  # broadcast a 2x1 column vector across
 2×3 Matrix{Float64}:
  1.0  2.0  3.0
  2.0  2.5  3.0
+
+julia> m ./ [1 1 1; 2 2 2]  # 2x3 elementwise division
+2×3 Matrix{Float64}:
+ 1.0  2.0  3.0
+ 2.0  2.5  3.0
+```
+
+**Note:** It is the non-singleton dimensions should match in size (e.g. `2x3 Matrix .* 2x1 Matrix`) for broadcasting.
+
+Furthermore, a function can be broadcast to each element of a `Matrix` exactly how it is done with a `Vector`.
+
+```julia-repl
+julia> m
+2×3 Matrix{Int64}:
+ 1  2  3
+ 4  5  6
 
 julia> (x -> x^2).(m)  # broadcast a function to all elements
 2×3 Matrix{Int64}:
@@ -330,4 +350,5 @@ julia> (x -> x^2).(m)  # broadcast a function to all elements
  16  25  36
 ```
 
-In general, Julia will broadcast any singleton dimension(s) to match the shape of the larger array.
+You may feel at first that the scope for programmer confusion scales exponentially in the number of dimensions, but practice helps a lot.
+Also, familiarity with NumPy arrays translates quite well to Julia, despite the different syntax.


### PR DESCRIPTION
Since `exercism-matrix` is still hovering around 60% completion rate, I'm still looking for ways to make it more approachable...

This is in response to a [this question](https://forum.exercism.org/t/exercism-matrix-task-5/20254) on the forum.

- Further explanation of how broadcasting is working is given to try to help with intuition/visualization of the process. 
- A few small items were added to `hints.md`.