### PR TITLE
Exercise sync, part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tmp/
 Manifest.toml
 
 .idea/
+
+*.pyc

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -1,0 +1,15 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+{%- macro test_case(case) %}
+    {%- set input = case["input"] %}
+    @testset "{{ case["description"]}}" begin
+        @test bob("""{{ case["input"]["heyBob"] }}""") == "{{ case["expected"] }}"
+    end
+{% endmacro %}
+
+    {% for case in cases -%}
+    {{ test_case(case) }}
+    {% endfor %}
+end

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -81,7 +81,6 @@ include = false
 
 [153c0e25-9bb5-4ec5-966e-598463658bcd]
 description = "using acronyms in regular speech"
-include = false
 
 [f7bc4b92-bdff-421e-a238-ae97f230ccac]
 description = "no letters"

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -9,23 +9,71 @@
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
 
-[e162fead-606f-437a-a166-d051915cea8e]
-description = "stating something"
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
 
 [73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
 description = "shouting"
 
-[d6c98afd-df35-4806-b55e-2c457c3ab748]
-description = "shouting gibberish"
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
 
-[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
-description = "asking a question"
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
 
 [81080c62-4e4d-4066-b30a-48d8d76920d9]
 description = "asking a numeric question"
 
 [2a02716d-685b-4e2e-a804-2adaf281c01e]
 description = "asking gibberish"
+
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+include = false
+
+[2c7278ac-f955-4eb4-bf8f-e33eb4116a15]
+description = "multiple line question"
+reimplements = "66953780-165b-4e7e-8ce3-4bcb80b6385a"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[3c954328-86fb-4c71-8961-e18d6a5e2517]
+description = "shouting a statement containing a question mark"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+include = false
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
 
 [c02f9179-ab16-4aa7-a8dc-940145c385f7]
 description = "talking forcefully"
@@ -35,59 +83,14 @@ include = false
 description = "using acronyms in regular speech"
 include = false
 
-[a5193c61-4a92-4f68-93e2-f554eb385ec6]
-description = "forceful question"
-include = false
-
-[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
-description = "shouting numbers"
-
 [f7bc4b92-bdff-421e-a238-ae97f230ccac]
 description = "no letters"
-
-[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
-description = "question with no letters"
-
-[496143c8-1c31-4c01-8a08-88427af85c66]
-description = "shouting with special characters"
-
-[e6793c1c-43bd-4b8d-bc11-499aea73925f]
-description = "shouting with no exclamation mark"
 
 [aa8097cc-c548-4951-8856-14a404dd236a]
 description = "statement containing question mark"
 
-[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
-description = "non-letters with question"
-
-[8608c508-f7de-4b17-985b-811878b3cf45]
-description = "prattling on"
-
-[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
-description = "silence"
-
-[d6c47565-372b-4b09-b1dd-c40552b8378b]
-description = "prolonged silence"
-
-[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
-description = "alternate silence"
-
-[66953780-165b-4e7e-8ce3-4bcb80b6385a]
-description = "multiple line question"
-include = false
-
 [5371ef75-d9ea-4103-bcfa-2da973ddec1b]
 description = "starting with whitespace"
 
-[05b304d6-f83b-46e7-81e0-4cd3ca647900]
-description = "ending with whitespace"
-
-[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
-description = "other whitespace"
-
 [12983553-8601-46a8-92fa-fcaa3bc4a2a0]
 description = "non-question ending with whitespace"
-
-[2c7278ac-f955-4eb4-bf8f-e33eb4116a15]
-description = "multiple line question"
-reimplements = "66953780-165b-4e7e-8ce3-4bcb80b6385a"

--- a/exercises/practice/bob/runtests.jl
+++ b/exercises/practice/bob/runtests.jl
@@ -1,91 +1,104 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
+# File last updated on 2026-07-28
+
 using Test
 
 include("bob.jl")
 
-questions = (
-        "Does this cryogenic chamber make me look fat?",
-        "Hä?",
-        "You are, what, like 15?",
-        "fffbbcbeab?",
-        "4?", ":) ?",
-        "Wait! Hang on. Are you going to be OK?",
-        "Okay if like my  spacebar  quite a bit?   ",
-        "Oida?",
-        "\nDoes this cryogenic chamber make\n me look fat?"
-)
-
-yells = (
-        "WATCH OUT!",
-        "FCECDFCAAB",
-        "FCÄEÜCÖDFCẞAB",
-        "1, 2, 3 GO!",
-        "ZOMG THE %^*@#\$(*^ ZOMBIES ARE COMING!!11!!1!",
-        "I HATE YOU",
-        "I HATE THE DENTIST",
-        "OIDA!",
-)
-
-silences = (
-        "",
-        "          ",
-        "\t\t\t\t\t\t\t\t\t\t",
-        "\n\r \t",
-)
-
-miscs = (
-        "Tom-ay-to, tom-aaaah-to.",
-        "Let's go make out behind the gym!",
-        "It's OK if you don't want to work for the NSA.",
-        "Es ist okay, wenn du nicht für den BND arbeiten möchtest.",
-        "1, 2, 3",
-        "Ending with ? means a question.",
-        "         hmmmmmmm...",
-        "This is a statement ending with whitespace      ",
-        "Oida.",
-)
-
-forceful_questions = (
-        "WHAT THE HELL WERE YOU THINKING?",
-        "WAS ZUR HÖLLE GEHT HIER VOR?",
-        "OIDA?",
-)
-
-response = Dict(
-        :question => "Sure.",
-        :yelling => "Whoa, chill out!",
-        :silence => "Fine. Be that way!",
-        :misc => "Whatever.",
-        :forceful_question => "Calm down, I know what I'm doing!",
-)
-
 @testset verbose = true "tests" begin
-    @testset "questions" begin
-        @testset "$question" for question in questions
-            @test bob(question) == response[:question]
-        end
+    @testset "asking a question" begin
+        @test bob("""Does this cryogenic chamber make me look fat?""") == "Sure."
     end
 
-    @testset "yelling" begin
-        @testset "$yell" for yell in yells
-            @test bob(yell) == response[:yelling]
-        end
+    @testset "shouting" begin
+        @test bob("""WATCH OUT!""") == "Whoa, chill out!"
+    end
+
+    @testset "forceful question" begin
+        @test bob("""WHAT'S GOING ON?""") == "Calm down, I know what I'm doing!"
     end
 
     @testset "silence" begin
-        @testset "$silence" for silence in silences
-            @test bob(silence) == response[:silence]
-        end
+        @test bob("""""") == "Fine. Be that way!"
     end
 
-    @testset "misc" begin
-        @testset "$misc" for misc in miscs
-            @test bob(misc) == response[:misc]
-        end
+    @testset "stating something" begin
+        @test bob("""Tom-ay-to, tom-aaaah-to.""") == "Whatever."
     end
 
-    @testset "forceful questions" begin
-        @testset "$question" for question in forceful_questions
-            @test bob(question) == response[:forceful_question]
-        end 
+    @testset "asking a numeric question" begin
+        @test bob("""You are, what, like 15?""") == "Sure."
+    end
+
+    @testset "asking gibberish" begin
+        @test bob("""fffbbcbeab?""") == "Sure."
+    end
+
+    @testset "question with no letters" begin
+        @test bob("""4?""") == "Sure."
+    end
+
+    @testset "non-letters with question" begin
+        @test bob(""":) ?""") == "Sure."
+    end
+
+    @testset "prattling on" begin
+        @test bob("""Wait! Hang on. Are you going to be OK?""") == "Sure."
+    end
+
+    @testset "ending with whitespace" begin
+        @test bob("""Okay if like my  spacebar  quite a bit?   """) == "Sure."
+    end
+
+    @testset "multiple line question" begin
+        @test bob("""
+Does this cryogenic chamber make
+ me look fat?""") == "Sure."
+    end
+
+    @testset "shouting gibberish" begin
+        @test bob("""FCECDFCAAB""") == "Whoa, chill out!"
+    end
+
+    @testset "shouting a statement containing a question mark" begin
+        @test bob("""DO LIONS EAT PEOPLE? AHHHHH.""") == "Whoa, chill out!"
+    end
+
+    @testset "shouting numbers" begin
+        @test bob("""1, 2, 3 GO!""") == "Whoa, chill out!"
+    end
+
+    @testset "shouting with no exclamation mark" begin
+        @test bob("""I HATE THE DENTIST""") == "Whoa, chill out!"
+    end
+
+    @testset "prolonged silence" begin
+        @test bob("""          """) == "Fine. Be that way!"
+    end
+
+    @testset "alternate silence" begin
+        @test bob("""										""") == "Fine. Be that way!"
+    end
+
+    @testset "other whitespace" begin
+        @test bob("""
+   """) == "Fine. Be that way!"
+    end
+
+    @testset "no letters" begin
+        @test bob("""1, 2, 3""") == "Whatever."
+    end
+
+    @testset "statement containing question mark" begin
+        @test bob("""Ending with ? means a question.""") == "Whatever."
+    end
+
+    @testset "starting with whitespace" begin
+        @test bob("""         hmmmmmmm...""") == "Whatever."
+    end
+
+    @testset "non-question ending with whitespace" begin
+        @test bob("""This is a statement ending with whitespace      """) == "Whatever."
     end
 end

--- a/exercises/practice/bob/runtests.jl
+++ b/exercises/practice/bob/runtests.jl
@@ -86,6 +86,10 @@ Does this cryogenic chamber make
    """) == "Fine. Be that way!"
     end
 
+    @testset "using acronyms in regular speech" begin
+        @test bob("""It's OK if you don't want to go work for NASA.""") == "Whatever."
+    end
+
     @testset "no letters" begin
         @test bob("""1, 2, 3""") == "Whatever."
     end

--- a/exercises/practice/connect/.meta/tests.toml
+++ b/exercises/practice/connect/.meta/tests.toml
@@ -30,6 +30,12 @@ description = "nobody wins crossing adjacent angles"
 [cd61c143-92f6-4a8d-84d9-cb2b359e226b]
 description = "X wins crossing from left to right"
 
+[495e33ed-30a9-4012-b46e-d7c4d5fe13c3]
+description = "X wins with left-hand dead end fork"
+
+[ab167ab0-4a98-4d0f-a1c0-e1cddddc3d58]
+description = "X wins with right-hand dead end fork"
+
 [73d1eda6-16ab-4460-9904-b5f5dd401d0b]
 description = "O wins crossing from top to bottom"
 

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -21,5 +21,5 @@
   },
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
-  "source_url": "https://www.oreilly.com/library/view/functional-thinking/9781449365509/"
+  "source_url": "https://nealford.com/books/functionalthinking.html"
 }

--- a/exercises/practice/swift-scheduling/.meta/tests.toml
+++ b/exercises/practice/swift-scheduling/.meta/tests.toml
@@ -56,3 +56,6 @@ description = "Q4 in the second quarter translates to the last workday of the fo
 
 [c920886c-44ad-4d34-a156-dc4176186581]
 description = "Q3 in the fourth quarter translates to the last workday of the third quarter of next year"
+
+[7c8f1616-be62-417e-bbd5-a60fa743eccc]
+description = "Q2 starting in the last month of the second quarter translates to the last workday of the second quarter of this year"


### PR DESCRIPTION
Running `configlet sync -u`  identified a few practice exercises that needed updating.

I added a template for Bob, but ran into errors when regenerating the tests: one of the string literals confuses the Julia parser.

```
ERROR: failed to parse input from /tmp/tmpe_xswoap: ParseError:
# Error @ line 86:38
    @testset "shouting with special characters" begin
        @test bob("""ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!""") == "Whoa, chill out!"
#                                    ╙ ── not a unary operator
```

A few potential workarounds failed, so I've marked that test as `include = false` in `tests.toml`. 

Conversely, a few older tests were excluded for reasons that no longer seem relevant, so I removed the `include = false` lines.

Finally, I added `.pyc` files (from the `generate_tests.py` runs) to `.gitignore`.

This seems enough complexity for one PR, so I'll template and update `connect`, `perfect-numbers` and `swift-scheduling` separately