### PR TITLE
Update testing tolerances for captains-log

### DIFF
--- a/exercises/concept/captains-log/runtests.jl
+++ b/exercises/concept/captains-log/runtests.jl
@@ -54,7 +54,7 @@ include("captains-log.jl")
             n_expected = length(random_stardates) / 3
             
             uniform_if = sum(((n_small, n_mid, n_large) .- n_expected) .^ 2) / n_expected
-            @test uniform_if < 6 # startdates should have uniform distribution
+            @test uniform_if < 10 # startdates should have uniform distribution
         end
     end
 
@@ -72,7 +72,7 @@ include("captains-log.jl")
             n_expected = length(rounded_stardates) / 3
 
             uniform_if = sum(((n_small, n_mid, n_large) .- n_expected) .^ 2) / n_expected
-            @test uniform_if < 6 # startdates should have uniform distribution
+            @test uniform_if < 10 # startdates should have uniform distribution
         end
 
         @testset "stardates have one decimal place" begin
@@ -99,7 +99,7 @@ include("captains-log.jl")
         end
 
         @testset "starships are chosen at random" begin
-            @test all([sum(fleet .== starships[1:length(fleet)]) ≤ 3  for fleet in chosen_starships])
+            @test all([sum(fleet .== starships[1:length(fleet)]) ≤ 4  for fleet in chosen_starships])
         end
     end
 


### PR DESCRIPTION
This looses the tolerances on `captains-log` since they might be unnecessarily tight as it is. 

With these settings:
- alpha for the Chi-squared test sits at `0.00673794699908547`.
- the threshold for the Poisson case has been moved to five or more fixed points.

There is a probability of 0.00365984682734371 that five out of 100 points in a random permutation remain fixed, so, with the added constraint that at least five have to be congregated in the returned values, this becomes *highly* unlikely to return a false negative.