### PR TITLE
state-of-tic-tac-toe: sync tests and fix example.jl win/turn parity bug

### DIFF
--- a/exercises/practice/state-of-tic-tac-toe/.meta/example.jl
+++ b/exercises/practice/state-of-tic-tac-toe/.meta/example.jl
@@ -2,7 +2,8 @@
 function gamestate(board)
     M = reshape([col == ' ' ? 0 : (-1)^(col == 'O') for row in board for col in row], (3,3))
     mini, maxi = extrema([sum(M, dims=1)..., sum(M, dims=2)..., M[1,1]+M[2,2]+M[3,3], M[1,3]+M[2,2]+M[3,1]])
-    (sum(M) ∉ (0, 1) || maxi == 3 && mini == -3) && error("Invalid board")
+    invalid = sum(M) ∉ (0, 1) || (maxi == 3 && mini == -3) || (maxi == 3 && sum(M) != 1) || (mini == -3 && sum(M) != 0)
+    invalid && error("Invalid board")
     (maxi == 3 || mini == -3) ? "win" : 0 ∈ M ? "ongoing" : "draw"
 end
 
@@ -15,7 +16,7 @@ end
 #     mini, maxi = extrema([sum(M, dims=1)..., sum(M, dims=2)..., M[1,1]+M[2,2]+M[3,3], M[1,3]+M[2,2]+M[3,1]])
 
 #     # A board is invalid if either: the total sum is not 0 or 1; or X and O have simultaneously won.
-#     if sum(M) ∉ (0, 1) || maxi == 3 && mini == -3
+#     if sum(M) ∉ (0, 1) || maxi == 3 && mini == -3 || (maxi == 3 && sum(M) != 1) || (mini == -3 && sum(M) != 0)
 #         error("Invalid board")
 #     end
 
@@ -70,6 +71,11 @@ end
 #     o_wins = wins(b_int, o)
 #     (sum(x_wins) > 0 && sum(o_wins) > 0) && error("Too many wins!")
 
+#     x_has_win = sum(x_wins) > 0 || valid_double_win(x_wins)
+#     o_has_win = sum(o_wins) > 0 || valid_double_win(o_wins)
+#     x_has_win && sum(b_int) != 1 && error("Invalid board: turn count doesn't match X win")
+#     o_has_win && sum(b_int) != 0 && error("Invalid board: turn count doesn't match O win")
+
 #     total_wins = sum(x_wins) + sum(o_wins)
 #     if total_wins == 1 || valid_double_win(x_wins) || valid_double_win(o_wins)
 #         "win"
@@ -122,6 +128,11 @@ end
 #     x_wins = wins(b, "X")
 #     o_wins = wins(b, "O")
 #     (sum(x_wins) > 0 && sum(o_wins) > 0) && error("Too many wins!")
+
+#     x_has_win = sum(x_wins) > 0 || valid_double_win(x_wins)
+#     o_has_win = sum(o_wins) > 0 || valid_double_win(o_wins)
+#     x_has_win && nₓ != nₒ + 1 && error("Invalid board: turn count doesn't match X win")
+#     o_has_win && nₓ != nₒ && error("Invalid board: turn count doesn't match O win")
 
 #     total_wins = sum(x_wins) + sum(o_wins)
 #     if total_wins == 1 || valid_double_win(x_wins) || valid_double_win(o_wins)

--- a/exercises/practice/state-of-tic-tac-toe/.meta/tests.toml
+++ b/exercises/practice/state-of-tic-tac-toe/.meta/tests.toml
@@ -99,3 +99,9 @@ reimplements = "b1dc8b13-46c4-47db-a96d-aa90eedc4e8d"
 
 [4801cda2-f5b7-4c36-8317-3cdd167ac22c]
 description = "Invalid boards -> Invalid board: players kept playing after a win"
+
+[5a84757a-fc86-4328-aec9-a5759e6ed35d]
+description = "Invalid boards -> Invalid board: O kept playing after X wins"
+
+[cf25543d-583a-4656-b9ab-f82dc00a4a02]
+description = "Invalid boards -> Invalid board: X kept playing after O wins"

--- a/exercises/practice/state-of-tic-tac-toe/runtests.jl
+++ b/exercises/practice/state-of-tic-tac-toe/runtests.jl
@@ -123,6 +123,13 @@ include("state-of-tic-tac-toe.jl")
         @testset "Invalid board: players kept playing after a win" begin
             @test_throws ErrorException gamestate(["XXX", "OOO", "XOX"])
         end
-    end
 
+        @testset "Invalid board: O kept playing after X wins" begin
+            @test_throws ErrorException gamestate(["OO ", "XXX", " O "])
+        end
+
+        @testset "Invalid board: X kept playing after O wins" begin
+            @test_throws ErrorException gamestate(["XX ", "OOO", " XX"])
+        end
+    end
 end


### PR DESCRIPTION
# state-of-tic-tac-toe: Sync tests for playing after a win ([exercism/problem-specifications#2667](https://github.com/exercism/problem-specifications/pull/2667))
Sync `tests.toml` and `runtests.jl` with the two new canonical test cases that verify an error is thrown when a player makes a move after the game has already been won:

* O kept playing after X wins
* X kept playing after O wins

# Fix example.jl: enforce win/turn-count parity
The reference solution failed both new test cases — it validated turn order and rejected simultaneous double wins, but never checked that a win matched the expected move count, so a board where the wrong player had an extra move after a win was incorrectly accepted. Added the missing parity check (`X winning requires sum(M) == 1`, `O winning requires sum(M) == 0`). The three alternative implementations kept as comments shared the same gap and were fixed too.