### PR TITLE
More templates: connect, swift-scheduling

### DIFF
--- a/exercises/practice/connect/.meta/template.j2
+++ b/exercises/practice/connect/.meta/template.j2
@@ -1,0 +1,20 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+{%- macro test_case(case) %}
+    {%- set input = case["input"] %}
+    @testset "{{ case["description"]}}" begin
+        board = [
+            {% for row in case["input"]["board"] -%}
+            "{{ row }}",
+            {% endfor %}
+        ]
+        @test connect(board) == "{{ case["expected"] }}"
+    end
+{% endmacro %}
+
+    {% for case in cases -%}
+    {{ test_case(case) }}
+    {% endfor %}
+end

--- a/exercises/practice/connect/runtests.jl
+++ b/exercises/practice/connect/runtests.jl
@@ -1,117 +1,122 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/connect/canonical-data.json
+# File last updated on 2026-07-28
+
 using Test
 
 include("connect.jl")
 
 @testset verbose = true "tests" begin
     @testset "an empty board has no winner" begin
-        board = [
-            ". . . . .",
-            " . . . . .",
-            "  . . . . .",
-            "   . . . . .",
-            "    . . . . ."
-        ]
-        @test connect(board) == ""
-    end
-
-    @testset "an empty 1x1 board has no winner" begin
-        board = [
-            "."
-        ]
+        board = [". . . . .",
+                 " . . . . .",
+                 "  . . . . .",
+                 "   . . . . .",
+                 "    . . . . ."
+                 ]
         @test connect(board) == ""
     end
 
     @testset "X can win on a 1x1 board" begin
-        board = [
-            "X"
-        ]
+        board = ["X"
+                 ]
         @test connect(board) == "X"
     end
 
     @testset "O can win on a 1x1 board" begin
-        board = [
-            "O"
-        ]
+        board = ["O"
+                 ]
         @test connect(board) == "O"
     end
 
     @testset "only edges does not make a winner" begin
-        board = [
-            "O O O X",
-            " X . . X",
-            "  X . . X",
-            "   X O O O"
-        ]
+        board = ["O O O X",
+                 " X . . X",
+                 "  X . . X",
+                 "   X O O O"
+                 ]
         @test connect(board) == ""
     end
 
     @testset "illegal diagonal does not make a winner" begin
-        board = [
-            "X O . .",
-            " O X X X",
-            "  O X O .",
-            "   . O X .",
-            "    X X O O"
-        ]
+        board = ["X O . .",
+                 " O X X X",
+                 "  O X O .",
+                 "   . O X .",
+                 "    X X O O"
+                 ]
         @test connect(board) == ""
     end
 
     @testset "nobody wins crossing adjacent angles" begin
-        board = [
-            "X . . .",
-            " . X O .",
-            "  O . X O",
-            "   . O . X",
-            "    . . O ."
-        ]
+        board = ["X . . .",
+                 " . X O .",
+                 "  O . X O",
+                 "   . O . X",
+                 "    . . O ."
+                 ]
         @test connect(board) == ""
     end
 
     @testset "X wins crossing from left to right" begin
-        board = [
-            ". O . .",
-            " O X X X",
-            "  O X O .",
-            "   X X O X",
-            "    . O X ."
-        ]
+        board = [". O . .",
+                 " O X X X",
+                 "  O X O .",
+                 "   X X O X",
+                 "    . O X ."
+                 ]
+        @test connect(board) == "X"
+    end
+
+    @testset "X wins with left-hand dead end fork" begin
+        board = [". . X .",
+                 " X X . .",
+                 "  . X X X",
+                 "   O O O O"
+                 ]
+        @test connect(board) == "X"
+    end
+
+    @testset "X wins with right-hand dead end fork" begin
+        board = [". . X X",
+                 " X X . .",
+                 "  . X X .",
+                 "   O O O O"
+                 ]
         @test connect(board) == "X"
     end
 
     @testset "O wins crossing from top to bottom" begin
