### PR TITLE
Update runtests.jl

### DIFF
--- a/exercises/concept/captains-log/runtests.jl
+++ b/exercises/concept/captains-log/runtests.jl
@@ -49,12 +49,12 @@ include("captains-log.jl")
 
         @testset "stardates are not all similar" begin
             n_small = sum(random_stardates .< 41333)
-            n_mid = sum(41333 .< random_stardates .< 41667)
-            n_large = sum(random_stardates .> 41667)
+            n_mid = sum(41333 .≤ random_stardates .< 41667)
+            n_large = sum(random_stardates .≥ 41667)
             n_expected = length(random_stardates) / 3
             
             uniform_if = sum(((n_small, n_mid, n_large) .- n_expected) .^ 2) / n_expected
-            @test uniform_if < 6
+            @test uniform_if < 6 # startdates should have uniform distribution
         end
     end
 
@@ -67,8 +67,8 @@ include("captains-log.jl")
 
         @testset "stardates are not all similar" begin
             n_small = sum(rounded_stardates .< 41333)
-            n_mid = sum(41333 .<= rounded_stardates .< 41667)
-            n_large = sum(rounded_stardates .>= 41667)
+            n_mid = sum(41333 .≤ rounded_stardates .< 41667)
+            n_large = sum(rounded_stardates .≥ 41667)
             n_expected = length(rounded_stardates) / 3
 
             uniform_if = sum(((n_small, n_mid, n_large) .- n_expected) .^ 2) / n_expected


### PR DESCRIPTION
Addresses Issue #1095.

Beyond testing for correct "fleet" size:
- testing added for random "fleet" selection in Task 5
- changed input to a copy of `starships` in case student uses the mutating `shuffle!` in Task 5.
- corrected testing for correct prefix in Task 2
- corrected testing for correct numerical range in Task 2

The testing for randomness of fleet selection is rather weak (only requires one ship out of given order) but I figure that's probably good enough. If there are other ideas, feel free to discuss.

Update: I've adjusted the testing for randomness in Task 5 to better reflect that the distribution of fixed points for random permutations is Poisson(1). I've set the limit of fixed points to be three, since the probability of having 4 or more fixed points is around 2%, but we could be more generous by setting the limit to four. This test is aimed at the larger fleets since this passes trivially for tests on fleets of under four starships. The issue is still open to discussion on whether there is a better option.