### PR TITLE
Add hint about approximate equality

### DIFF
--- a/exercises/concept/robot-revolution/.docs/hints.md
+++ b/exercises/concept/robot-revolution/.docs/hints.md
@@ -13,6 +13,7 @@
 - Remember, it is the *second* column of the matrix which indicates orientation.
 - This can be checked with a dot product.
 - It might be helpful to normalize the vectors.
+- In case of floating point discrepancies, the orientation only needs to be [approximately][isapprox-ref] equal to around `~1e-7`.
 - The following identity could be helpful: `x⋅y = ||x||*||y||cos(θ)` where [`||x|| = norm(x)`][norm-ref] 
 
 ## 4. Robot Body Coordinates
@@ -22,4 +23,5 @@
 [hcat-ref]: https://docs.julialang.org/en/v1/base/arrays/#Base.hcat
 [reshape-ref]: https://docs.julialang.org/en/v1/base/arrays/#Base.reshape
 [stack-ref]: https://docs.julialang.org/en/v1/base/arrays/#Base.stack
+[isapprox-ref]: https://docs.julialang.org/en/v1/base/math/#Base.isapprox
 [norm-ref]: https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.norm


### PR DESCRIPTION
I realized that I had forgotten to include a hint about approximate equality when dealing with floating point numbers in Task 3. This adds that hint.