-        board = [
-            ". O . .",
-            " O X X X",
-            "  O O O .",
-            "   X X O X",
-            "    . O X ."
-        ]
+        board = [". O . .",
+                 " O X X X",
+                 "  O O O .",
+                 "   X X O X",
+                 "    . O X ."
+                 ]
         @test connect(board) == "O"
     end
 
     @testset "X wins using a convoluted path" begin
-        board = [
-            ". X X . .",
-            " X . X . X",
-            "  . X . X .",
-            "   . X X . .",
-            "    O O O O O"
-        ]
+        board = [". X X . .",
+                 " X . X . X",
+                 "  . X . X .",
+                 "   . X X . .",
+                 "    O O O O O"
+                 ]
         @test connect(board) == "X"
     end
 
     @testset "X wins using a spiral path" begin
-        board = [
-            "O X X X X X X X X",
-            " O X O O O O O O O",
-            "  O X O X X X X X O",
-            "   O X O X O O O X O",
-            "    O X O X X X O X O",
-            "     O X O O O X O X O",
-            "      O X X X X X O X O",
-            "       O O O O O O O X O",
-            "        X X X X X X X X O"
-        ]
+        board = ["O X X X X X X X X",
+                 " O X O O O O O O O",
+                 "  O X O X X X X X O",
+                 "   O X O X O O O X O",
+                 "    O X O X X X O X O",
+                 "     O X O O O X O X O",
+                 "      O X X X X X O X O",
+                 "       O O O O O O O X O",
+                 "        X X X X X X X X O"
+                 ]
         @test connect(board) == "X"
     end
 end

--- a/exercises/practice/swift-scheduling/.meta/template.j2
+++ b/exercises/practice/swift-scheduling/.meta/template.j2
@@ -1,0 +1,15 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+{%- macro test_case(case) %}
+    {%- set input = case["input"] %}
+    @testset "{{ case["description"]}}" begin
+        @test delivery_date("{{ case["input"]["meetingStart"] }}", "{{ case["input"]["description"] }}") == "{{ case["expected"] }}"
+    end
+{% endmacro %}
+
+    {% for case in cases -%}
+    {{ test_case(case) }}
+    {% endfor %}
+end

--- a/exercises/practice/swift-scheduling/runtests.jl
+++ b/exercises/practice/swift-scheduling/runtests.jl
@@ -1,70 +1,77 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/swift-scheduling/canonical-data.json
+# File last updated on 2026-07-28
+
 using Test
 
 include("swift-scheduling.jl")
 
 @testset verbose = true "tests" begin
     @testset "NOW translates to two hours later" begin
-        @test delivery_date("2012-02-13T09:00:00", "NOW") ==  "2012-02-13T11:00:00"
+        @test delivery_date("2012-02-13T09:00:00", "NOW") == "2012-02-13T11:00:00"
     end
 
     @testset "ASAP before one in the afternoon translates to today at five in the afternoon" begin
-        @test delivery_date("1999-06-03T09:45:00", "ASAP") ==  "1999-06-03T17:00:00"
+        @test delivery_date("1999-06-03T09:45:00", "ASAP") == "1999-06-03T17:00:00"
     end
 
     @testset "ASAP at one in the afternoon translates to tomorrow at one in the afternoon" begin
-        @test delivery_date("2008-12-21T13:00:00", "ASAP") ==  "2008-12-22T13:00:00"
+        @test delivery_date("2008-12-21T13:00:00", "ASAP") == "2008-12-22T13:00:00"
     end
 
     @testset "ASAP after one in the afternoon translates to tomorrow at one in the afternoon" begin
-        @test delivery_date("2008-12-21T14:50:00", "ASAP") ==  "2008-12-22T13:00:00"
+        @test delivery_date("2008-12-21T14:50:00", "ASAP") == "2008-12-22T13:00:00"
     end
 
     @testset "EOW on Monday translates to Friday at five in the afternoon" begin
-        @test delivery_date("2025-02-03T16:00:00", "EOW") ==  "2025-02-07T17:00:00"
+        @test delivery_date("2025-02-03T16:00:00", "EOW") == "2025-02-07T17:00:00"
     end
 
     @testset "EOW on Tuesday translates to Friday at five in the afternoon" begin
-        @test delivery_date("1997-04-29T10:50:00", "EOW") ==  "1997-05-02T17:00:00"
+        @test delivery_date("1997-04-29T10:50:00", "EOW") == "1997-05-02T17:00:00"
     end
 
     @testset "EOW on Wednesday translates to Friday at five in the afternoon" begin
-        @test delivery_date("2005-09-14T11:00:00", "EOW") ==  "2005-09-16T17:00:00"
+        @test delivery_date("2005-09-14T11:00:00", "EOW") == "2005-09-16T17:00:00"
     end
 
     @testset "EOW on Thursday translates to Sunday at eight in the evening" begin
-        @test delivery_date("2011-05-19T08:30:00", "EOW") ==  "2011-05-22T20:00:00"
+        @test delivery_date("2011-05-19T08:30:00", "EOW") == "2011-05-22T20:00:00"
     end
 
     @testset "EOW on Friday translates to Sunday at eight in the evening" begin
-        @test delivery_date("2022-08-05T14:00:00", "EOW") ==  "2022-08-07T20:00:00"
+        @test delivery_date("2022-08-05T14:00:00", "EOW") == "2022-08-07T20:00:00"
     end
 
     @testset "EOW translates to leap day" begin
-        @test delivery_date("2008-02-25T10:30:00", "EOW") ==  "2008-02-29T17:00:00"
+        @test delivery_date("2008-02-25T10:30:00", "EOW") == "2008-02-29T17:00:00"
     end
 
     @testset "2M before the second month of this year translates to the first workday of the second month of this year" begin
-        @test delivery_date("2007-01-02T14:15:00", "2M") ==  "2007-02-01T08:00:00"
+        @test delivery_date("2007-01-02T14:15:00", "2M") == "2007-02-01T08:00:00"
     end
 
     @testset "11M in the eleventh month translates to the first workday of the eleventh month of next year" begin
-        @test delivery_date("2013-11-21T15:30:00", "11M") ==  "2014-11-03T08:00:00"
+        @test delivery_date("2013-11-21T15:30:00", "11M") == "2014-11-03T08:00:00"
     end
 
     @testset "4M in the ninth month translates to the first workday of the fourth month of next year" begin
-        @test delivery_date("2019-11-18T15:15:00", "4M") ==  "2020-04-01T08:00:00"
+        @test delivery_date("2019-11-18T15:15:00", "4M") == "2020-04-01T08:00:00"
     end
 
     @testset "Q1 in the first quarter translates to the last workday of the first quarter of this year" begin
-        @test delivery_date("2003-01-01T10:45:00", "Q1") ==  "2003-03-31T08:00:00"
+        @test delivery_date("2003-01-01T10:45:00", "Q1") == "2003-03-31T08:00:00"
     end
 
     @testset "Q4 in the second quarter translates to the last workday of the fourth quarter of this year" begin
-        @test delivery_date("2001-04-09T09:00:00", "Q4") ==  "2001-12-31T08:00:00"
+        @test delivery_date("2001-04-09T09:00:00", "Q4") == "2001-12-31T08:00:00"
     end
 
     @testset "Q3 in the fourth quarter translates to the last workday of the third quarter of next year" begin
-        @test delivery_date("2022-10-06T11:00:00", "Q3") ==  "2023-09-29T08:00:00"
+        @test delivery_date("2022-10-06T11:00:00", "Q3") == "2023-09-29T08:00:00"
     end
 
+    @testset "Q2 starting in the last month of the second quarter translates to the last workday of the second quarter of this year" begin
+        @test delivery_date("2019-06-15T09:50:00", "Q2") == "2019-06-28T08:00:00"
+    end
 end


### PR DESCRIPTION
Continues from #1127.

These were simpler than Bob, though displaying the board in `connect` took a few attempts to get Jinja2 to play nicely with `jlfmt`.

`perfect-numbers` had an update in #1127, but it turns out that was just a URL change in the documentation. Fortunate, because the current Julia implementation is wildly different from the `problem-specifications`. Three separate boolean functions here, versus a single function returning a text classifier in `canonical-data`. I'm not eager to step into that compatibility minefield.